### PR TITLE
Add bundle-icons to fake data cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle",
     "watch": "watch -p 'static/sass/**/*' -p 'static/js/**/*.js' -c 'yarn run build'",
     "watch-js": "webpack --watch",
-    "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-scss'",
+    "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
     "build": "yarn run build-css && yarn run build-js",
     "build-css": "node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --map false --use autoprefixer --replace 'static/css/**/*.css'",
     "build-js": "yarn run build-js-bundle",

--- a/static/sass/_charmhub_p-bundle-icons.scss
+++ b/static/sass/_charmhub_p-bundle-icons.scss
@@ -15,7 +15,7 @@
       text-decoration: none;
     }
 
-    .p-bundle-icons__image {
+    img {
       border-radius: $icon-size / 2;
       box-shadow: 0 0 0 0.125rem $color-x-light;
       display: inline-block;

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -1,29 +1,4 @@
 @mixin p-charmhub-card {
-  .p-card--bundle {
-    @extend %vf-card;
-
-    padding: 1rem 0 0 0;
-
-    .p-card__title {
-      padding-bottom: $spv-inner--small;
-
-      .p-card__title-text {
-        display: inline;
-      }
-    }
-
-    .p-card__subtitle {
-      .series-tags {
-        margin-top: $spv-inner--large;
-      }
-    }
-
-    .p-card__content {
-      padding-bottom: $spv-inner--large;
-      padding-top: $spv-inner--large;
-    }
-  }
-
   .p-card {
     &.p-button {
       background: none;

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -1,4 +1,29 @@
 @mixin p-charmhub-card {
+  .p-card--bundle {
+    @extend %vf-card;
+
+    padding: 1rem 0 0 0;
+
+    .p-card__title {
+      padding-bottom: $spv-inner--small;
+
+      .p-card__title-text {
+        display: inline;
+      }
+    }
+
+    .p-card__subtitle {
+      .series-tags {
+        margin-top: $spv-inner--large;
+      }
+    }
+
+    .p-card__content {
+      padding-bottom: $spv-inner--large;
+      padding-top: $spv-inner--large;
+    }
+  }
+  
   .p-card {
     &.p-button {
       background: none;

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -23,7 +23,7 @@
       padding-top: $spv-inner--large;
     }
   }
-  
+
   .p-card {
     &.p-button {
       background: none;

--- a/templates/partial/_entity-card.html
+++ b/templates/partial/_entity-card.html
@@ -1,8 +1,14 @@
+{% if package["package-type"] == "bundle" %}
+{% set isBundle = True %}
+{% endif %}
 <div class="col-3">
   <a href="/{{ package.name }}" class="p-button p-card">
     <div class="u-clearfix">
-      <div class="u-float-left">
+      <div class="u-float-left {% if isBundle %}p-bundle-icons{% endif %}">
         <img src="{{ package.store_front.icons[0] }}" alt="{{ package.title}}" class="p-card__thumbnail">
+        {% if isBundle %}
+          <img src="{{ package.store_front.icons[0] }}" alt="{{ package.title}}" class="p-card__thumbnail">
+        {% endif %}
       </div>
       <div class="u-float-right">
         <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" alt="" class="p-card__thumbnail--small">

--- a/templates/partial/_entity-card.html
+++ b/templates/partial/_entity-card.html
@@ -7,7 +7,8 @@
       <div class="u-float-left {% if isBundle %}p-bundle-icons{% endif %}">
         <img src="{{ package.store_front.icons[0] }}" alt="{{ package.title}}" class="p-card__thumbnail">
         {% if isBundle %}
-          <img src="{{ package.store_front.icons[0] }}" alt="{{ package.title}}" class="p-card__thumbnail">
+        <img src="{{ package.store_front.icons[0] }}" alt="{{ package.title}}" class="p-card__thumbnail">
+        <img src="{{ package.store_front.icons[0] }}" alt="{{ package.title}}" class="p-card__thumbnail">
         {% endif %}
       </div>
       <div class="u-float-right">


### PR DESCRIPTION
## Done

- Update bundle cards to have double icons

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Pull the branch
- Visit http://0.0.0.0:8045/store
- Some cards should have double icons - these are bundles


## Issue / Card

Fixes #89 
