### PR TITLE
Add charmhub logo to the navigation

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -4,7 +4,7 @@
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="/">
           <img class="p-navigation__image"
-            src="https://assets.ubuntu.com/v1/7f93bb62-snapcraft-logo--web-white-text.svg"
+            src="https://assets.ubuntu.com/v1/1f8628d2-Charmhub_white-orange_hex.svg" width="175" height="31"
             alt="Charmhub" />
         </a>
       </div>


### PR DESCRIPTION
## Done

Add charmhub logo to the navigation

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the snapcrat logo is replaced by charmhub logo

## Issue / Card

Fixes #12 

## Screenshots

[if relevant, include a screenshot]
