### PR TITLE
Remove the grid from the body

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -10,7 +10,7 @@ $theme-default-nav: dark;
 // import custom mixins
 
 // Import Vanilla framework
-@import "vanilla-framework/scss/vanilla";
+@import 'vanilla-framework/scss/vanilla';
 
 // Base Vanilla styles
 @include vf-base;
@@ -54,51 +54,51 @@ $theme-default-nav: dark;
 @include vf-u-vertically-center;
 
 // Import site specific patterns and overrides
-@import "pattern_p-card";
+@import 'pattern_p-card';
 
 @include p-charmhub-card;
 
-@import "pattern_p-link";
+@import 'pattern_p-link';
 
 @include p-charmhub-link;
 
-@import "pattern_p-media-object";
+@import 'pattern_p-media-object';
 
 @include p-charmhub-media-object;
 
-@import "pattern_p-image";
+@import 'pattern_p-image';
 
 @include p-charmhub-image;
 
-@import "pattern_p-strip";
+@import 'pattern_p-strip';
 
 @include p-charmhub-strip;
 
-@import "pattern_p-accordion";
+@import 'pattern_p-accordion';
 
 @include p-charmhub-accordion;
 
-@import "pattern_p-table-of-contents";
+@import 'pattern_p-table-of-contents';
 
 @include p-charmhub-table-of-contents;
 
-@import "charmhub_p-bundle-icons";
+@import 'charmhub_p-bundle-icons';
 
 @include charmhub-p-bundle-icons;
 
-@import "charmhub_p-separator";
+@import 'charmhub_p-separator';
 
 @include p-charmhub-separator;
 
-@import "charmhub_footer";
+@import 'charmhub_footer';
 
 @include charmhub-p-footer;
 
-@import "charmhub_p-header";
+@import 'charmhub_p-header';
 
 @include charmhub-p-header;
 
-@import "charmhub_p-series-tag";
+@import 'charmhub_p-series-tag';
 
 @include charmhub-p-series-tag;
 
@@ -139,9 +139,4 @@ $theme-default-nav: dark;
 html,
 body {
   height: 100%;
-}
-
-body {
-  display: grid;
-  grid-template-rows: auto 1fr auto;
 }

--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 
 <html lang="en" dir="ltr">
 

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -1,4 +1,4 @@
-<footer class="p-footer is-sticky">
+<footer class="p-footer">
   <div class="row">
     <div class="col-8">
       <!-- TO DO - add backend for the current year -->


### PR DESCRIPTION
## Done

- Remove the body specific SCSS. It's fragile when adding/ not adding the global-nav.
This makes the homepage footer squash to the header, but this won't be an issue when we have content.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the global-nav doesn't take up the majority of the page on the homepage.

## Issue/Card

Fixes #71 

## Screenshots
### Before
![Screenshot_2020-04-17 charmhub io(1)](https://user-images.githubusercontent.com/479384/79560414-7d62be00-809f-11ea-8c85-b06277584748.png)
### After
![Screenshot_2020-04-17 charmhub io](https://user-images.githubusercontent.com/479384/79560418-7dfb5480-809f-11ea-9025-d05336e3f97c.png)

