### PR TITLE
Add charm and bundle dummy data to python

### DIFF
--- a/static/sass/_pattern_p-media-object.scss
+++ b/static/sass/_pattern_p-media-object.scss
@@ -13,7 +13,7 @@
       }
 
       @media only screen and (max-width: $breakpoint-small) {
-        width: 5.5rem;
+        width: 4.5rem;
       }
 
       @media only screen and (min-width: $breakpoint-medium) {

--- a/templates/details.html
+++ b/templates/details.html
@@ -14,12 +14,13 @@
           {% if entity_type == "charm" %}
           <img src="{{ icon_url }}" class="p-media-object__image">
           {% else %}
-          <a href="/canonical-kubernetes/bundle/804" class="p-bundle-icons">
-            <img src="https://api.jujucharms.com/charmstore/v5/openstack-dashboard-271/icon.svg"
-              class="p-bundle-icons__image" alt="">
-            <img src="https://api.jujucharms.com/charmstore/v5/lxd-22/icon.svg" class="p-bundle-icons__image" alt="">
-            <img src="https://api.jujucharms.com/charmstore/v5/ceph/icon.svg" class="p-bundle-icons__image" alt="">
-          </a>
+          <div class="p-bundle-icons">
+            {% for bundle in bundle_content %}
+              {% if loop.index0 < 3 %}
+              <img src="{{ bundle.icon_url }}" class="p-bundle-icons__image" alt="">
+              {% endif %}
+            {% endfor %}
+          </div>
           {% endif %}
           <div class="p-media-object__details">
             <h1 class="p-media-object__title">
@@ -54,21 +55,11 @@
     <div class="col-4">
       <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="" width="89" height="20">
       <div class="series-tags">
+        {% for supported_os in supported_os_list %}
         <span class="series-tag">
-          16.04 LTS
+          {{ supported_os }}
         </span>
-        <span class="series-tag">
-          18.04 LTS
-        </span>
-        <span class="series-tag">
-          18.10
-        </span>
-        <span class="series-tag">
-          19.04
-        </span>
-        <span class="series-tag">
-          14.04 LTS
-        </span>
+        {% endfor %}
       </div>
       <p>Also supports: <a href="/">Kubernetes</a></p>
     </div>

--- a/templates/partial/_side-navigation.html
+++ b/templates/partial/_side-navigation.html
@@ -1,183 +1,39 @@
 <div class="col-3 u-hide--small">
   <div class="p-side-navigation">
+    {% if categories %}
     <ul class="p-side-navigation__list">
       <li class="p-side-navigation__item--title">
         <span class="p-side-navigation__text">Categories</span>
       </li>
+      {% for category in categories %}
       <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'analytics') %}{{ remove_filter('category', 'analytics') }}{% else %}{{ add_filter('category', 'analytics') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'analytics') %} is-active{% endif %}">
-          Analytics
-          {% if active_filter('category', 'analytics') %}
+        <a href="{% if active_filter('category', category.slug) %}{{ remove_filter('category', category.slug) }}{% else %}{{ add_filter('category', category.slug) }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', category.slug) %} is-active{% endif %}">
+          {{ category.name }}
+          {% if active_filter('category', category.slug) %}
           <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
           {% endif %}
         </a>
       </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'app-servers') %}{{ remove_filter('category', 'app-servers') }}{% else %}{{ add_filter('category', 'app-servers') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'app-servers') %} is-active{% endif %}">
