### PR TITLE
Remove loader from the store page

### DIFF
--- a/templates/store.html
+++ b/templates/store.html
@@ -40,9 +40,6 @@
         {% endfor %}
       {% endif %}
       </div>
-      <div class="u-fixed-width">
-        <div class="u-align--center"><i class="p-icon--spinner u-animation--spin"></i></div>
-      </div>
     </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Done

- Removed spinner from store page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8045/store
- no spinner
