### PR TITLE
Add no-JS section separator on details page

### DIFF
--- a/static/sass/_charmhub_p-separator.scss
+++ b/static/sass/_charmhub_p-separator.scss
@@ -1,0 +1,5 @@
+@mixin p-charmhub-separator {
+  .p-separator {
+    margin: $spv-outer--medium * 2 0 $spv-outer--regular-scaleable 0;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -85,6 +85,10 @@ $theme-default-nav: dark;
 
 @include charmhub-p-bundle-icons;
 
+@import "charmhub_p-separator";
+
+@include p-charmhub-separator;
+
 @import "charmhub_footer";
 
 @include charmhub-p-footer;

--- a/templates/partial/_tab-actions.html
+++ b/templates/partial/_tab-actions.html
@@ -1,10 +1,13 @@
 <div class="u-fixed-width p-tabs__content" id="actions">
+  <noscript>
+    <hr class="p-separator" />
+    <h2>Actions</h2>
+  </noscript>
   <aside class="p-accordion" role="tablist" aria-multiselect="true">
     <ul class="p-accordion__list">
-    {% for action in actions %}
+      {% for action in actions %}
       <li class="p-accordion__group">
-        <button type="button" class="p-accordion__tab" id="{{action.name}}" role="tab" aria-controls="{{action.name}}-section"
-          aria-expanded="true">
+        <button type="button" class="p-accordion__tab" id="{{action.name}}" role="tab" aria-controls="{{action.name}}-section" aria-expanded="true">
           <div class="row">
             <div class="col-4">
               {{ action.name }}
@@ -14,8 +17,7 @@
             </div>
           </div>
         </button>
-        <section class="p-accordion__panel" id="{{action.name}}-section" role="tabpanel" aria-hidden="false"
-          aria-labelledby="{{action.name}}-section">
+        <section class="p-accordion__panel" id="{{action.name}}-section" role="tabpanel" aria-hidden="false" aria-labelledby="{{action.name}}-section">
           <ul class="p-list--divided u-no-margin--bottom">
             {% if action.description %}
             <li class="p-list__item">
@@ -60,7 +62,7 @@
           </ul>
         </section>
       </li>
-    {% endfor %}
+      {% endfor %}
     </ul>
   </aside>
 </div>

--- a/templates/partial/_tab-configuration.html
+++ b/templates/partial/_tab-configuration.html
@@ -1,28 +1,34 @@
-<div class="row p-tabs__content" id="configuration">
-  <div class="col-3">
-    <div class="p-side-navigation">
-      <ul class="p-side-navigation__list">
-        <li class="p-side-navigation__item--title">
-          <span class="p-side-navigation__text">Contents</span>
-        </li>
+<div class="u-fixed-width p-tabs__content" id="configuration">
+  <noscript>
+    <hr class="p-separator" />
+    <h2>Configuration</h2>
+  </noscript>
+  <div class="row">
+    <div class="col-3">
+      <div class="p-side-navigation">
+        <ul class="p-side-navigation__list">
+          <li class="p-side-navigation__item--title">
+            <span class="p-side-navigation__text">Contents</span>
+          </li>
+          {% for content in configuration %}
+          <li class="p-side-navigation__item">
+            <a href="#{{ content.name }}" class="p-side-navigation__link">
+              {{ content.name }}
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+    <div class="col-7 col-start-large-5">
+      <ul class="p-list--divided">
         {% for content in configuration %}
-        <li class="p-side-navigation__item">
-          <a href="#{{ content.name }}" class="p-side-navigation__link">
-            {{ content.name }}
-          </a>
+        <li class="p-list__item" id="{{ content.name }}">
+          <p><strong>{{ content.name }}</strong></p>
+          {{ content.description | safe }}
         </li>
         {% endfor %}
       </ul>
     </div>
-  </div>
-  <div class="col-7 col-start-large-5">
-    <ul class="p-list--divided">
-      {% for content in configuration %}
-      <li class="p-list__item" id="{{ content.name }}">
-        <p><strong>{{ content.name }}</strong></p>
-        {{ content.description | safe }}
-      </li>
-      {% endfor %}
-    </ul>
   </div>
 </div>

--- a/templates/partial/_tab-contribute.html
+++ b/templates/partial/_tab-contribute.html
@@ -1,4 +1,8 @@
 <div class="u-fixed-width p-tabs__content" id="contribute">
+  <noscript>
+    <hr class="p-separator" />
+    <h2>Contribute</h2>
+  </noscript>
   <p>Community participation is welcome on this project, here is how you can get involved&hellip;</p>
   <h4>Github</h4>
   <p>

--- a/templates/partial/_tab-docs.html
+++ b/templates/partial/_tab-docs.html
@@ -1,91 +1,97 @@
-<div class="row p-tabs__content" id="docs">
-  <div class="col-3">
-    <div class="p-side-navigation">
-      <ul class="p-side-navigation__list">
-        <li class="p-side-navigation__item--title">
-          <span class="p-side-navigation__text">Contents</span>
+<div class="u-fixed-width p-tabs__content" id="docs">
+  <noscript>
+    <hr class="p-separator" />
+    <h2>Docs</h2>
+  </noscript>
+  <div class="row">
+    <div class="col-3">
+      <div class="p-side-navigation">
+        <ul class="p-side-navigation__list">
+          <li class="p-side-navigation__item--title">
+            <span class="p-side-navigation__text">Contents</span>
+          </li>
+          <li class="p-side-navigation__item">
+            <a href="#deploying" class="p-side-navigation__link">
+              Deploying
+            </a>
+          </li>
+          <li class="p-side-navigation__item">
+            <a href="#network-restricted-environments" class="p-side-navigation__link is-active">
+              Network-Restricted Environments
+            </a>
+          </li>
+          <li class="p-side-navigation__item">
+            <a href="#status" class="p-side-navigation__link">
+              Status
+            </a>
+          </li>
+          <li class="p-side-navigation__item">
+            <a href="#smoke-test" class="p-side-navigation__link">
+              Smoke test
+            </a>
+          </li>
+          <li class="p-side-navigation__item">
+            <a href="#utilities" class="p-side-navigation__link">
+              Utilities
+            </a>
+          </li>
+          <li class="p-side-navigation__item">
+            <a href="#monitoring" class="p-side-navigation__link">
+              Monitoring
+            </a>
+          </li>
+          <li class="p-side-navigation__item">
+            <a href="#logging" class="p-side-navigation__link">
+              Logging
+            </a>
+          </li>
+          <li class="p-side-navigation__item">
+            <a href="#benchmarking" class="p-side-navigation__link">
+              Benchmarking
+            </a>
+          </li>
+          <li class="p-side-navigation__item">
+            <a href="#scaling" class="p-side-navigation__link">
+              Scaling
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="col-7 col-start-large-5">
+      <ul class="p-list">
+        <li class="p-list__item" id="deploying">
+          <h4>Deploying</h4>
+          <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+          <pre><code>juju deploy openstack-dashboard</code></pre>
+          <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+          <pre><code>juju deploy /path/to/bundle.yaml</code></pre>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+            aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
         </li>
-        <li class="p-side-navigation__item">
-          <a href="#deploying" class="p-side-navigation__link">
-            Deploying
-          </a>
+        <li class="p-list__item" id="network-restricted-environments">
+          <h4>Network-Restricted Environments</h4>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+            aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
         </li>
-        <li class="p-side-navigation__item">
-          <a href="#network-restricted-environments" class="p-side-navigation__link is-active">
-            Network-Restricted Environments
-          </a>
+        <li class="p-list__item" id="verifying">
+          <h4>Verifying</h4>
+          <p><strong>Status</strong></p>
+          <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+          <pre><code>juju status</code></pre>
+          <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+          <pre><code>watch-n 2 juju status</code></pre>
+          <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto possimus, quibusdam similique, sint minus nihil aliquid voluptatem asperiores, illum optio officia porro tempora. Esse cumque repellat, amet eaque exercitationem distinctio.</p>
         </li>
-        <li class="p-side-navigation__item">
-          <a href="#status" class="p-side-navigation__link">
-            Status
-          </a>
-        </li>
-        <li class="p-side-navigation__item">
-          <a href="#smoke-test" class="p-side-navigation__link">
-            Smoke test
-          </a>
-        </li>
-        <li class="p-side-navigation__item">
-          <a href="#utilities" class="p-side-navigation__link">
-            Utilities
-          </a>
-        </li>
-        <li class="p-side-navigation__item">
-          <a href="#monitoring" class="p-side-navigation__link">
-            Monitoring
-          </a>
-        </li>
-        <li class="p-side-navigation__item">
-          <a href="#logging" class="p-side-navigation__link">
-            Logging
-          </a>
-        </li>
-        <li class="p-side-navigation__item">
-          <a href="#benchmarking" class="p-side-navigation__link">
-            Benchmarking
-          </a>
-        </li>
-        <li class="p-side-navigation__item">
-          <a href="#scaling" class="p-side-navigation__link">
-            Scaling
-          </a>
+        <li class="p-list__item" id="smoke-test">
+          <h4>Smoke test</h4>
+          <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto possimus, quibusdam similique, sint minus nihil aliquid voluptatem asperiores, illum optio officia porro tempora. Esse cumque repellat, amet eaque exercitationem distinctio.</p>
+          <pre><code>juju run-action namenode/0 smoke-test
+    juju run-action resourcemanager/0 smoke-test
+    juju run-action slave/0 smoke-test
+    juju run-action spark/0 smoke-test</code></pre>
         </li>
       </ul>
     </div>
-  </div>
-  <div class="col-7 col-start-large-5">
-    <ul class="p-list">
-      <li class="p-list__item" id="deploying">
-        <h4>Deploying</h4>
-        <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-        <pre><code>juju deploy openstack-dashboard</code></pre>
-        <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-        <pre><code>juju deploy /path/to/bundle.yaml</code></pre>
-        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-        aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-      </li>
-      <li class="p-list__item" id="network-restricted-environments">
-        <h4>Network-Restricted Environments</h4>
-        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-        aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-      </li>
-      <li class="p-list__item" id="verifying">
-        <h4>Verifying</h4>
-        <p><strong>Status</strong></p>
-        <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-        <pre><code>juju status</code></pre>
-        <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-        <pre><code>watch-n 2 juju status</code></pre>
-        <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto possimus, quibusdam similique, sint minus nihil aliquid voluptatem asperiores, illum optio officia porro tempora. Esse cumque repellat, amet eaque exercitationem distinctio.</p>
-      </li>
-      <li class="p-list__item" id="smoke-test">
-        <h4>Smoke test</h4>
-        <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Architecto possimus, quibusdam similique, sint minus nihil aliquid voluptatem asperiores, illum optio officia porro tempora. Esse cumque repellat, amet eaque exercitationem distinctio.</p>
-        <pre><code>juju run-action namenode/0 smoke-test
-juju run-action resourcemanager/0 smoke-test
-juju run-action slave/0 smoke-test
-juju run-action spark/0 smoke-test</code></pre>
-      </li>
-    </ul>
   </div>
 </div>

--- a/templates/partial/_tab-history.html
+++ b/templates/partial/_tab-history.html
@@ -1,4 +1,8 @@
 <div class="u-fixed-width p-tabs__content" id="history">
+  <noscript>
+    <hr class="p-separator" />
+    <h2>History</h2>
+  </noscript>
   <p>Displaying release history for the <strong>‘latest/stable’</strong> channel:</p>
   <table class="p-table--mobile-card" role="grid">
     <thead>
@@ -11,7 +15,7 @@
       </tr>
     </thead>
     <tbody>
-    {% for release in channel_map.amd64.latest %}
+      {% for release in channel_map.amd64.latest %}
       <tr role="row">
         <td role="rowheader" aria-label="Date">{{ release.created }}</td>
         <td role="gridcell" aria-label="hadoop slave (charm)" class="u-align--right">{{ release.charm }}</td>
@@ -19,7 +23,7 @@
         <td role="gridcell" aria-label="Imagery" class="u-align--right">{{ release.imagery }}</td>
         <td role="gridcell" aria-label="Translations" class="u-align--right">{{ release.translations }}</td>
       </tr>
-    {% endfor %}
+      {% endfor %}
     </tbody>
   </table>
   <!-- TO DO - add functionality -->

--- a/templates/partial/_tab-integrations.html
+++ b/templates/partial/_tab-integrations.html
@@ -1,4 +1,8 @@
 <div class="u-fixed-width p-tabs__content" id="integrations">
+  <noscript>
+    <hr class="p-separator" />
+    <h2>Integrations</h2>
+  </noscript>
   {% for integration_category in integrations %}
   <p><strong>{{ integration_category.category }}</strong></p>
   <div class="row u-no-padding--left u-no-padding--right p-heading-icon__group">

--- a/templates/partial/_tab-overview.html
+++ b/templates/partial/_tab-overview.html
@@ -1,5 +1,8 @@
 <div class="row p-tabs__content" id="overview">
   <div class="col-8">
+    <noscript>
+      <h2>Overview</h2>
+    </noscript>
     <h4>This is overview tab</h4>
     {{ description | safe }}
   </div>


### PR DESCRIPTION
## Done

- Add no-JS section separator on details page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [Disable JS](https://developers.google.com/web/tools/chrome-devtools/javascript/disable) and see the sections have a title and a clear separation. Also note the navigation works as expected.


## Issue / Card

Fixes #45 
