### PR TITLE
Add grey icons

### DIFF
--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -24,4 +24,18 @@
       padding-top: $spv-inner--large;
     }
   }
+
+  .p-card {
+    .p-card__thumbnail--small {
+      filter: grayscale(100%);
+      height: 1.5rem;
+      margin-top: 0.5rem;
+      opacity: 0.18;
+
+      &:hover {
+        filter: none;
+        opacity: 1;
+      }
+    }
+  }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,8 +41,8 @@
                 <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
               </div>
               <div class="u-float-right">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
+                <a href="#"><img src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="" class="p-card__thumbnail--small"></a>
+                <a href="#"><img src="https://assets.ubuntu.com/v1/afe7c4c4-picto-ubuntu_smaller.svg" alt="" class="p-card__thumbnail--small"></a>
               </div>
             </div>
             <h5 class="p-card__title u-no-margin--bottom">Kibana</h5>
@@ -59,8 +59,8 @@
                 <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
               </div>
               <div class="u-float-right">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
+                <a href="#"><img src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="" class="p-card__thumbnail--small"></a>
+                <a href="#"><img src="https://assets.ubuntu.com/v1/afe7c4c4-picto-ubuntu_smaller.svg" alt="" class="p-card__thumbnail--small"></a>
               </div>
             </div>
             <h5 class="p-card__title u-no-margin--bottom">Kibana</h5>
@@ -77,8 +77,8 @@
                 <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
               </div>
               <div class="u-float-right">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
+                <a href="#"><img src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="" class="p-card__thumbnail--small"></a>
+                <a href="#"><img src="https://assets.ubuntu.com/v1/afe7c4c4-picto-ubuntu_smaller.svg" alt="" class="p-card__thumbnail--small"></a>
               </div>
             </div>
             <h5 class="p-card__title u-no-margin--bottom">Kibana</h5>
@@ -95,8 +95,8 @@
                 <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
               </div>
               <div class="u-float-right">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
+                <a href="#"><img src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="" class="p-card__thumbnail--small"></a>
+                <a href="#"><img src="https://assets.ubuntu.com/v1/afe7c4c4-picto-ubuntu_smaller.svg" alt="" class="p-card__thumbnail--small"></a>
               </div>
             </div>
             <h5 class="p-card__title u-no-margin--bottom">Kibana</h5>
@@ -113,8 +113,8 @@
                 <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
               </div>
               <div class="u-float-right">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
+                <a href="#"><img src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="" class="p-card__thumbnail--small"></a>
+                <a href="#"><img src="https://assets.ubuntu.com/v1/afe7c4c4-picto-ubuntu_smaller.svg" alt="" class="p-card__thumbnail--small"></a>
               </div>
             </div>
             <h5 class="p-card__title u-no-margin--bottom">Kibana</h5>
@@ -131,8 +131,8 @@
                 <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
               </div>
               <div class="u-float-right">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
+                <a href="#"><img src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="" class="p-card__thumbnail--small"></a>
+                <a href="#"><img src="https://assets.ubuntu.com/v1/afe7c4c4-picto-ubuntu_smaller.svg" alt="" class="p-card__thumbnail--small"></a>
               </div>
             </div>
             <h5 class="p-card__title u-no-margin--bottom">Kibana</h5>
@@ -149,8 +149,8 @@
                 <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
               </div>
               <div class="u-float-right">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
+                <a href="#"><img src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="" class="p-card__thumbnail--small"></a>
+                <a href="#"><img src="https://assets.ubuntu.com/v1/afe7c4c4-picto-ubuntu_smaller.svg" alt="" class="p-card__thumbnail--small"></a>
               </div>
             </div>
             <h5 class="p-card__title u-no-margin--bottom">Kibana</h5>
@@ -167,8 +167,8 @@
                 <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
               </div>
               <div class="u-float-right">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
+                <a href="#"><img src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="" class="p-card__thumbnail--small"></a>
+                <a href="#"><img src="https://assets.ubuntu.com/v1/afe7c4c4-picto-ubuntu_smaller.svg" alt="" class="p-card__thumbnail--small"></a>
               </div>
             </div>
             <h5 class="p-card__title u-no-margin--bottom">Kibana</h5>
@@ -185,8 +185,8 @@
                 <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
               </div>
               <div class="u-float-right">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
+                <a href="#"><img src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="" class="p-card__thumbnail--small"></a>
+                <a href="#"><img src="https://assets.ubuntu.com/v1/afe7c4c4-picto-ubuntu_smaller.svg" alt="" class="p-card__thumbnail--small"></a>
               </div>
             </div>
             <h5 class="p-card__title u-no-margin--bottom">Kibana</h5>
@@ -203,8 +203,8 @@
                 <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
               </div>
               <div class="u-float-right">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
+                <a href="#"><img src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="" class="p-card__thumbnail--small"></a>
+                <a href="#"><img src="https://assets.ubuntu.com/v1/afe7c4c4-picto-ubuntu_smaller.svg" alt="" class="p-card__thumbnail--small"></a>
               </div>
             </div>
             <h5 class="p-card__title u-no-margin--bottom">Kibana</h5>
@@ -221,8 +221,8 @@
                 <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
               </div>
               <div class="u-float-right">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
+                <a href="#"><img src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="" class="p-card__thumbnail--small"></a>
+                <a href="#"><img src="https://assets.ubuntu.com/v1/afe7c4c4-picto-ubuntu_smaller.svg" alt="" class="p-card__thumbnail--small"></a>
               </div>
             </div>
             <h5 class="p-card__title u-no-margin--bottom">Kibana</h5>
@@ -239,8 +239,8 @@
                 <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
               </div>
               <div class="u-float-right">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
-                <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" class="p-card__thumbnail">
+                <a href="#"><img src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="" class="p-card__thumbnail--small"></a>
+                <a href="#"><img src="https://assets.ubuntu.com/v1/afe7c4c4-picto-ubuntu_smaller.svg" alt="" class="p-card__thumbnail--small"></a>
               </div>
             </div>
             <h5 class="p-card__title u-no-margin--bottom">Kibana</h5>


### PR DESCRIPTION
## Done

- Add grey icons on homepage

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See grey icons in the cards


## Issue / Card

Fixes #29 
