### PR TITLE
Add bundles page details header

### DIFF
--- a/static/sass/_charmhub_p-bundle-icons.scss
+++ b/static/sass/_charmhub_p-bundle-icons.scss
@@ -1,0 +1,39 @@
+@mixin charmhub-p-bundle-icons {
+  .p-bundle-icons {
+    $icon-size: 1.5rem;
+    $padding: 0.12rem;
+
+    border: 0.06rem solid $color-mid-light;
+    border-radius: (($padding * 2) + $icon-size) / 2;
+    color: #333;
+    display: inline-block;
+    font-size: 0.875rem;
+    padding: $padding 0.3rem + $padding $padding $padding;
+    position: relative;
+    top: -0.12rem;
+
+    &:hover {
+      text-decoration: none;
+    }
+
+    .p-bundle-icons__image {
+      border-radius: $icon-size / 2;
+      display: inline-block;
+      height: $icon-size;
+      margin-bottom: 0;
+      vertical-align: bottom;
+      width: $icon-size;
+
+      &:first-child {
+        // Set a background to handle overlapping transparent icons.
+        background-color: $color-x-light;
+        box-shadow: 0 0 0 0.04rem $color-x-light;
+        position: relative;
+      }
+
+      &:nth-child(2) {
+        margin-left: -1.2rem;
+      }
+    }
+  }
+}

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -1,0 +1,27 @@
+@mixin p-charmhub-card {
+  .p-card--bundle {
+    @extend %vf-card;
+
+    padding: 1rem 0 0 0;
+
+    .p-card__title {
+      padding-bottom: $spv-inner--small;
+      // padding-top: $spv-inner--large;
+
+      .p-card__title-text {
+        display: inline;
+      }
+    }
+
+    .p-card__subtitle {
+      .series-tags {
+        margin-top: $spv-inner--large;
+      }
+    }
+
+    .p-card__content {
+      padding-bottom: $spv-inner--large;
+      padding-top: $spv-inner--large;
+    }
+  }
+}

