### PR TITLE
Fix tabs order when js is disabled

### DIFF
--- a/templates/details.html
+++ b/templates/details.html
@@ -70,15 +70,13 @@
 
   {% include "partial/_tab-overview.html" %}
   {% include "partial/_tab-configuration.html" %}
-  {% include "partial/_tab-contribute.html" %}
-
   {% if entity_type == "charm" %}
     {% include "partial/_tab-actions.html" %}
     {% include "partial/_tab-integrations.html" %}
     {% include "partial/_tab-docs.html" %}
   {% endif %}
-
   {% include "partial/_tab-history.html" %}
+  {% include "partial/_tab-contribute.html" %}
 
   {% include "partial/_top-bundles.html" %}
 </div>


### PR DESCRIPTION
## Done

- Fix tabs order when js is disabled

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045/charm
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Disable `js` and see the tabs content is in the correct order


## Issue / Card

Fixes #46 

## Screenshots

[if relevant, include a screenshot]
