### PR TITLE
Update flask-base to 0.5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ version: 2
 defaults: &defaults
   docker:
     - image: canonicalwebteam/dev:v1.6.7
+      environment:
+        SECRET_KEY: local_development_fake_key
 
 jobs:
   test-site:

--- a/.dockerignore
+++ b/.dockerignore
@@ -17,7 +17,6 @@ run
 .docker-project
 
 # Environemnt
-.env
 .env.local
 
 # Node is only needed for building, not running

--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 PORT=8045
 FLASK_DEBUG=true
+SECRET_KEY=local_development_fake_key

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-canonicalwebteam.flask-base==0.4.3
-gunicorn[gevent]
+canonicalwebteam.flask-base==0.5.1


### PR DESCRIPTION
## Done

Update flask-base to 0.5.1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
