### PR TITLE
Initial store JS to update the UI without page load

### DIFF
--- a/static/js/public/store.js
+++ b/static/js/public/store.js
@@ -1,5 +1,0 @@
-const test = () => {
-  console.log("Store loaded");
-};
-
-export { test };

--- a/static/js/public/store/filters.js
+++ b/static/js/public/store/filters.js
@@ -1,0 +1,224 @@
+/** Store page filters */
+class Filters {
+  constructor(selectors) {
+    this._filters = this.initFilters();
+    this.searchCache = window.location.search;
+
+    this.wrapperEls = {};
+
+    Object.keys(selectors).forEach((selectorName) => {
+      const el = document.querySelector(selectors[selectorName]);
+      if (el) {
+        this.wrapperEls[selectorName] = el;
+      }
+    });
+
+    this.initEvents();
+
+    window.addEventListener("popstate", (e) => {
+      if (!e.state) {
+        const activeFilters = this.wrapperEls.filter.querySelectorAll(
+          "[data-filter-type][data-filter-value].is-active"
+        );
+        activeFilters.forEach((filter) => {
+          filter.classList.remove("is-active");
+          filter
+            .querySelector("[data-js='remove-filter']")
+            .classList.add("u-hide");
+        });
+
+        this.wrapperEls.sort.value = "";
+
+        this.wrapperEls.search.querySelector("[name='q']").value = "";
+
+        return;
+      }
+
+      this._filters = e.state.filters;
+
+      const searchField = this.wrapperEls.search.querySelector("[name='q']");
+
+      if (this._filters.q) {
+        searchField.value = this._filters.q[0];
+      } else {
+        searchField.value = "";
+      }
+
+      if (this._filters.sort) {
+        this.wrapperEls.sort.value = this._filters.sort[0];
+      } else {
+        this.wrapperEls.sort.value = "";
+      }
+
+      Object.keys(this._filters).forEach((type) => {
+        if (type !== "q" && type !== "sort") {
+          const activeFilters = this.wrapperEls.filter.querySelectorAll(
+            "[data-filter-type][data-filter-value].is-active"
+          );
+          activeFilters.forEach((filter) => {
+            filter.classList.remove("is-active");
+            filter
+              .querySelector("[data-js='remove-filter']")
+              .classList.add("u-hide");
+          });
+
+          this._filters[type].forEach((value) => {
+            const el = this.wrapperEls.filter.querySelector(
+              `[data-filter-type="${type}"][data-filter-value="${value}"]`
+            );
+
+            el.classList.add("is-active");
+            el.querySelector("[data-js='remove-filter']").classList.remove(
+              "u-hide"
+            );
+          });
+        }
+      });
+    });
+  }
+
+  initFilters() {
+    const filters = {};
+
+    if (window.location.search) {
+      const searchParams = new URLSearchParams(window.location.search);
+      for (const [filterType, filterValue] of searchParams) {
+        filters[filterType] = filterValue.split(",");
+      }
+    }
+
+    return filters;
+  }
+
+  addFilter(filterType, filterValue) {
+    if (!this._filters[filterType]) {
+      this._filters[filterType] = [];
+    }
+
+    this._filters[filterType].push(filterValue);
+  }
+
+  removeFilter(filterType, filterValue) {
+    if (filterValue) {
+      const index = this._filters[filterType].indexOf(filterValue);
+
+      this._filters[filterType].splice(index, 1);
+    } else {
+      this._filters[filterType] = [];
+    }
+  }
+
+  filterExists(filterType, filterValue) {
+    return (
+      this._filters[filterType] &&
+      this._filters[filterType].indexOf(filterValue) > -1
+    );
+  }
+
+  cleanFilters() {
+    Object.keys(this._filters).forEach((filterType) => {
+      if (this._filters[filterType].length === 0) {
+        delete this._filters[filterType];
+      }
+    });
+  }
+
+  updateHistory() {
+    const searchParams = new URLSearchParams();
+
+    Object.keys(this._filters).forEach((filterType) => {
+      searchParams.set(filterType, this._filters[filterType].join(","));
+    });
+
+    let searchStr = searchParams.toString();
+
+    if (searchStr !== this.searchCache) {
+      this.searchCache = searchStr;
+
+      if (searchStr !== "") {
+        searchStr = `?${searchStr}`;
+      }
+
+      const newUrl = `${window.location.origin}${window.location.pathname}${searchStr}`;
+
+      history.pushState(
+        { filters: this._filters },
+        null,
+        decodeURIComponent(newUrl)
+      );
+    }
+  }
+
+  isFilterElement(el) {
+    return el.dataset.js && el.dataset.js === "filter";
+  }
+
+  initFilterEvents(el) {
+    el.addEventListener("click", (e) => {
+      let target = e.target;
+
+      while (!this.isFilterElement(target) || !target.parentNode) {
+        target = target.parentNode;
+      }
+
+      if (target) {
+        e.preventDefault();
+        const removeEl = target.querySelector("[data-js='remove-filter']");
+
+        const filterType = target.dataset.filterType;
+        const filterValue = target.dataset.filterValue;
+
+        if (this.filterExists(filterType, filterValue)) {
+          this.removeFilter(filterType, filterValue);
+          target.classList.remove("is-active");
+          removeEl.classList.add("u-hide");
+        } else {
+          this.addFilter(filterType, filterValue);
+          target.classList.add("is-active");
+          removeEl.classList.remove("u-hide");
+        }
+
+        this.cleanFilters();
+        this.updateHistory();
+      }
+    });
+  }
+
+  initSearchEvents(el) {
+    el.addEventListener("submit", (e) => {
+      e.preventDefault();
+      const formData = new FormData(el);
+      const q = formData.get("q");
+
+      if (q === "") {
+        this.removeFilter("q");
+      } else {
+        this.removeFilter("q");
+        this.addFilter("q", q);
+      }
+
+      this.cleanFilters();
+      this.updateHistory();
+    });
+  }
+
+  initSortEvents(el) {
+    el.addEventListener("change", (e) => {
+      e.preventDefault();
+      this.removeFilter("sort");
+      this.addFilter("sort", el.value);
+
+      this.cleanFilters();
+      this.updateHistory();
+    });
+  }
+
+  initEvents() {
+    const { filter, search, sort } = this.wrapperEls;
+    filter && this.initFilterEvents(filter);
+    search && this.initSearchEvents(search);
+    sort && this.initSortEvents(sort);
+  }
+}
+
+export { Filters };