-          App-servers
-          {% if active_filter('category', 'app-servers') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'big-data') %}{{ remove_filter('category', 'big-data') }}{% else %}{{ add_filter('category', 'big-data') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'big-data') %} is-active{% endif %}">
-          Big-data
-          {% if active_filter('category', 'big-data') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'containers') %}{{ remove_filter('category', 'containers') }}{% else %}{{ add_filter('category', 'containers') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'containers') %} is-active{% endif %}">
-          Containers
-          {% if active_filter('category', 'containers') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'databases') %}{{ remove_filter('category', 'databases') }}{% else %}{{ add_filter('category', 'databases') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'databases') %} is-active{% endif %}">
-          Databases
-          {% if active_filter('category', 'databases') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'keystone') %}{{ remove_filter('category', 'keystone') }}{% else %}{{ add_filter('category', 'keystone') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'keystone') %} is-active{% endif %}">
-          Keystone
-          {% if active_filter('category', 'keystone') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'kubernetes') %}{{ remove_filter('category', 'kubernetes') }}{% else %}{{ add_filter('category', 'kubernetes') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'kubernetes') %} is-active{% endif %}">
-          Kubernetes
-          {% if active_filter('category', 'kubernetes') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'identity') %}{{ remove_filter('category', 'identity') }}{% else %}{{ add_filter('category', 'identity') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'identity') %} is-active{% endif %}">
-          Identity
-          {% if active_filter('category', 'identity') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'monitoring') %}{{ remove_filter('category', 'monitoring') }}{% else %}{{ add_filter('category', 'monitoring') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'monitoring') %} is-active{% endif %}">
-          Monitoring
-          {% if active_filter('category', 'monitoring') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'network') %}{{ remove_filter('category', 'network') }}{% else %}{{ add_filter('category', 'network') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'network') %} is-active{% endif %}">
-          Network
-          {% if active_filter('category', 'network') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'openstack') %}{{ remove_filter('category', 'openstack') }}{% else %}{{ add_filter('category', 'openstack') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'openstack') %} is-active{% endif %}">
-          OpenStack
-          {% if active_filter('category', 'openstack') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'operations') %}{{ remove_filter('category', 'operations') }}{% else %}{{ add_filter('category', 'operations') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'operations') %} is-active{% endif %}">
-          Operations
-          {% if active_filter('category', 'operations') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'performance') %}{{ remove_filter('category', 'performance') }}{% else %}{{ add_filter('category', 'performance') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'performance') %} is-active{% endif %}">
-          Performance
-          {% if active_filter('category', 'performance') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'security') %}{{ remove_filter('category', 'security') }}{% else %}{{ add_filter('category', 'security') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'security') %} is-active{% endif %}">
-          Security
-          {% if active_filter('category', 'security') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'system') %}{{ remove_filter('category', 'system') }}{% else %}{{ add_filter('category', 'system') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'system') %} is-active{% endif %}">
-          System
-          {% if active_filter('category', 'system') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', 'storage') %}{{ remove_filter('category', 'storage') }}{% else %}{{ add_filter('category', 'storage') }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', 'storage') %} is-active{% endif %}">
-          Storage
-          {% if active_filter('category', 'storage') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
+      {% endfor %}
     </ul>
+    {% endif %}
+    {% if publisher_list %}
     <ul class="p-side-navigation__list">
       <li class="p-side-navigation__item--title">
         <span class="p-side-navigation__text">Publisher</span>
       </li>
+      {% for publisher in publisher_list %}
       <li class="p-side-navigation__item">
-        <a href="{% if active_filter('publisher', 'charmers') %}{{ remove_filter('publisher', 'charmers') }}{% else %}{{ add_filter('publisher', 'charmers') }}{% endif %}" class="p-side-navigation__link{% if active_filter('publisher', 'charmers') %} is-active{% endif %}">
-          Analytics
-          {% if active_filter('publisher', 'charmers') %}
+        <a href="{% if active_filter('publisher', publisher.slug) %}{{ remove_filter('publisher', publisher.slug) }}{% else %}{{ add_filter('publisher', publisher.slug) }}{% endif %}" class="p-side-navigation__link{% if active_filter('publisher', publisher.slug) %} is-active{% endif %}">
+          {{ publisher.name }}
+          {% if active_filter('publisher', publisher.slug) %}
           <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
           {% endif %}
         </a>
       </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('publisher', 'containers') %}{{ remove_filter('publisher', 'containers') }}{% else %}{{ add_filter('publisher', 'containers') }}{% endif %}" class="p-side-navigation__link{% if active_filter('publisher', 'containers') %} is-active{% endif %}">