--- a/static/sass/_pattern_p-media-object.scss
+++ b/static/sass/_pattern_p-media-object.scss
@@ -1,0 +1,9 @@
+@mixin p-charmhub-media-object {
+  .p-media-object--medium {
+    .p-bundle-icons {
+      height: fit-content;
+      margin-right: $spv-inner--medium;
+      margin-top: $spv-inner--large;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -36,6 +36,7 @@ $theme-default-nav: dark;
 @include vf-p-strip;
 @include vf-p-table-of-contents;
 @include vf-p-tabs;
+@include vf-p-tooltips;
 
 // Vanilla utilities
 @include vf-u-align;
@@ -50,9 +51,17 @@ $theme-default-nav: dark;
 @include vf-u-vertically-center;
 
 // Import site specific patterns and overrides
+@import "pattern_p-card";
+
+@include p-charmhub-card;
+
 @import "pattern_p-link";
 
 @include p-charmhub-link;
+
+@import "pattern_p-media-object";
+
+@include p-charmhub-media-object;
 
 @import "pattern_p-strip";
 
@@ -65,6 +74,10 @@ $theme-default-nav: dark;
 @import "pattern_p-table-of-contents";
 
 @include p-charmhub-table-of-contents;
+
+@import "charmhub_p-bundle-icons";
+
+@include charmhub-p-bundle-icons;
 
 @import "charmhub_footer";
 

--- a/templates/details.html
+++ b/templates/details.html
@@ -11,17 +11,26 @@
     <div class="col-8">
       <div class="p-charm-header">
         <div class="p-media-object--medium u-no-margin--bottom">
+          {% if detail_type == "charm" %}
           <img src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" class="p-media-object__image">
+          {% else %}
+          <a href="/canonical-kubernetes/bundle/804" class="p-bundle-icons">
+            <img src="https://api.jujucharms.com/charmstore/v5/lxd-22/icon.svg" class="p-bundle-icons__image" alt="">
+            <img src="https://api.jujucharms.com/charmstore/v5/openstack-dashboard-271/icon.svg" class="p-bundle-icons__image"
+              alt=""> +12
+          </a>
+          {% endif %}
           <div class="p-media-object__details">
             <h1 class="p-media-object__title">
               openstack-dashboard
             </h1>
             <div class="p-media-object__content u-no-margin--bottom">
               <ul class="p-inline-list--middot">
-                <li class="p-inline-list__item u-hide--small">
+                <li class="p-inline-list__item">
                   By <a href="/">openstack-charmers</a>
-                  <span class="p-verified p-tooltip p-tooltip--top-center" aria-describedby="postman-tooltip">
+                  <span class="p-tooltip--top-center" aria-describedby="openstack-tooltip">
                     <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg">
+                    <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Verified account</span>
                   </span>
                 </li>
                 <li class="p-inline-list__item">
@@ -67,11 +76,15 @@
 
   {% include "partial/_tab-overview.html" %}
   {% include "partial/_tab-configuration.html" %}
-  {% include "partial/_tab-actions.html" %}
-  {% include "partial/_tab-integrations.html" %}
-  {% include "partial/_tab-docs.html" %}
-  {% include "partial/_tab-history.html" %}
   {% include "partial/_tab-contribute.html" %}
+  {% if detail_type == "charm" %}
+    {% include "partial/_tab-actions.html" %}
+    {% include "partial/_tab-integrations.html" %}
+    {% include "partial/_tab-docs.html" %}
+  {% endif %}
+  {% include "partial/_tab-history.html" %}
+
+  {% include "partial/_top-bundles.html" %}
 </div>
 
 <script defer src="{{ versioned_static('js/tabs.js') }}"></script>

--- a/templates/partial/_tabs-navigation.html
+++ b/templates/partial/_tabs-navigation.html
@@ -10,6 +10,7 @@
           <a href="#configuration" class="p-tabs__link" tabindex="-1" role="tab"
             aria-controls="configuration">Configuration</a>
         </li>
+        {% if detail_type == "charm" %}
         <li class="p-tabs__item" role="presentation">
           <a href="#actions" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="actions">Actions</a>
         </li>
@@ -20,6 +21,7 @@
         <li class="p-tabs__item" role="presentation">
           <a href="#docs" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="docs">Docs</a>
         </li>
+        {% endif %}
         <li class="p-tabs__item" role="presentation">
           <a href="#history" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="history">History</a>
         </li>

--- a/templates/partial/_top-bundles.html
+++ b/templates/partial/_top-bundles.html
@@ -1,0 +1,193 @@
+<div class="p-strip is-shallow u-fixed-width">
+  <hr>
+</div>
+{% if detail_type == "charm" %}
+<div class="p-strip is-shallow u-no-padding--top u-fixed-width">
+  <h4>Top bundles using this charm</h4>
+</div>
+{% else %}
+<div class="p-strip is-shallow u-no-padding--top row">
+  <div class="col-3">
+    <h4>11 similar bundles</h4>
+  </div>
+  <div class="col-3 col-start-large-10 u-align--right">
+    <a href="#" class="p-button--neutral">View all similar bundles&hellip;</a>
+  </div>
+</div>
+{% endif %}
+<div class="row">
+  <div class="col-4">
+    <div class="p-card--bundle">
+      <div class="p-card__title">
+        <a href="/canonical-kubernetes/bundle/804" class="p-bundle-icons">
+          <img src="https://api.jujucharms.com/charmstore/v5/lxd-22/icon.svg" class="p-bundle-icons__image" alt="">
+          <img src="https://api.jujucharms.com/charmstore/v5/openstack-dashboard-271/icon.svg" class="p-bundle-icons__image" alt=""> +12 </a>
+        <h4 class="p-card__title-text">Openstack Lxd</h4>
+      </div>
+      <div class="p-card__subtitle">
+        <ul class="p-inline-list--middot u-no-margin--bottom">
+          <li class="p-inline-list__item"> By <a href="/">openstack-charmers</a>
+            <span class="p-tooltip--top-center" aria-describedby="openstack-tooltip">
+              <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg">
+              <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Verified account</span>
+            </span>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="/">Openstack</a>
+          </li>
+        </ul>
+        <div class="series-tags">
+          <span class="series-tag"> 18.04 </span>
+        </div>
+      </div>
+      <div class="p-card__content">
+        <p>This example bundle deploys a basic OpenStack Cloud (Stein with Ceph Mimic) on Ubuntu 18.04 LTS (Bionic), providing Dashboard, Compute, Network, Block Storage, Object Storage, Identity and Image services.</p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4">
+    <div class="p-card--bundle">
+      <div class="p-card__title">
+        <a href="/canonical-kubernetes/bundle/804" class="p-bundle-icons">
+          <img src="https://api.jujucharms.com/charmstore/v5/lxd-22/icon.svg" class="p-bundle-icons__image" alt="">
+          <img src="https://api.jujucharms.com/charmstore/v5/openstack-dashboard-271/icon.svg" class="p-bundle-icons__image" alt=""> +12 </a>
+        <h4 class="p-card__title-text">Openstack Lxd</h4>
+      </div>
+      <div class="p-card__subtitle">
+        <ul class="p-inline-list--middot u-no-margin--bottom">
+          <li class="p-inline-list__item"> By <a href="/">openstack-charmers</a>
+            <span class="p-tooltip--top-center" aria-describedby="openstack-tooltip">
+              <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg">
+              <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Verified account</span>
+            </span>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="/">Openstack</a>
+          </li>
+        </ul>
+        <div class="series-tags">
+          <span class="series-tag"> 18.04 </span>
+        </div>
+      </div>
+      <div class="p-card__content">
+        <p>This example bundle deploys a basic OpenStack Cloud (Stein with Ceph Mimic) on Ubuntu 18.04 LTS (Bionic), providing Dashboard, Compute, Network, Block Storage, Object Storage, Identity and Image services.</p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4">
+    <div class="p-card--bundle">
+      <div class="p-card__title">
+        <a href="/canonical-kubernetes/bundle/804" class="p-bundle-icons">
+          <img src="https://api.jujucharms.com/charmstore/v5/lxd-22/icon.svg" class="p-bundle-icons__image" alt="">
+          <img src="https://api.jujucharms.com/charmstore/v5/openstack-dashboard-271/icon.svg" class="p-bundle-icons__image" alt=""> +12 </a>
+        <h4 class="p-card__title-text">Openstack Lxd</h4>
+      </div>
+      <div class="p-card__subtitle">
+        <ul class="p-inline-list--middot u-no-margin--bottom">
+          <li class="p-inline-list__item"> By <a href="/">openstack-charmers</a>
+            <span class="p-tooltip--top-center" aria-describedby="openstack-tooltip">
+              <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg">
+              <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Verified account</span>
+            </span>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="/">Openstack</a>
+          </li>
+        </ul>
+        <div class="series-tags">
+          <span class="series-tag"> 18.04 </span>
+        </div>
+      </div>
+      <div class="p-card__content">
+        <p>This example bundle deploys a basic OpenStack Cloud (Stein with Ceph Mimic) on Ubuntu 18.04 LTS (Bionic), providing Dashboard, Compute, Network, Block Storage, Object Storage, Identity and Image services.</p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4">
+    <div class="p-card--bundle">
+      <div class="p-card__title">
+        <a href="/canonical-kubernetes/bundle/804" class="p-bundle-icons">
+          <img src="https://api.jujucharms.com/charmstore/v5/lxd-22/icon.svg" class="p-bundle-icons__image" alt="">
+          <img src="https://api.jujucharms.com/charmstore/v5/openstack-dashboard-271/icon.svg" class="p-bundle-icons__image" alt=""> +12 </a>
+        <h4 class="p-card__title-text">Openstack Lxd</h4>
+      </div>
+      <div class="p-card__subtitle">
+        <ul class="p-inline-list--middot u-no-margin--bottom">
+          <li class="p-inline-list__item"> By <a href="/">openstack-charmers</a>
+            <span class="p-tooltip--top-center" aria-describedby="openstack-tooltip">
+              <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg">
+              <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Verified account</span>
+            </span>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="/">Openstack</a>
+          </li>
+        </ul>
+        <div class="series-tags">
+          <span class="series-tag"> 18.04 </span>
+        </div>
+      </div>
+      <div class="p-card__content">
+        <p>This example bundle deploys a basic OpenStack Cloud (Stein with Ceph Mimic) on Ubuntu 18.04 LTS (Bionic), providing Dashboard, Compute, Network, Block Storage, Object Storage, Identity and Image services.</p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4">
+    <div class="p-card--bundle">
+      <div class="p-card__title">
+        <a href="/canonical-kubernetes/bundle/804" class="p-bundle-icons">
+          <img src="https://api.jujucharms.com/charmstore/v5/lxd-22/icon.svg" class="p-bundle-icons__image" alt="">
+          <img src="https://api.jujucharms.com/charmstore/v5/openstack-dashboard-271/icon.svg" class="p-bundle-icons__image" alt=""> +12 </a>
+        <h4 class="p-card__title-text">Openstack Lxd</h4>
+      </div>
+      <div class="p-card__subtitle">
+        <ul class="p-inline-list--middot u-no-margin--bottom">
+          <li class="p-inline-list__item"> By <a href="/">openstack-charmers</a>
+            <span class="p-tooltip--top-center" aria-describedby="openstack-tooltip">
+              <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg">
+              <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Verified account</span>
+            </span>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="/">Openstack</a>
+          </li>
+        </ul>
+        <div class="series-tags">
+          <span class="series-tag"> 18.04 </span>
+        </div>
+      </div>
+      <div class="p-card__content">
+        <p>This example bundle deploys a basic OpenStack Cloud (Stein with Ceph Mimic) on Ubuntu 18.04 LTS (Bionic), providing Dashboard, Compute, Network, Block Storage, Object Storage, Identity and Image services.</p>
+      </div>
+    </div>
+  </div>
+  <div class="col-4">
+    <div class="p-card--bundle">
+      <div class="p-card__title">
+        <a href="/canonical-kubernetes/bundle/804" class="p-bundle-icons">
+          <img src="https://api.jujucharms.com/charmstore/v5/lxd-22/icon.svg" class="p-bundle-icons__image" alt="">
+          <img src="https://api.jujucharms.com/charmstore/v5/openstack-dashboard-271/icon.svg" class="p-bundle-icons__image" alt=""> +12 </a>
+        <h4 class="p-card__title-text">Openstack Lxd</h4>
+      </div>
+      <div class="p-card__subtitle">
+        <ul class="p-inline-list--middot u-no-margin--bottom">
+          <li class="p-inline-list__item"> By <a href="/">openstack-charmers</a>
+            <span class="p-tooltip--top-center" aria-describedby="openstack-tooltip">
+              <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg">
+              <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Verified account</span>
+            </span>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="/">Openstack</a>
+          </li>
+        </ul>
+        <div class="series-tags">
+          <span class="series-tag"> 18.04 </span>
+        </div>
+      </div>
+      <div class="p-card__content">
+        <p>This example bundle deploys a basic OpenStack Cloud (Stein with Ceph Mimic) on Ubuntu 18.04 LTS (Bionic), providing Dashboard, Compute, Network, Block Storage, Object Storage, Identity and Image services.</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -28,6 +28,19 @@ def index():
     return render_template("index.html")
 
 
+# TO DO - the routes below ("/charm" and "/bundle") need to be merged in one
+# single route "/details"
 @app.route("/charm")
-def details():
-    return render_template("details.html")
+def charm():
+    context = {
+        "detail_type": "charm",
+    }
+    return render_template("details.html", **context)
+
+
+@app.route("/bundle")
+def bundle():
+    context = {
+        "detail_type": "bundle",
+    }
+    return render_template("details.html", **context)


### PR DESCRIPTION
## Done

- Add details page header for bundles
- Add `related` bundles for both charms and bundles

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045/charm & http://0.0.0.0:8045/bundle 
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [design charm](https://app.zeplin.io/project/5d3f1850b938ee0dc24c60c4/screen/5e2abd064f4c2353123c8366) & [design bundle](https://app.zeplin.io/project/5d3f1850b938ee0dc24c60c4/screen/5e2abccfca786f806478cbb4)


## Issue / Card

Fixes #18 