--- a/static/js/public/store/filters.js
+++ b/static/js/public/store/filters.js
@@ -16,7 +16,46 @@ class Filters {
     this.initEvents();
 
     window.addEventListener("popstate", (e) => {
-      if (!e.state) {
+      this._filters = e.state ? e.state.filters : null;
+      this.updateUI();
+    });
+  }
+
+  updateUI() {
+    if (!this._filters) {
+      const activeFilters = this.wrapperEls.filter.querySelectorAll(
+        "[data-filter-type][data-filter-value].is-active"
+      );
+      activeFilters.forEach((filter) => {
+        filter.classList.remove("is-active");
+        filter
+          .querySelector("[data-js='remove-filter']")
+          .classList.add("u-hide");
+      });
+
+      this.wrapperEls.sort.value = "";
+
+      this.wrapperEls.search.querySelector("[name='q']").value = "";
+
+      return;
+    }
+
+    const searchField = this.wrapperEls.search.querySelector("[name='q']");
+
+    if (this._filters.q) {
+      searchField.value = this._filters.q[0];
+    } else {
+      searchField.value = "";
+    }
+
+    if (this._filters.sort) {
+      this.wrapperEls.sort.value = this._filters.sort[0];
+    } else {
+      this.wrapperEls.sort.value = "";
+    }
+
+    Object.keys(this._filters).forEach((type) => {
+      if (type !== "q" && type !== "sort") {
         const activeFilters = this.wrapperEls.filter.querySelectorAll(
           "[data-filter-type][data-filter-value].is-active"
         );
@@ -27,53 +66,17 @@ class Filters {
             .classList.add("u-hide");
         });
 
-        this.wrapperEls.sort.value = "";
-
-        this.wrapperEls.search.querySelector("[name='q']").value = "";
-
-        return;
-      }
-
-      this._filters = e.state.filters;
-
-      const searchField = this.wrapperEls.search.querySelector("[name='q']");
-
-      if (this._filters.q) {
-        searchField.value = this._filters.q[0];
-      } else {
-        searchField.value = "";
-      }
-
-      if (this._filters.sort) {
-        this.wrapperEls.sort.value = this._filters.sort[0];
-      } else {
-        this.wrapperEls.sort.value = "";
-      }
-
-      Object.keys(this._filters).forEach((type) => {
-        if (type !== "q" && type !== "sort") {
-          const activeFilters = this.wrapperEls.filter.querySelectorAll(
-            "[data-filter-type][data-filter-value].is-active"
+        this._filters[type].forEach((value) => {
+          const el = this.wrapperEls.filter.querySelector(
+            `[data-filter-type="${type}"][data-filter-value="${value}"]`
           );
-          activeFilters.forEach((filter) => {
-            filter.classList.remove("is-active");
-            filter
-              .querySelector("[data-js='remove-filter']")
-              .classList.add("u-hide");
-          });
 
-          this._filters[type].forEach((value) => {
-            const el = this.wrapperEls.filter.querySelector(
-              `[data-filter-type="${type}"][data-filter-value="${value}"]`
-            );
-
-            el.classList.add("is-active");
-            el.querySelector("[data-js='remove-filter']").classList.remove(
-              "u-hide"
-            );
-          });
-        }
-      });
+          el.classList.add("is-active");
+          el.querySelector("[data-js='remove-filter']").classList.remove(
+            "u-hide"
+          );
+        });
+      }
     });
   }
 

