### PR TITLE
Add actions tab on the details page

### DIFF
--- a/static/sass/_pattern_p-accordion.scss
+++ b/static/sass/_pattern_p-accordion.scss
@@ -11,7 +11,6 @@
         font-size: 0.875rem;
       }
     }
-
     .p-accordion__panel {
       padding-left: 0;
 
@@ -28,7 +27,6 @@
         &--1 {
           padding-left: $spv-inner--large;
         }
-
         &--2 {
           padding-left: $spv-inner--large * 2;
         }

--- a/static/sass/_pattern_p-accordion.scss
+++ b/static/sass/_pattern_p-accordion.scss
@@ -11,24 +11,24 @@
         font-size: 0.875rem;
       }
     }
+
     .p-accordion__panel {
-      padding-left: 0;
-
-      .p-accordion__panel-title {
+      .p-list__item {
         font-weight: 400;
-      }
 
-      .p-accordion__panel-subtitle {
-        font-style: italic;
-        padding-left: $spv-inner--large;
-      }
-
-      .u-offset {
-        &--1 {
+        .p-list__item {
+          font-style: italic;
+          font-weight: 300;
           padding-left: $spv-inner--large;
-        }
-        &--2 {
-          padding-left: $spv-inner--large * 2;
+
+          &::after {
+            border: none;
+          }
+
+          .p-list__item {
+            font-style: normal;
+            padding-left: 2 * $spv-inner--large;
+          }
         }
       }
     }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -19,6 +19,7 @@ $theme-default-nav: dark;
 @include vf-base;
 
 // Vanilla components
+@include vf-p-accordion;
 @include vf-p-buttons;
 @include vf-p-card;
 @include vf-p-forms;
@@ -59,9 +60,9 @@ $theme-default-nav: dark;
 
 @include p-charmhub-strip;
 
-@import "pattern_p-table-of-contents";
+@import "pattern_p-accordion";
 
-@include p-charmhub-table-of-contents;
+@include p-charmhub-accordion;
 
 @import "charmhub_footer";
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -64,6 +64,10 @@ $theme-default-nav: dark;
 
 @include p-charmhub-accordion;
 
+@import "pattern_p-table-of-contents";
+
+@include p-charmhub-table-of-contents;
+
 @import "charmhub_footer";
 
 @include charmhub-p-footer;

--- a/templates/details.html
+++ b/templates/details.html
@@ -58,7 +58,7 @@
           14.04 LTS
         </span>
       </div>
-      <p>Also supports: <a href="/">Kubernets</a></p>
+      <p>Also supports: <a href="/">Kubernetes</a></p>
     </div>
   </div>
 </div>

--- a/templates/partial/_tab-actions.html
+++ b/templates/partial/_tab-actions.html
@@ -1,6 +1,69 @@
 <div class="u-fixed-width p-tabs__content" id="actions">
-  <h4>This is actions tab</h4>
-  <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptate possimus eos dolore voluptatem cum, ducimus
-    iste natus deserunt aspernatur reprehenderit veritatis recusandae assumenda aut inventore a est vel cupiditate
-    officia?</p>
+  <aside class="p-accordion" role="tablist" aria-multiselect="true">
+    <ul class="p-accordion__list">
+      <li class="p-accordion__group">
+        <button type="button" class="p-accordion__tab" id="tab1" role="tab">
+          <div class="row">
+            <div class="col-4">
+              pause
+            </div>
+            <div class="col-8">
+              <span class="p-accordion__tab-description">Pause the openstack-dashboard unit</span>
+            </div>
+          </div>
+        </button>
+      </li>
+      <li class="p-accordion__group">
+        <button type="button" class="p-accordion__tab" id="tab1" role="tab">
+          <div class="row">
+            <div class="col-4">
+              resume
+            </div>
+            <div class="col-8">
+              <span class="p-accordion__tab-description">Resume the openstack-dashboard unit</span>
+            </div>
+          </div>
+        </button>
+      </li>
+      <li class="p-accordion__group">
+        <button type="button" class="p-accordion__tab" id="tab1" role="tab" aria-controls="tab1-section"
+          aria-expanded="true">openstack-upgrade</button>
+        <section class="p-accordion__panel" id="tab1-section" role="tabpanel" aria-hidden="false"
+          aria-labelledby="tab1-section">
+          <p class="p-accordion__panel-title">description</p>
+          <p class="u-offset--1">Set a value for the pool</p>
+          <hr>
+          <p class="p-accordion__panel-title">params:</p>
+          <p class="p-accordion__panel-subtitle">pool-name:</p>
+          <p class="u-offset--2">type: string</p>
+          <p class="u-offset--2">description: The pool to set this variable on.</p>
+          <p class="p-accordion__panel-subtitle">Key:</p>
+          <p class="u-offset--2">type: string</p>
+          <p class="u-offset--2">description: Any valid Ceph key from
+            http://docs.ceph.com/docs/master/rados/operations/pools/#set-pool-values</p>
+          <p class="p-accordion__panel-subtitle">Value:</p>
+          <p class="u-offset--2">type: string</p>
+          <p class="u-offset--2">description: The value to set</p>
+          <hr>
+          <p class="p-accordion__panel-title">required</p>
+          <p class="u-offset--1">[key, value, pool-name]</p>
+          <hr>
+          <p class="p-accordion__panel-title">additionalProperties</p>
+          <p class="u-offset--1">False</p>
+        </section>
+      </li>
+      <li class="p-accordion__group">
+        <button type="button" class="p-accordion__tab" id="tab1" role="tab">
+          <div class="row">
+            <div class="col-4">
+              security-checklist
+            </div>
+            <div class="col-8">
+              <span class="p-accordion__tab-description">Validate the running configuration against the OpenStack security guides checklist.</span>
+            </div>
+          </div>
+        </button>
+      </li>
+    </ul>
+  </aside>
 </div>

--- a/templates/partial/_tab-actions.html
+++ b/templates/partial/_tab-actions.html
@@ -2,7 +2,8 @@
   <aside class="p-accordion" role="tablist" aria-multiselect="true">
     <ul class="p-accordion__list">
       <li class="p-accordion__group">
-        <button type="button" class="p-accordion__tab" id="tab1" role="tab">
+        <button type="button" class="p-accordion__tab" id="tab1" role="tab" aria-controls="tab1-section"
+          aria-expanded="true">
           <div class="row">
             <div class="col-4">
               pause
@@ -12,9 +13,33 @@
             </div>
           </div>
         </button>
+        <section class="p-accordion__panel" id="tab1-section" role="tabpanel" aria-hidden="false"
+          aria-labelledby="tab1-section">
+          <ul class="p-list--divided u-no-margin--bottom">
+            <li class="p-list__item">
+              description
+              <ul class="p-list">
+                <li class="p-list__item">Set a value for the pool</li>
+              </ul>
+            </li>
+            <li class="p-list__item">
+              params:
+              <ul class="p-list">
+                <li class="p-list__item">
+                  pool-name:
+                  <ul class="p-list">
+                    <li class="p-list__item">type: string</li>
+                    <li class="p-list__item">description: The pool to set this variable on.</li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </section>
       </li>
       <li class="p-accordion__group">
-        <button type="button" class="p-accordion__tab" id="tab1" role="tab">
+        <button type="button" class="p-accordion__tab" id="tab2" role="tab" aria-controls="tab2-section"
+          aria-expanded="true">
           <div class="row">
             <div class="col-4">
               resume
@@ -24,45 +49,124 @@
             </div>
           </div>
         </button>
-      </li>
-      <li class="p-accordion__group">
-        <button type="button" class="p-accordion__tab" id="tab1" role="tab" aria-controls="tab1-section"
-          aria-expanded="true">openstack-upgrade</button>
-        <section class="p-accordion__panel" id="tab1-section" role="tabpanel" aria-hidden="false"
+        <section class="p-accordion__panel" id="tab2-section" role="tabpanel" aria-hidden="false"
           aria-labelledby="tab1-section">
-          <p class="p-accordion__panel-title">description</p>
-          <p class="u-offset--1">Set a value for the pool</p>
-          <hr>
-          <p class="p-accordion__panel-title">params:</p>
-          <p class="p-accordion__panel-subtitle">pool-name:</p>
-          <p class="u-offset--2">type: string</p>
-          <p class="u-offset--2">description: The pool to set this variable on.</p>
-          <p class="p-accordion__panel-subtitle">Key:</p>
-          <p class="u-offset--2">type: string</p>
-          <p class="u-offset--2">description: Any valid Ceph key from
-            http://docs.ceph.com/docs/master/rados/operations/pools/#set-pool-values</p>
-          <p class="p-accordion__panel-subtitle">Value:</p>
-          <p class="u-offset--2">type: string</p>
-          <p class="u-offset--2">description: The value to set</p>
-          <hr>
-          <p class="p-accordion__panel-title">required</p>
-          <p class="u-offset--1">[key, value, pool-name]</p>
-          <hr>
-          <p class="p-accordion__panel-title">additionalProperties</p>
-          <p class="u-offset--1">False</p>
+          <ul class="p-list--divided u-no-margin--bottom">
+            <li class="p-list__item">
+              description
+              <ul class="p-list">
+                <li class="p-list__item">Set a value for the pool</li>
+              </ul>
+            </li>
+            <li class="p-list__item">
+              params:
+              <ul class="p-list">
+                <li class="p-list__item">
+                  pool-name:
+                  <ul class="p-list">
+                    <li class="p-list__item">type: string</li>
+                    <li class="p-list__item">description: The pool to set this variable on.</li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+          </ul>
         </section>
       </li>
       <li class="p-accordion__group">
-        <button type="button" class="p-accordion__tab" id="tab1" role="tab">
+        <button type="button" class="p-accordion__tab" id="tab3" role="tab" aria-controls="tab3-section"
+          aria-expanded="true">openstack-upgrade</button>
+        <section class="p-accordion__panel" id="tab3-section" role="tabpanel" aria-hidden="false"
+          aria-labelledby="tab1-section">
+          <ul class="p-list--divided u-no-margin--bottom">
+            <li class="p-list__item">
+              description
+              <ul class="p-list">
+                <li class="p-list__item">Set a value for the pool</li>
+              </ul>
+            </li>
+            <li class="p-list__item">
+              params:
+              <ul class="p-list">
+                <li class="p-list__item">
+                  pool-name:
+                  <ul class="p-list">
+                    <li class="p-list__item">type: string</li>
+                    <li class="p-list__item">description: The pool to set this variable on.</li>
+                  </ul>
+                </li>
+                <li class="p-list__item">
+                  Key:
+                  <ul class="p-list">
+                    <li class="p-list__item">type: string</li>
+                    <li class="p-list__item">description: Any valid Ceph key from
+                    http://docs.ceph.com/docs/master/rados/operations/pools/#set-pool-values</li>
+                  </ul>
+                </li>
+                <li class="p-list__item">
+                  Value:
+                  <ul class="p-list">
+                    <li class="p-list__item">type: string</li>
+                    <li class="p-list__item">description: The value to set</li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+            <li class="p-list__item">
+              required
+              <ul class="p-list">
+                <li class="p-list__item">
+                  [key, value, pool-name]
+                </li>
+              </ul>
+            </li>
+            <li class="p-list__item">
+              additionalProperties
+              <ul class="p-list">
+                <li class="p-list__item">
+                  False
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </section>
+      </li>
+      <li class="p-accordion__group">
+        <button type="button" class="p-accordion__tab" id="tab4" role="tab" aria-controls="tab4-section"
+          aria-expanded="true">
           <div class="row">
             <div class="col-4">
               security-checklist
             </div>
             <div class="col-8">
-              <span class="p-accordion__tab-description">Validate the running configuration against the OpenStack security guides checklist.</span>
+              <span class="p-accordion__tab-description">Validate the running configuration against the OpenStack
+                security guides checklist.</span>
             </div>
           </div>
         </button>
+        <section class="p-accordion__panel" id="tab4-section" role="tabpanel" aria-hidden="false"
+          aria-labelledby="tab1-section">
+          <ul class="p-list--divided u-no-margin--bottom">
+            <li class="p-list__item">
+              description
+              <ul class="p-list">
+                <li class="p-list__item">Set a value for the pool</li>
+              </ul>
+            </li>
+            <li class="p-list__item">
+              params:
+              <ul class="p-list">
+                <li class="p-list__item">
+                  pool-name:
+                  <ul class="p-list">
+                    <li class="p-list__item">type: string</li>
+                    <li class="p-list__item">description: The pool to set this variable on.</li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </section>
       </li>
     </ul>
   </aside>


### PR DESCRIPTION
## Done

Add actions tab on the details page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045/charm#actions
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [design](https://app.zeplin.io/project/5d3f1850b938ee0dc24c60c4/screen/5e2abd087eecc454cf8abf82)
- There is no js for the accordion to work yet. This will be added once we implement actions for all the accordion buttons


## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1265

