### PR TITLE
Update 404 and 500 pages design

### DIFF
--- a/static/sass/_pattern_p-image.scss
+++ b/static/sass/_pattern_p-image.scss
@@ -1,0 +1,8 @@
+@mixin p-charmhub-image {
+  .p-image--smaller-mobile {
+    @media screen and (max-width: $breakpoint-medium) {
+      height: 200px;
+      margin-bottom: 2rem;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -25,6 +25,7 @@ $theme-default-nav: dark;
 @include vf-p-headings;
 @include vf-p-heading-icon;
 @include vf-p-icons;
+@include vf-p-image;
 @include vf-p-label;
 @include vf-p-links;
 @include vf-p-lists;
@@ -63,6 +64,10 @@ $theme-default-nav: dark;
 @import "pattern_p-media-object";
 
 @include p-charmhub-media-object;
+
+@import "pattern_p-image";
+
+@include p-charmhub-image;
 
 @import "pattern_p-strip";
 
@@ -122,4 +127,16 @@ $theme-default-nav: dark;
 
 .p-heading-icon__group {
   margin-bottom: 1rem;
+}
+
+// XXX Ovi - 04.04.20: This can be removed once this issue is closed.
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/1452
+html,
+body {
+  height: 100%;
+}
+
+body {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
 }

--- a/templates/404.html
+++ b/templates/404.html
@@ -7,13 +7,37 @@
 {% block content %}
 <div class="p-strip is-deep">
   <div class="row">
-    <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/4de1c56c-404_v1.svg" alt="Error owl" width="400" height="400" />
+    <div class="col-4">
+      <img src="https://assets.ubuntu.com/v1/4de1c56c-404_v1.svg" alt="Error owl" width="400" height="400" class="p-image--smaller-mobile"/>
     </div>
-    <div class="col-6">
-      <h1>404: Page not found</h1>
-      <p>Sorry, we can't find the page you're looking for.</p>
-      <p>If you think this is an error on our site, please <a href="https://github.com/canonical-web-and-design/charmhub.io/issues/new" class="p-link--external">file a bug</a>.</p>
+    <div class="col-7 col-start-large-6">
+      <h1 class="p-heading--2">404: We couldn't find that page</h1>
+      <p><strong>The page you requested isn't currently available.</strong><br>
+        Here are some things that may have caused this:</p>
+      <ul>
+        <li>
+          The page that sent you here may have the wrong link.<br>
+          You can let us know about this <a href="https://github.com/canonical-web-and-design/charmhub.io/issues/new">here</a>
+        </li>
+        <li>
+          The URL may be wrong. We recommend you check it for typos
+        </li>
+        <li>
+          We made a mistake and this page has stopped working momentarily
+        </li>
+      </ul>
+      <p>You may want to do a new search:</p>
+      <!-- TO DO - update url for search page -->
+      <form action="/search" class="p-form p-form--inline">
+      <div class="p-form__group">
+        <div class="p-form__control u-clearfix">
+          <label for="search-input" class="u-off-screen">Search</label>
+          <input type="search" name="q" id="search-input" placeholder="Search" required>
+        </div>
+      </div>
+      <button type="submit" alt="search" class="p-button--positive">Search</button>
+      </form>
+      <p>Or return to the <a href="/">homepage</a>.</p>
     </div>
   </div>
 </div>

--- a/templates/500.html
+++ b/templates/500.html
@@ -7,18 +7,27 @@
 {% block content %}
 <div class="p-strip is-deep">
   <div class="row">
-    <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/4de1c56c-404_v1.svg" alt="Error owl" width="400" height="400" />
+    <div class="col-4">
+      <img src="https://assets.ubuntu.com/v1/4de1c56c-404_v1.svg" alt="Error owl" width="400" height="400" class="p-image--smaller-mobile"/>
     </div>
-    <div class="col-6">
-      <h1>500: Server error</h1>
-      <p class="p-heading--four">Something&rsquo;s gone wrong.</p>
-      {% if message %}<blockquote><code>{{ message }}</code></blockquote>{% endif %}
+    <div class="col-7 col-start-large-6">
+      <h1 class="p-heading--2">500: This page isn’t working</h1>
       <p>
-        Try reloading the page.
-        If the error persists, please note that it may be a <a class="p-link--external" href="https://github.com/canonical-web-and-design/charmhub.io/issues">known issue</a>.
-        If not, please <a class="p-link--external" href="https://github.com/canonical-web-and-design/charmhub.io/issues/new">file a new issue</a>.
+        <strong>We are sorry, the page you requested isn't currently available.</strong>
+        Our servers may be having some issues loading this page. This could be because we are doing some maintenance and the site will be up soon. Please try again later.
       </p>
+      <p>You may want to do a new search:</p>
+      <!-- TO DO - update url for search page -->
+      <form action="/search" class="p-form p-form--inline">
+        <div class="p-form__group">
+          <div class="p-form__control u-clearfix">
+            <label for="search-input" class="u-off-screen">Search</label>
+            <input type="search" name="q" id="search-input" placeholder="Search" required>
+          </div>
+        </div>
+        <button type="submit" alt="search" class="p-button--positive">Search</button>
+      </form>
+      <p>Or return to the <a href="/">homepage</a>.</p>
     </div>
   </div>
 </div>

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -1,4 +1,4 @@
-<footer class="p-footer">
+<footer class="p-footer is-sticky">
   <div class="row">
     <div class="col-8">
       <!-- TO DO - add backend for the current year -->


### PR DESCRIPTION
## Done

- Update 404 and 500 pages design

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to design [404](https://app.zeplin.io/project/5d3f1850b938ee0dc24c60c4/screen/5e85ffbac21a2a48cb0e8e4a) and [500](https://app.zeplin.io/project/5d3f1850b938ee0dc24c60c4/screen/5e85ffba54e15f45b5aa2b19)


## Issue / Card

Fixes #50 

## Screenshot
![image](https://user-images.githubusercontent.com/40214246/78361061-a79c8200-75af-11ea-9a30-cffed27e0870.png)