--- a/static/js/public/store/index.js
+++ b/static/js/public/store/index.js
@@ -1,0 +1,3 @@
+import { Filters } from "./filters";
+
+export { Filters };

--- a/templates/partial/_side-navigation.html
+++ b/templates/partial/_side-navigation.html
@@ -1,5 +1,5 @@
 <div class="col-3 u-hide--small">
-  <div class="p-side-navigation">
+  <div class="p-side-navigation" data-js="filter-handler">
     {% if categories %}
     <ul class="p-side-navigation__list">
       <li class="p-side-navigation__item--title">
@@ -7,11 +7,13 @@
       </li>
       {% for category in categories %}
       <li class="p-side-navigation__item">
-        <a href="/store{% if active_filter('category', category.slug) %}{{ remove_filter('category', category.slug) }}{% else %}{{ add_filter('category', category.slug) }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', category.slug) %} is-active{% endif %}">
+        <a href="/store{% if active_filter('category', category.slug) %}{{ remove_filter('category', category.slug) }}{% else %}{{ add_filter('category', category.slug) }}{% endif %}" class="p-side-navigation__link{% if active_filter('category', category.slug) %} is-active{% endif %}" data-js="filter" data-filter-type="category" data-filter-value="{{ category.slug }}">
           {{ category.name }}