-          Containers
-          {% if active_filter('publisher', 'containers') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('publisher', 'bigdata-charmers') %}{{ remove_filter('publisher', 'bigdata-charmers') }}{% else %}{{ add_filter('publisher', 'bigdata-charmers') }}{% endif %}" class="p-side-navigation__link{% if active_filter('publisher', 'bigdata-charmers') %} is-active{% endif %}">
-          Bigdata-charmers
-          {% if active_filter('publisher', 'bigdata-charmers') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('publisher', 'omnivector') %}{{ remove_filter('publisher', 'omnivector') }}{% else %}{{ add_filter('publisher', 'omnivector') }}{% endif %}" class="p-side-navigation__link{% if active_filter('publisher', 'omnivector') %} is-active{% endif %}">
-          Omnivector
-          {% if active_filter('publisher', 'omnivector') %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
-      <li class="p-side-navigation__item">
-        <a href="{% if active_filter('publisher', 'spicule') %}{{ remove_filter('publisher', 'spicule') }}{% else %}{{ add_filter('publisher', 'spicule') }}{% endif %}" class="p-side-navigation__link{% if active_filter('publisher', 'spicule') %} is-active{% endif %}">
-          Spicule
-          {% if active_filter('publisher', 'spicule') %}
-          <div class="p-side-navigation__status"><i class="p-icon--close"></i></div>
-          {% endif %}
-        </a>
-      </li>
+      {% endfor %}
     </ul>
+    {% endif %}
   </div>
 </div>
 

--- a/templates/partial/_tab-overview.html
+++ b/templates/partial/_tab-overview.html
@@ -10,16 +10,17 @@
     <p>License<br /><strong>{{ license }}</strong></p>
     <ul class="p-list">
       <li class="p-list__item">
-        <a href="#"><i class="p-icon--share"></i>&nbsp;&nbsp;Homepage</a>
+        <a href="{{ website }}"><i class="p-icon--share"></i>&nbsp;&nbsp;Homepage</a>
       </li>
       <li class="p-list__item">
-        <a href="#"><i class="p-icon--user"></i>&nbsp;&nbsp;Repository</a>
+        <a href="{{ repository_url }}"><i class="p-icon--user"></i>&nbsp;&nbsp;Repository</a>
       </li>
       <li class="p-list__item">
-        <a href="#"><i class="p-icon--search"></i>&nbsp;&nbsp;Submit a bug</a>
+        <!-- TO DO - what if the bugs are submitted to launchpad? -->
+        <a href="{{ repository_url }}/issues/new"><i class="p-icon--search"></i>&nbsp;&nbsp;Submit a bug</a>
       </li>
       <li class="p-list__item">
-        <a href="#"><i class="p-icon--code"></i>&nbsp;&nbsp;Contact</a>
+        <a href="{{ contact }}"><i class="p-icon--code"></i>&nbsp;&nbsp;Contact</a>
       </li>
     </ul>
     <h4 class="p-muted-heading">Share this charm</h4>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,8 +1,14 @@
 from canonicalwebteam.flask_base.app import FlaskBase
-from flask import render_template
+from flask import render_template, request
 
 from webapp import helpers
-from webapp.charmhub import config
+from webapp.charmhub import (
+    config,
+    mock_entities,
+    mock_search_results,
+    mock_categories,
+    mock_publisher_list,
+)
 
 app = FlaskBase(
     __name__,
@@ -25,89 +31,11 @@ def utility_processor():
 
 @app.route("/")
 def index():
-    search_results = [
-        {
-            "developer_validation": "unproven",
-            "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/"
-            "2016/09/logo_-_256px.png",
-            "media": [
-                {
-                    "type": "icon",
-                    "url": "https://dashboard.snapcraft.io/site_media/"
-                    "appmedia/2016/09/logo_-_256px.png",
-                },
-                {
-                    "type": "screenshot",
-                    "url": "https://dashboard.snapcraft.io/site_media/"
-                    "appmedia/2016/09/"
-                    "Electrum_2.6.4__-__default_wallet_018.png",
-                },
-            ],
-            "origin": "antonwilc0x",
-            "package_name": "electrum",
-            "type": "bundle",
-            "publisher": "Tomas CaseyWilcox",
-            "sections": [{"featured": True, "name": "finance"}],
-            "summary": "Lightweight Bitcoin Client",
-            "title": "electrum",
-        },
-        {
-            "developer_validation": "verified",
-            "icon_url": "https://dashboard.snapcraft.io/site_media/"
-            "appmedia/2017/06/copy_1.ico.png",
-            "media": [
-                {
-                    "type": "icon",
-                    "url": "https://dashboard.snapcraft.io/site_media/"
-                    "appmedia/2017/06/copy_1.ico.png",
-                },
-                {
-                    "type": "screenshot",
-                    "url": "https://dashboard.snapcraft.io/site_media/"
-                    "appmedia/2017/06/"
-                    "Screen_Shot_2017-06-07_at_8.16.09_AM.png",
-                },
-            ],
-            "origin": "aws",
-            "package_name": "aws-cli",
-            "type": "charm",
-            "publisher": "Amazon Web Services",
-            "sections": [{"featured": True, "name": "server-and-cloud"}],
-            "summary": "Universal Command Line Interface for"
-            " Amazon Web Services",
-            "title": "aws-cli",
-        },
-        {
-            "developer_validation": "unproven",
-            "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia"
-            "/2018/03/rsz_android_studio_icon.png",
-            "media": [
-                {
-                    "type": "icon",
-                    "url": "https://dashboard.snapcraft.io/site_media"
-                    "/appmedia/2018/03/rsz_android_studio_icon.png",
-                },
-                {
-                    "type": "screenshot",
-                    "url": "https://dashboard.snapcraft.io/site_media"
-                    "/appmedia/2018/03/android-studio.png",
-                },
-                {
-                    "type": "screenshot",
-                    "url": "https://dashboard.snapcraft.io/site_media"
-                    "/appmedia/2019/04/Screenshot_20190418_002828.png",
-                },
-            ],
-            "origin": "snapcrafters",
-            "package_name": "android-studio",
-            "publisher": "Snapcrafters",
-            "sections": [{"featured": True, "name": "development"}],
-            "summary": "The IDE for Android",
-            "title": "Android Studio",
-        },
-    ]
-
-    context = {"results": search_results}
+    context = {
+        "categories": mock_categories,
+        "publisher_list": mock_publisher_list,
+        "results": mock_search_results,
+    }
     return render_template("index.html", **context)
 
 
@@ -115,96 +43,11 @@ def index():
 def details(entity_name):
     # TO DO - get entity info from API
 
-    context = {
-        "entity-id": "RT9mcUhVsRYrDLG8qnvGiy26NKvv6Qkd",
-        "entity_title": "VLC",
-        "package_name": "vlc",
-        "categories": [{"slug": "photo-and-video", "name": "Photo and Video"}],
-        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2016/"
-        "07/vlc.png",
-        "version": "3.0.8",
-        "license": "GPL-2.0+",
-        "publisher": "VideoLAN",
-        "username": "videolan",
-        "screenshots": [
-            {
-                "height": "None",
-                "type": "screenshot",
-                "url": "https://dashboard.snapcraft.io/site_media/appmedia/"
-                "2016/07/vlc-2.0-poney.jpg",
-                "width": "None",
-            },
-            {
-                "height": "None",
-                "type": "screenshot",
-                "url": "https://dashboard.snapcraft.io/site_media/appmedia/"
-                "2018/04/2018-04-26-161203_1126x899_scrot_yBFL55L.png",
-                "width": "None",
-            },
-        ],
-        "videos": [],
-        "prices": {},
-        "contact": "https://www.videolan.org/support/",
-        "website": "https://www.videolan.org/vlc/",
-        "summary": "The ultimate media player",
-        "description": "<p>VLC is the VideoLAN project's media player.</p>"
-        "\n<p>Completely open source and privacy-friendly, it plays every "
-        "multimedia file and streams.</p>\n<p>It notably plays MKV, MP4, "
-        "MPEG, MPEG-2, MPEG-4, DivX, MOV, WMV, QuickTime, WebM, FLAC, MP3, "
-        "Ogg/Vorbis files, BluRays, DVDs, VCDs, podcasts, and multimedia "
-        "streams from various network sources. It supports subtitles, closed "
-        "captions and is translated in numerous languages.</p>\n",
-        "channel_map": {
-            "amd64": {
-                "latest": [
-                    {
-                        "created-at": "16 December 2019",
-                        "version": "3.0.8",
-                        "channel": "stable",
-                        "risk": "stable",
-                        "confinement": "strict",
-                        "size": 212758528,
-                    },
-                    {
-                        "created-at": "16 December 2019",
-                        "version": "3.0.8",
-                        "channel": "candidate",
-                        "risk": "candidate",
-                        "confinement": "strict",
-                        "size": 212758528,
-                    },
-                    {
-                        "created-at": "30 March 2020",
-                        "version": "3.0.8-308-g9488c3e",
-                        "channel": "beta",
-                        "risk": "beta",
-                        "confinement": "strict",
-                        "size": 206848000,
-                    },
-                    {
-                        "created-at": "30 March 2020",
-                        "version": "4.0.0-dev-11534-gd2a01fe376",
-                        "channel": "edge",
-                        "risk": "edge",
-                        "confinement": "strict",
-                        "size": 340590592,
-                    },
-                ]
-            }
-        },
-        "entity_type": "charm",
-        "deployments": "6021",
-        "has_stable": True,
-        "developer_validation": "verified",
-        "default_track": "latest",
-        "lowest_risk_available": "stable",
-        "confinement": "strict",
-        "trending": False,
-        "filesize": "212.8 MB",
-        "last_updated": "16 December 2019",
-        "last_updated_raw": "2019-12-16T21:50:10.209544+00:00",
-        "is_users_snap": False,
-        "unlisted": False,
-    }
+    # TO DO this will not be required when we have the data from the API
+    entity_type = request.args.get("type")
+    if entity_type == "bundle":
+        context = mock_entities[0]
+    else:
+        context = mock_entities[1]
 
     return render_template("details.html", **context)

--- a/webapp/charmhub.py
+++ b/webapp/charmhub.py
@@ -10,3 +10,333 @@ config = Config(
         "details_regex_uppercase": "[A-Za-z0-9-]*[A-Za-z][A-Za-z0-9-]*",
     }
 )
+
+
+# Dummy data for home page
+mock_search_results = [
+    {
+        "developer_validation": "unproven",
+        "entity_type": "bundle",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/"
+        "2016/09/logo_-_256px.png",
+        "media": [
+            {
+                "type": "icon",
+                "url": "https://dashboard.snapcraft.io/site_media/"
+                "appmedia/2016/09/logo_-_256px.png",
+            },
+            {
+                "type": "screenshot",
+                "url": "https://dashboard.snapcraft.io/site_media/"
+                "appmedia/2016/09/"
+                "Electrum_2.6.4__-__default_wallet_018.png",
+            },
+        ],
+        "origin": "antonwilc0x",
+        "package_name": "electrum",
+        "type": "bundle",
+        "publisher": "Tomas CaseyWilcox",
+        "sections": [{"featured": True, "name": "finance"}],
+        "summary": "Lightweight Bitcoin Client",
+        "title": "electrum",
+    },
+    {
+        "developer_validation": "verified",
+        "entity_type": "charm",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/"
+        "appmedia/2017/06/copy_1.ico.png",
+        "media": [
+            {
+                "type": "icon",
+                "url": "https://dashboard.snapcraft.io/site_media/"
+                "appmedia/2017/06/copy_1.ico.png",
+            },
+            {
+                "type": "screenshot",
+                "url": "https://dashboard.snapcraft.io/site_media/"
+                "appmedia/2017/06/"
+                "Screen_Shot_2017-06-07_at_8.16.09_AM.png",
+            },
+        ],
+        "origin": "aws",
+        "package_name": "aws-cli",
+        "type": "charm",
+        "publisher": "Amazon Web Services",
+        "sections": [{"featured": True, "name": "server-and-cloud"}],
+        "summary": "Universal Command Line Interface for"
+        " Amazon Web Services",
+        "title": "aws-cli",
+    },
+    {
+        "developer_validation": "unproven",
+        "entity_type": "charm",
+        "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia"
+        "/2018/03/rsz_android_studio_icon.png",
+        "media": [
+            {
+                "type": "icon",
+                "url": "https://dashboard.snapcraft.io/site_media"
+                "/appmedia/2018/03/rsz_android_studio_icon.png",
+            },
+            {
+                "type": "screenshot",
+                "url": "https://dashboard.snapcraft.io/site_media"
+                "/appmedia/2018/03/android-studio.png",
+            },
+            {
+                "type": "screenshot",
+                "url": "https://dashboard.snapcraft.io/site_media"
+                "/appmedia/2019/04/Screenshot_20190418_002828.png",
+            },
+        ],
+        "origin": "snapcrafters",
+        "package_name": "android-studio",
+        "publisher": "Snapcrafters",
+        "sections": [{"featured": True, "name": "development"}],
+        "summary": "The IDE for Android",
+        "title": "Android Studio",
+    },
+]
+
+mock_categories = [
+    {"name": "Analytics", "slug": "analytics"},
+    {"name": "App-servers", "slug": "app-servers"},
+    {"name": "Big-data", "slug": "big-data"},
+    {"name": "Containers", "slug": "containers"},
+    {"name": "Databases", "slug": "databases"},
+    {"name": "Keystone", "slug": "keystone"},
+    {"name": "Kubernetes", "slug": "kubernetes"},
+    {"name": "Identity", "slug": "identity"},
+    {"name": "Monitoring", "slug": "monitoring"},
+    {"name": "Network", "slug": "network"},
+    {"name": "Openstack", "slug": "openstack"},
+    {"name": "Operations", "slug": "operations"},
+    {"name": "Performance", "slug": "performance"},
+    {"name": "Security", "slug": "security"},
+    {"name": "System", "slug": "system"},
+    {"name": "Storage", "slug": "storage"},
+]
+
+mock_publisher_list = [
+    {"name": "Charmers", "slug": "charmers"},
+    {"name": "Containers", "slug": "containers"},
+    {"name": "Bigdata-charmers", "slug": "bigdata-charmers"},
+    {"name": "Omnivector", "slug": "omnivector"},
+    {"name": "Spicule", "slug": "spicule"},
+]
+
+
+# Dummy data for details page
+mock_entities = [
+    {
+        "entity-id": "RT9mcUhVsRYrDLG8qnvGiy26NKvv6Qkd",
+        "entity_title": "VLC",
+        "package_name": "vlc",
+        "categories": [{"slug": "photo-and-video", "name": "Photo and Video"}],
+        "version": "3.0.8",
+        "license": "GPL-2.0+",
+        "repository_url": "https://github.com/openstack-charmers/"
+        "openstack-bundles",
+        "publisher": "VideoLAN",
+        "username": "videolan",
+        "screenshots": [
+            {
+                "height": "None",
+                "type": "screenshot",
+                "url": "https://dashboard.snapcraft.io/site_media/"
+                "appmedia/2016/07/vlc-2.0-poney.jpg",
+                "width": "None",
+            },
+            {
+                "height": "None",
+                "type": "screenshot",
+                "url": "https://dashboard.snapcraft.io/site_media/"
+                "appmedia/2018/04/"
+                "2018-04-26-161203_1126x899_scrot_yBFL55L.png",
+                "width": "None",
+            },
+        ],
+        "videos": [],
+        "prices": {},
+        "contact": "https://www.videolan.org/support/",
+        "website": "https://www.videolan.org/vlc/",
+        "summary": "The ultimate media player",
+        "description": "<p>VLC is the VideoLAN project's media player.</p>"
+        "\n<p>Completely open source and privacy-friendly, it plays every "
+        "multimedia file and streams.</p>\n<p>It notably plays MKV, MP4, "
+        "MPEG, MPEG-2, MPEG-4, DivX, MOV, WMV, QuickTime, WebM, FLAC,"
+        " MP3, Ogg/Vorbis files, BluRays, DVDs, VCDs, podcasts, and "
+        "multimedia streams from various network sources. It supports "
+        "subtitles, closed captions and is translated in numerous "
+        "languages.</p>\n",
+        "channel_map": {
+            "amd64": {
+                "latest": [
+                    {
+                        "created-at": "16 December 2019",
+                        "version": "3.0.8",
+                        "channel": "stable",
+                        "risk": "stable",
+                        "confinement": "strict",
+                        "size": 212758528,
+                    },
+                    {
+                        "created-at": "16 December 2019",
+                        "version": "3.0.8",
+                        "channel": "candidate",
+                        "risk": "candidate",
+                        "confinement": "strict",
+                        "size": 212758528,
+                    },
+                    {
+                        "created-at": "30 March 2020",
+                        "version": "3.0.8-308-g9488c3e",
+                        "channel": "beta",
+                        "risk": "beta",
+                        "confinement": "strict",
+                        "size": 206848000,
+                    },
+                    {
+                        "created-at": "30 March 2020",
+                        "version": "4.0.0-dev-11534-gd2a01fe376",
+                        "channel": "edge",
+                        "risk": "edge",
+                        "confinement": "strict",
+                        "size": 340590592,
+                    },
+                ]
+            }
+        },
+        "bundle_content": [
+            {
+                "icon_url": "https://api.jujucharms.com/charmstore/v5/"
+                "openstack-dashboard-271/icon.svg"
+            },
+            {
+                "icon_url": "https://api.jujucharms.com/charmstore/v5/"
+                "lxd-22/icon.svg"
+            },
+            {
+                "icon_url": "https://api.jujucharms.com/charmstore/v5/"
+                "ceph/icon.svg"
+            },
+            {
+                "icon_url": "https://api.jujucharms.com/charmstore/v5/"
+                "ceph/icon.svg"
+            },
+            {
+                "icon_url": "https://api.jujucharms.com/charmstore/v5/"
+                "lxd-22/icon.svg"
+            },
+        ],
+        "supported_os_list": ["18.04 LTS", "19.10"],
+        "entity_type": "bundle",
+        "deployments": "6021",
+        "has_stable": True,
+        "developer_validation": "verified",
+        "default_track": "latest",
+        "lowest_risk_available": "stable",
+        "confinement": "strict",
+        "trending": False,
+        "filesize": "212.8 MB",
+        "last_updated": "16 December 2019",
+        "last_updated_raw": "2019-12-16T21:50:10.209544+00:00",
+        "is_users_snap": False,
+        "unlisted": False,
+    },
+    {
+        "entity-id": "RT9mcUhVsRYrDLG8qnvGiy26NKvv6Qkd",
+        "entity_title": "VLC",
+        "package_name": "vlc",
+        "categories": [{"slug": "photo-and-video", "name": "Photo and Video"}],
+        "icon_url": "https://dashboard.snapcraft.io/site_media/"
+        "appmedia/2016/07/vlc.png",
+        "repository_url": "https://github.com/openstack/charm-neutron-api",
+        "version": "3.0.8",
+        "license": "GPL-2.0+",
+        "publisher": "VideoLAN",
+        "username": "videolan",
+        "screenshots": [
+            {
+                "height": "None",
+                "type": "screenshot",
+                "url": "https://dashboard.snapcraft.io/site_media/"
+                "appmedia/2016/07/vlc-2.0-poney.jpg",
+                "width": "None",
+            },
+            {
+                "height": "None",
+                "type": "screenshot",
+                "url": "https://dashboard.snapcraft.io/site_media/"
+                "appmedia/2018/04/"
+                "2018-04-26-161203_1126x899_scrot_yBFL55L.png",
+                "width": "None",
+            },
+        ],
+        "videos": [],
+        "prices": {},
+        "contact": "https://www.videolan.org/support/",
+        "website": "https://www.videolan.org/vlc/",
+        "summary": "The ultimate media player",
+        "description": "<p>VLC is the VideoLAN project's media player.</p>"
+        "\n<p>Completely open source and privacy-friendly, it plays every "
+        "multimedia file and streams.</p>\n<p>It notably plays MKV, MP4, "
+        "MPEG, MPEG-2, MPEG-4, DivX, MOV, WMV, QuickTime, WebM, FLAC,"
+        " MP3, Ogg/Vorbis files, BluRays, DVDs, VCDs, podcasts, and "
+        "multimedia streams from various network sources. It supports "
+        "subtitles, closed captions and is translated in numerous "
+        "languages.</p>\n",
+        "channel_map": {
+            "amd64": {
+                "latest": [
+                    {
+                        "created-at": "16 December 2019",
+                        "version": "3.0.8",
+                        "channel": "stable",
+                        "risk": "stable",
+                        "confinement": "strict",
+                        "size": 212758528,
+                    },
+                    {
+                        "created-at": "16 December 2019",
+                        "version": "3.0.8",
+                        "channel": "candidate",
+                        "risk": "candidate",
+                        "confinement": "strict",
+                        "size": 212758528,
+                    },
+                    {
+                        "created-at": "30 March 2020",
+                        "version": "3.0.8-308-g9488c3e",
+                        "channel": "beta",
+                        "risk": "beta",
+                        "confinement": "strict",
+                        "size": 206848000,
+                    },
+                    {
+                        "created-at": "30 March 2020",
+                        "version": "4.0.0-dev-11534-gd2a01fe376",
+                        "channel": "edge",
+                        "risk": "edge",
+                        "confinement": "strict",
+                        "size": 340590592,
+                    },
+                ]
+            }
+        },
+        "entity_type": "charm",
+        "supported_os_list": ["14.04 LTS", "18.04 LTS", "19.04", "19.10"],
+        "deployments": "6021",
+        "has_stable": True,
+        "developer_validation": "verified",
+        "default_track": "latest",
+        "lowest_risk_available": "stable",
+        "confinement": "strict",
+        "trending": False,
+        "filesize": "212.8 MB",
+        "last_updated": "16 December 2019",
+        "last_updated_raw": "2019-12-16T21:50:10.209544+00:00",
+        "is_users_snap": False,
+        "unlisted": False,
+    },
+]


### PR DESCRIPTION
## Done

- Add dummy data to python for a bundle to be used on the details page
- Generate side navigation on home page using dummy data from python

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to http://0.0.0.0:8045 and see the side nav looks as previously
- Go to http://0.0.0.0:8045charm and http://0.0.0.0:8045/the-great-bundle?type=bundle and see that everything looks the same as before


## Issue / Card

Fixes #44 #47 

