### PR TITLE
Improve card heights to avoid scrollbars on smaller screens

### DIFF
--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -36,6 +36,8 @@
   }
 
   .p-card {
+    min-height: 12rem;
+    
     .p-card__thumbnail--small {
       filter: grayscale(100%);
       height: 1.5rem;
@@ -46,10 +48,6 @@
         filter: none;
         opacity: 1;
       }
-    }
-
-    .p-card__content {
-      height: 5.5rem;
     }
   }
 }

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -26,7 +26,7 @@
 
   .p-card {
     min-height: 12rem;
-    
+
     &.p-button {
       background: none;
       border-color: $color-mid-light;
@@ -44,7 +44,7 @@
     &:hover .p-card__title {
       text-decoration: underline;
     }
-    
+
     .p-card__thumbnail--small {
       filter: grayscale(100%);
       height: 1.5rem;

--- a/templates/store.html
+++ b/templates/store.html
@@ -39,7 +39,7 @@
           </select>
         </div>
       </div>
-      <div class="row u-equal-height">
+      <div class="row">
       {% if results %}
         {% for package in results %}
           {% include "partial/_entity-card.html" %}

--- a/templates/store.html
+++ b/templates/store.html
@@ -39,7 +39,7 @@
           </select>
         </div>
       </div>
-      <div class="row">
+      <div class="row u-equal-height">
       {% if results %}
         {% for package in results %}
           {% include "partial/_entity-card.html" %}


### PR DESCRIPTION
## Done

- Don't set an explicit height, on smaller screens that breaks things

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8045/store
- Resize your browser
- Things should look ok