-          {% if active_filter('category', category.slug) %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
+          <div
+            data-js="remove-filter"
+            class="p-side-navigation__status is-toggle {% if not active_filter('category', category.slug) %}u-hide{% endif %}">
+            <i class="p-icon--close"></i>
+          </div>
         </a>
       </li>
       {% endfor %}
@@ -24,11 +26,13 @@
       </li>
       {% for publisher in publisher_list %}
       <li class="p-side-navigation__item">
-        <a href="/store{% if active_filter('publisher', publisher.slug) %}{{ remove_filter('publisher', publisher.slug) }}{% else %}{{ add_filter('publisher', publisher.slug) }}{% endif %}" class="p-side-navigation__link{% if active_filter('publisher', publisher.slug) %} is-active{% endif %}">
+        <a href="/store{% if active_filter('publisher', publisher.slug) %}{{ remove_filter('publisher', publisher.slug) }}{% else %}{{ add_filter('publisher', publisher.slug) }}{% endif %}" class="p-side-navigation__link{% if active_filter('publisher', publisher.slug) %} is-active{% endif %}" data-js="filter" data-filter-type="publisher" data-filter-value="{{ publisher.slug }}">
           {{ publisher.name }}
-          {% if active_filter('publisher', publisher.slug) %}
-          <div class="p-side-navigation__status is-toggle"><i class="p-icon--close"></i></div>
-          {% endif %}
+          <div
+            data-js="remove-filter"
+            class="p-side-navigation__status is-toggle {% if not active_filter("publisher", publisher.slug) %}u-hide{% endif %}">
+            <i class="p-icon--close"></i>
+          </div>
         </a>
       </li>
       {% endfor %}

--- a/templates/store.html
+++ b/templates/store.html
@@ -22,20 +22,19 @@
           <h4 class="p-muted-heading u-float-left">{{ results|length }} items</h4>
         </div>
         <div class="col-4 col-start-large-4">
-          <form class="p-search-box">
+          <form class="p-search-box" data-js="search-handler">
             <input type="search" class="p-search-box__input" name="q" placeholder="Search" {% if q %}value="{{ q }}"{% endif %} />
             <button type="submit" class="p-search-box__button" alt="Search"><i class="p-icon--search"></i></button>
           </form>
         </div>
         <div class="col-2">
-          <!-- TO DO - add filter functionality -->
-          <select name="filter">
+          <select name="sort" data-js="sort-handler">
             <option disabled="disabled" value="" selected="">Sort by</option>
-            <option value="/careers/engineering">Most popular</option>
-            <option value="/careers/tech-ops">Name A/Z</option>
-            <option value="/careers/commercial-ops">Name Z/A</option>
-            <option value="/careers/commercial-ops">Author</option>
-            <option value="/careers/all">Featured</option>
+            <option value="featured">Featured</option>
+            <option value="name-desc">Name A/Z</option>
+            <option value="name-asc">Name Z/A</option>
+            {#<option value="most-popular">Most popular</option>#}
+            {#<option value="publisher">Publisher</option>#}
           </select>
         </div>
       </div>
@@ -54,7 +53,11 @@
 <script src="{{ versioned_static('js/dist/store.js') }}" defer></script>
 <script>
   window.addEventListener("DOMContentLoaded", function () {
-    charmhub.store.test()
+    new charmhub.store.Filters({
+      filter: "[data-js='filter-handler']",
+      search: "[data-js='search-handler']",
+      sort: "[data-js='sort-handler']"
+    });
   });
 </script>
 {% endblock %}

--- a/templates/store.html
+++ b/templates/store.html
@@ -28,8 +28,8 @@
           </form>
         </div>
         <div class="col-2">
-          <select name="sort" data-js="sort-handler">
-            <option disabled="disabled" value="" selected="">Sort by</option>
+          <select name="sort" data-js="sort-handler" value="{{ sort }}">
+            <option disabled="disabled" value="">Sort by</option>
             <option value="featured">Featured</option>
             <option value="name-desc">Name A/Z</option>
             <option value="name-asc">Name Z/A</option>

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -14,6 +14,7 @@ store = Blueprint(
 @store.route("/store")
 def store_view():
     query = request.args.get("q", default=None, type=str)
+    sort = request.args.get("sort", default="", type=str)
 
     if query:
         api_search_results = app.store_api.find(query=query).get("results", [])
@@ -33,6 +34,7 @@ def store_view():
     context = {
         "categories": data.mock_categories,
         "publisher_list": data.mock_publisher_list,
+        "sort": sort,
         "q": query,
         "results": results,
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,8 +8,8 @@ const production = process.env.ENVIRONMENT !== "devel";
 const minimizer = production
   ? [
       new TerserPlugin({
-        sourceMap: true
-      })
+        sourceMap: true,
+      }),
     ]
   : [];
 
@@ -17,12 +17,12 @@ module.exports = {
   entry: {
     "global-nav": "./static/js/base/global-nav.js",
     base: "./static/js/base/base.js",
-    store: "./static/js/public/store.js",
-    details: "./static/js/public/details.js"
+    store: "./static/js/public/store/index.js",
+    details: "./static/js/public/details.js",
   },
   output: {
     filename: "[name].js",
-    path: __dirname + "/static/js/dist"
+    path: __dirname + "/static/js/dist",
   },
   mode: production ? "production" : "development",
   devtool: production ? "source-map" : "eval-source-map",
@@ -36,27 +36,27 @@ module.exports = {
         // and also react-dnd related
         exclude: /node_modules\/(?!(dom7|ssr-window)\/).*/,
         use: {
-          loader: "babel-loader"
-        }
+          loader: "babel-loader",
+        },
       },
       // loaders are evaluated from bottom to top (right to left)
       // so first transpile via babel, then expose as global
       {
         test: require.resolve(__dirname + "/static/js/base/base.js"),
-        use: ["expose-loader?charmhub.base", "babel-loader"]
+        use: ["expose-loader?charmhub.base", "babel-loader"],
       },
       {
-        test: require.resolve(__dirname + "/static/js/public/store.js"),
-        use: ["expose-loader?charmhub.store", "babel-loader"]
+        test: require.resolve(__dirname + "/static/js/public/store/index.js"),
+        use: ["expose-loader?charmhub.store", "babel-loader"],
       },
       {
         test: require.resolve(__dirname + "/static/js/public/details.js"),
-        use: ["expose-loader?charmhub.details", "babel-loader"]
-      }
-    ]
+        use: ["expose-loader?charmhub.details", "babel-loader"],
+      },
+    ],
   },
   optimization: {
     minimize: true,
-    minimizer
-  }
+    minimizer,
+  },
 };


### PR DESCRIPTION
## Done

- Update the UI when you add/ remove filters, without reloading the page
- Update the url when you add/ remove filters, search or sorting without reloading the page
- THIS PR DOESN'T UPDATE THE CARDS/ GET ANYTHING FROM THE SERVER
- Set initial state if you land on the page with some query params already set
- Back and forward handling

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- THIS PR DOESN'T UPDATE THE CARDS/ GET ANYTHING FROM THE SERVER
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8045/store
- Click on some filters
- Type a search term and press return
- Change the sorting
- Do it a few more times
- Notice the URL and UI updates appropriately
- THIS PR DOESN'T UPDATE THE CARDS/ GET ANYTHING FROM THE SERVER
- Press the back and forward buttons in your browser
- Notice the URL and UI updates appropriately
- Copy the URL
- Open a new tab
- Paste the URL
- THIS PR DOESN'T UPDATE THE CARDS/ GET ANYTHING FROM THE SERVER
- Search for a term and press return
- Click and remove some filters
- Use the back and forwards buttons
- See that everything works correctly, if it doesn't, sue me.
- THIS PR DOESN'T UPDATE THE CARDS/ GET ANYTHING FROM THE SERVER

## Issue / Card

Fixes #78 

- THIS PR DOESN'T UPDATE THE CARDS/ GET ANYTHING FROM THE SERVER
