### PR TITLE
Update documentation link in footer

### DIFF
--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -18,7 +18,7 @@
             class="p-footer__link">Comunity</a></li>
         <li class="p-inline-list__item"><a href="/blog"
             class="p-footer__link">Blog</a></li> -->
-        <li class="p-inline-list__item"><a href="https://jaas.ai/docs/installing"
+        <li class="p-inline-list__item"><a href="https://juju.is/docs/installing"
             class="p-footer__link">Install Juju</a></li>
       </ul>
     </div>


### PR DESCRIPTION
## Done

Updated the installation link from jaas.ai to juju.is. A working redirect is already in place, but figured giving the most recent link is a good practice.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

N/A