### PR TITLE
Truncate summary in cards

### DIFF
--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -47,5 +47,9 @@
         opacity: 1;
       }
     }
+
+    .p-card__content {
+      height: 5.5rem;
+    }
   }
 }

--- a/templates/partial/_entity-card.html
+++ b/templates/partial/_entity-card.html
@@ -14,7 +14,7 @@
       <div class="p-card__content">
         <p class="u-text--subtle">by {{ package.store_front.publisher_name }}</p>
 
-        <p><small>{{ package.store_front.summary }}</small></p>
+        <p><small>{{ package.store_front.summary|truncate(60, True) }}</small></p>
       </div>
     </div>
   </a>


### PR DESCRIPTION
## Done

- Added a max-height to p-card-content
- Added truncate jinja function to summarys

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8045/store
- See that all the cards are the same height


## Issue / Card

Fixes #81