### PR TITLE
Removing a filter should stay on store page

### DIFF
--- a/templates/partial/_side-navigation.html
+++ b/templates/partial/_side-navigation.html
@@ -7,7 +7,7 @@
       </li>
       {% for category in categories %}
       <li class="p-side-navigation__item">
-        <a href="{% if active_filter('category', category.slug) %}{{ remove_filter('category', category.slug) }}{% else %}{{ add_filter('category', category.slug) }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', category.slug) %} is-active{% endif %}">
+        <a href="/store{% if active_filter('category', category.slug) %}{{ remove_filter('category', category.slug) }}{% else %}{{ add_filter('category', category.slug) }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', category.slug) %} is-active{% endif %}">
           {{ category.name }}
           {% if active_filter('category', category.slug) %}
           <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
@@ -24,7 +24,7 @@
       </li>
       {% for publisher in publisher_list %}
       <li class="p-side-navigation__item">
-        <a href="{% if active_filter('publisher', publisher.slug) %}{{ remove_filter('publisher', publisher.slug) }}{% else %}{{ add_filter('publisher', publisher.slug) }}{% endif %}" class="p-side-navigation__link{% if active_filter('publisher', publisher.slug) %} is-active{% endif %}">
+        <a href="/store{% if active_filter('publisher', publisher.slug) %}{{ remove_filter('publisher', publisher.slug) }}{% else %}{{ add_filter('publisher', publisher.slug) }}{% endif %}" class="p-side-navigation__link{% if active_filter('publisher', publisher.slug) %} is-active{% endif %}">
           {{ publisher.name }}
           {% if active_filter('publisher', publisher.slug) %}
           <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -22,7 +22,7 @@ def join_filters(filters):
             filter_string.append(f"{filter_type}={filter_type_filters}")
 
     if len(filter_string) == 0:
-        filter_string = "/"
+        filter_string = ""
     elif len(filter_string) == 1:
         filter_string = f"?{filter_string[0]}"
     else:


### PR DESCRIPTION
## Done

- Ensure when the last filter is removed the page is redirected to /store

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8045/store
- Click on some filters in the left nav
- Remove them all
- Don't be redirected to the homepage at any point

## Issue / Card

Fixes #77 
