### PR TITLE
100 store page mobile updates

### DIFF
--- a/static/js/public/store/filters.js
+++ b/static/js/public/store/filters.js
@@ -6,7 +6,7 @@ class Filters {
 
     this.wrapperEls = {};
 
-    Object.keys(selectors).forEach(selectorName => {
+    Object.keys(selectors).forEach((selectorName) => {
       const el = document.querySelector(selectors[selectorName]);
       if (el) {
         this.wrapperEls[selectorName] = el;
@@ -14,9 +14,8 @@ class Filters {
     });
 
     this.initEvents();
-    console.log(this.wrapperEls);
 
-    window.addEventListener("popstate", e => {
+    window.addEventListener("popstate", (e) => {
       this._filters = e.state ? e.state.filters : null;
       this.updateUI();
     });
@@ -27,7 +26,7 @@ class Filters {
       const activeFilters = this.wrapperEls.filter.querySelectorAll(
         "[data-filter-type][data-filter-value].is-active"
       );
-      activeFilters.forEach(filter => {
+      activeFilters.forEach((filter) => {
         filter.classList.remove("is-active");
         filter
           .querySelector("[data-js='remove-filter']")
@@ -55,19 +54,19 @@ class Filters {
       this.wrapperEls.sort.value = "";
     }
 
-    Object.keys(this._filters).forEach(type => {
+    Object.keys(this._filters).forEach((type) => {
       if (type !== "q" && type !== "sort") {
         const activeFilters = this.wrapperEls.filter.querySelectorAll(
           "[data-filter-type][data-filter-value].is-active"
         );
-        activeFilters.forEach(filter => {
+        activeFilters.forEach((filter) => {
           filter.classList.remove("is-active");
           filter
             .querySelector("[data-js='remove-filter']")
             .classList.add("u-hide");
         });
 
-        this._filters[type].forEach(value => {
+        this._filters[type].forEach((value) => {
           const el = this.wrapperEls.filter.querySelector(
             `[data-filter-type="${type}"][data-filter-value="${value}"]`
           );
@@ -103,7 +102,13 @@ class Filters {
   }
 
   removeFilter(filterType, filterValue) {
-    if (filterValue) {
+    if (!filterType && !filterValue) {
+      Object.keys(this._filters).forEach((filterType) => {
+        if (filterType !== "sort") {
+          delete this._filters[filterType];
+        }
+      });
+    } else if (filterValue) {
       const index = this._filters[filterType].indexOf(filterValue);
 
       this._filters[filterType].splice(index, 1);
@@ -120,7 +125,7 @@ class Filters {
   }
 
   cleanFilters() {
-    Object.keys(this._filters).forEach(filterType => {
+    Object.keys(this._filters).forEach((filterType) => {
       if (this._filters[filterType].length === 0) {
         delete this._filters[filterType];
       }
@@ -130,7 +135,7 @@ class Filters {
   updateHistory() {
     const searchParams = new URLSearchParams();
 
-    Object.keys(this._filters).forEach(filterType => {
+    Object.keys(this._filters).forEach((filterType) => {
       searchParams.set(filterType, this._filters[filterType].join(","));
     });
 
@@ -159,7 +164,7 @@ class Filters {
     } else if (selectorName === "sortMobile") {
       const options = this.wrapperEls[selectorName].querySelectorAll("input");
       if (options) {
-        options.forEach(el => {
+        options.forEach((el) => {
           if (el.value === newValue) {
             el.checked = true;
           } else {
@@ -175,7 +180,7 @@ class Filters {
   }
 
   initFilterEvents(el) {
-    el.addEventListener("click", e => {
+    el.addEventListener("click", (e) => {
       let target = e.target;
 
       while (!this.isFilterElement(target) || !target.parentNode) {
@@ -206,7 +211,7 @@ class Filters {
   }
 
   initSearchEvents(el) {
-    el.addEventListener("submit", e => {
+    el.addEventListener("submit", (e) => {
       e.preventDefault();
       const formData = new FormData(el);
       const q = formData.get("q");
@@ -224,7 +229,7 @@ class Filters {
   }
 
   initSortEvents(el) {
-    el.addEventListener("change", e => {
+    el.addEventListener("change", (e) => {
       e.preventDefault();
       this.removeFilter("sort");
       this.addFilter("sort", el.value);
@@ -236,7 +241,7 @@ class Filters {
   }
 
   initMobileSortEvents(el) {
-    el.addEventListener("change", e => {
+    el.addEventListener("change", (e) => {
       e.preventDefault();
       this.removeFilter("sort");
       this.addFilter("sort", e.target.value);
@@ -246,24 +251,76 @@ class Filters {
       this.updateHistory();
 
       // hide the drawer once clicked
-      el.classList.add("is-active");
+      el.classList.remove("is-active");
     });
   }
 
-  initMobileSortButton(el) {
-    el.addEventListener("click", e => {
+  initMobileFilterEvents(el) {
+    const mobileFilters = el.querySelectorAll("input");
+    const resetButton = el.querySelector("[data-js='filter-reset']");
+    const submitButton = el.querySelector("[data-js='filter-submit']");
+
+    if (mobileFilters) {
+      mobileFilters.forEach((filterEl) => {
+        filterEl.addEventListener("click", () => {
+          const filterType = filterEl.dataset.filterType;
+          const filterValue = filterEl.value;
+
+          if (this.filterExists(filterType, filterValue)) {
+            this.removeFilter(filterType, filterValue);
+          } else {
+            this.addFilter(filterType, filterValue);
+          }
+
+          this.cleanFilters();
+          this.updateHistory();
+        });
+      });
+    }
+
+    if (resetButton) {
+      resetButton.addEventListener("click", () => {
+        this.removeFilter();
+        this.updateHistory();
+      });
+    }
+
+    if (submitButton) {
+      submitButton.addEventListener("click", (e) => {
+        e.preventDefault();
+
+        el.classList.remove("is-active");
+        this.cleanFilters();
+        this.updateHistory();
+      });
+    }
+  }
+
+  initMobileButton(el, targetEl) {
+    el.addEventListener("click", (e) => {
       e.preventDefault();
-      this.wrapperEls["sortMobile"].classList.remove("is-active");
+      targetEl.classList.toggle("is-active");
     });
   }
 
   initEvents() {
-    const { filter, search, sort, sortMobile } = this.wrapperEls;
+    const {
+      filter,
+      search,
+      sort,
+      sortMobile,
+      sortMobileButton,
+      filterMobile,
+      filterMobileButton,
+    } = this.wrapperEls;
     filter && this.initFilterEvents(filter);
     search && this.initSearchEvents(search);
     sort && this.initSortEvents(sort);
     sortMobile && this.initMobileSortEvents(sortMobile);
-    // sortMobileButton && this.initMobileSortButton(sortMobileButton);
+    sortMobileButton && this.initMobileButton(sortMobileButton, sortMobile);
+    filterMobile && this.initMobileFilterEvents(filterMobile);
+    filterMobileButton &&
+      this.initMobileButton(filterMobileButton, filterMobile);
   }
 }
 

--- a/static/js/public/store/filters.js
+++ b/static/js/public/store/filters.js
@@ -6,7 +6,7 @@ class Filters {
 
     this.wrapperEls = {};
 
-    Object.keys(selectors).forEach((selectorName) => {
+    Object.keys(selectors).forEach(selectorName => {
       const el = document.querySelector(selectors[selectorName]);
       if (el) {
         this.wrapperEls[selectorName] = el;
@@ -14,8 +14,9 @@ class Filters {
     });
 
     this.initEvents();
+    console.log(this.wrapperEls);
 
-    window.addEventListener("popstate", (e) => {
+    window.addEventListener("popstate", e => {
       this._filters = e.state ? e.state.filters : null;
       this.updateUI();
     });
@@ -26,7 +27,7 @@ class Filters {
       const activeFilters = this.wrapperEls.filter.querySelectorAll(
         "[data-filter-type][data-filter-value].is-active"
       );
-      activeFilters.forEach((filter) => {
+      activeFilters.forEach(filter => {
         filter.classList.remove("is-active");
         filter
           .querySelector("[data-js='remove-filter']")
@@ -54,19 +55,19 @@ class Filters {
       this.wrapperEls.sort.value = "";
     }
 
-    Object.keys(this._filters).forEach((type) => {
+    Object.keys(this._filters).forEach(type => {
       if (type !== "q" && type !== "sort") {
         const activeFilters = this.wrapperEls.filter.querySelectorAll(
           "[data-filter-type][data-filter-value].is-active"
         );
-        activeFilters.forEach((filter) => {
+        activeFilters.forEach(filter => {
           filter.classList.remove("is-active");
           filter
             .querySelector("[data-js='remove-filter']")
             .classList.add("u-hide");
         });
 
-        this._filters[type].forEach((value) => {
+        this._filters[type].forEach(value => {
           const el = this.wrapperEls.filter.querySelector(
             `[data-filter-type="${type}"][data-filter-value="${value}"]`
           );
@@ -119,7 +120,7 @@ class Filters {
   }
 
   cleanFilters() {
-    Object.keys(this._filters).forEach((filterType) => {
+    Object.keys(this._filters).forEach(filterType => {
       if (this._filters[filterType].length === 0) {
         delete this._filters[filterType];
       }
@@ -129,7 +130,7 @@ class Filters {
   updateHistory() {
     const searchParams = new URLSearchParams();
 
-    Object.keys(this._filters).forEach((filterType) => {
+    Object.keys(this._filters).forEach(filterType => {
       searchParams.set(filterType, this._filters[filterType].join(","));
     });
 
@@ -152,12 +153,29 @@ class Filters {
     }
   }
 
+  syncSortUI(selectorName, newValue) {
+    if (selectorName === "sort") {
+      this.wrapperEls[selectorName].value = newValue;
+    } else if (selectorName === "sortMobile") {
+      const options = this.wrapperEls[selectorName].querySelectorAll("input");
+      if (options) {
+        options.forEach(el => {
+          if (el.value === newValue) {
+            el.checked = true;
+          } else {
+            el.checked = false;
+          }
+        });
+      }
+    }
+  }
+
   isFilterElement(el) {
     return el.dataset.js && el.dataset.js === "filter";
   }
 
   initFilterEvents(el) {
-    el.addEventListener("click", (e) => {
+    el.addEventListener("click", e => {
       let target = e.target;
 
       while (!this.isFilterElement(target) || !target.parentNode) {
@@ -188,7 +206,7 @@ class Filters {
   }
 
   initSearchEvents(el) {
-    el.addEventListener("submit", (e) => {
+    el.addEventListener("submit", e => {
       e.preventDefault();
       const formData = new FormData(el);
       const q = formData.get("q");
@@ -206,21 +224,46 @@ class Filters {
   }
 
   initSortEvents(el) {
-    el.addEventListener("change", (e) => {
+    el.addEventListener("change", e => {
       e.preventDefault();
       this.removeFilter("sort");
       this.addFilter("sort", el.value);
+      this.syncSortUI("sortMobile", el.value);
 
       this.cleanFilters();
       this.updateHistory();
     });
   }
 
+  initMobileSortEvents(el) {
+    el.addEventListener("change", e => {
+      e.preventDefault();
+      this.removeFilter("sort");
+      this.addFilter("sort", e.target.value);
+      this.syncSortUI("sort", e.target.value);
+
+      this.cleanFilters();
+      this.updateHistory();
+
+      // hide the drawer once clicked
+      el.classList.add("is-active");
+    });
+  }
+
+  initMobileSortButton(el) {
+    el.addEventListener("click", e => {
+      e.preventDefault();
+      this.wrapperEls["sortMobile"].classList.remove("is-active");
+    });
+  }
+
   initEvents() {
-    const { filter, search, sort } = this.wrapperEls;
+    const { filter, search, sort, sortMobile } = this.wrapperEls;
     filter && this.initFilterEvents(filter);
     search && this.initSearchEvents(search);
     sort && this.initSortEvents(sort);
+    sortMobile && this.initMobileSortEvents(sortMobile);
+    // sortMobileButton && this.initMobileSortButton(sortMobileButton);
   }
 }
 

--- a/static/sass/_charmhub_p-filter.scss
+++ b/static/sass/_charmhub_p-filter.scss
@@ -3,20 +3,22 @@
     background-color: $color-x-light;
     bottom: 0;
     box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.2);
-    display: none;
     max-height: 75%;
     overflow-y: scroll;
     position: fixed;
+    transform: translateY(100%);
+    transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+    transition-delay: 200ms;
     width: 100%;
     //set this to 10 to match the stick nav - it has to be greater than 2 (bundle icons use 2)
     z-index: 10;
 
-    @media screen and(max-width: $breakpoint-medium) {
-      display: block;
+    @media screen and(min-width: $breakpoint-medium) {
+      display: none;
     }
 
     &.is-active {
-
+      transform: none;
     }
 
     .p-drawer--bottom__title {
@@ -24,7 +26,8 @@
 
       background-color: $color-x-light;
       margin-bottom: 0;
-      padding: map-get($sp-after, small) - map-get($nudges, nudge--small)
+      padding:
+        map-get($sp-after, small) - map-get($nudges, nudge--small)
         $spv-inner--large;
       position: sticky;
       top: 0;

--- a/static/sass/_charmhub_p-filter.scss
+++ b/static/sass/_charmhub_p-filter.scss
@@ -1,0 +1,127 @@
+@mixin p-charmhub-filter {
+  .p-drawer--bottom {
+    background-color: $color-x-light;
+    bottom: 0;
+    box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.2);
+    display: none;
+    max-height: 75%;
+    overflow-y: scroll;
+    position: fixed;
+    width: 100%;
+    //set this to 10 to match the stick nav - it has to be greater than 2 (bundle icons use 2)
+    z-index: 10;
+
+    @media screen and(max-width: $breakpoint-medium) {
+      display: block;
+    }
+
+    &.is-active {
+
+    }
+
+    .p-drawer--bottom__title {
+      @extend %muted-heading;
+
+      background-color: $color-x-light;
+      margin-bottom: 0;
+      padding: map-get($sp-after, small) - map-get($nudges, nudge--small)
+        $spv-inner--large;
+      position: sticky;
+      top: 0;
+      z-index: 10;
+
+      &::after {
+        border-bottom: 1px solid $color-mid-light;
+        bottom: 0;
+        content: "";
+        height: 1px;
+        left: 0;
+        position: absolute;
+        right: 0;
+      }
+
+      &.has-shadow {
+        box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.2);
+
+        &::after {
+          border-bottom: none;
+        }
+      }
+    }
+
+    .p-drawer--bottom__content {
+      &:not(:last-child) {
+        padding-bottom: $spv-inner--small;
+      }
+
+      .p-drawer--bottom__group-name {
+        color: $color-mid-dark;
+        font-weight: 400;
+        padding: $spv-inner--small $spv-outer--small-scaleable;
+        position: relative;
+
+        &::after {
+          border-bottom: 1px solid $color-mid-light;
+          bottom: 0;
+          content: "";
+          height: 1px;
+          left: $spv-outer--small-scaleable;
+          position: absolute;
+          right: 0;
+        }
+      }
+
+      .p-drawer--bottom__item {
+        padding-left: $spv-outer--small-scaleable;
+        padding-right: $spv-outer--small-scaleable;
+        position: relative;
+
+        &:not(:last-child)::after {
+          border-bottom: 1px solid $color-mid-light;
+          bottom: 0;
+          content: "";
+          height: 1px;
+          left: 3rem;
+          position: absolute;
+          right: 0;
+        }
+
+        label {
+          margin-bottom: 0;
+          padding-bottom: $spv-inner--small;
+          width: 100%;
+        }
+      }
+    }
+
+    .p-drawer--bottom__controls {
+      background-color: $color-x-light;
+      bottom: 0;
+      box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.2);
+      display: flex;
+      justify-content: space-around;
+      padding: $spv-inner--medium 0 $spv-inner--large 0;
+      position: sticky;
+
+      @media screen and(max-width: 350px) {
+        display: block;
+        padding-left: $spv-inner--small;
+        padding-right: $spv-inner--small;
+      }
+
+      & * {
+        margin-bottom: 0;
+
+        @media screen and(min-width: 351px) {
+          width: 45%;
+        }
+
+        @media screen and(max-width: 350px) {
+          &:first-child {
+            margin-bottom: $spv-inner--medium;
+          }
+        }
+      }
+    }
+  }
+}

--- a/static/sass/_pattern_p-link.scss
+++ b/static/sass/_pattern_p-link.scss
@@ -12,4 +12,8 @@
       color: darken($color-light, 10%);
     }
   }
+
+  .has-icon [class*="p-icon"]:first-child {
+    margin-right: $spv-inner--small;
+  }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -165,6 +165,19 @@ $theme-default-nav: dark;
   margin-bottom: 1rem;
 }
 
+// XXX Ovi - 12.05.20: This can be removed once the new icon set is implemented in vanilla
+.p-icon--filter {
+  @extend %icon;
+
+  background-image: url("https://assets.ubuntu.com/v1/d8f7cd4d-filter.svg");
+}
+// XXX Ovi - 12.05.20: This can be removed once the new icon set is implemented in vanilla
+.p-icon--sort {
+  @extend %icon;
+
+  background-image: url("https://assets.ubuntu.com/v1/e75ab0cb-sort.svg");
+}
+
 // XXX Ovi - 04.04.20: This can be removed once this issue is closed.
 // https://github.com/canonical-web-and-design/vanilla-framework/issues/1452
 html,

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -102,6 +102,10 @@ $theme-default-nav: dark;
 
 @include charmhub-p-series-tag;
 
+@import 'charmhub_p-filter';
+
+@include p-charmhub-filter;
+
 .p-channel-map {
   position: absolute;
   z-index: 11;

--- a/templates/store.html
+++ b/templates/store.html
@@ -11,6 +11,59 @@
     <p>Find and deploy <a href="" class="p-link--inverted">Juju</a> solutions.</p>
   </div>
 </section>
+<div class="p-drawer--bottom u-hide" data-js="mobile-sort-handler">
+  <input type="checkbox" id="mobile-sort-opener" hidden>
+  <div class="p-drawer--bottom__title">
+    Sort by
+  </div>
+  <form class="p-drawer--bottom__content">
+    <div class="p-drawer--bottom__item">
+      <input type="radio" name="sortMobile" id="featured" value="featured" checked="">
+      <label for="featured">Featured</label>
+    </div>
+    <div class="p-drawer--bottom__item">
+      <input type="radio" name="sortMobile" id="name-desc" value="name-desc">
+      <label for="name-desc">Name A/Z</label>
+    </div>
+    <div class="p-drawer--bottom__item">
+      <input type="radio" name="sortMobile" id="name-asc" value="name-asc">
+      <label for="name-asc">Name Z/A</label>
+    </div>
+  </form>
+</div>
+<div class="p-drawer--bottom u-hide">
+  <div class="p-drawer--bottom__title">
+    Filter (22)
+  </div>
+  <form class="p-drawer--bottom__content">
+    {% if categories %}
+    <div class="p-drawer--bottom__group-name">
+      Categories
+    </div>
+      {% for category in categories %}
+      <div class="p-drawer--bottom__item">
+        <input type="checkbox" id="category-{{ category.slug }}" value="category-{{ category.slug }}">
+        <label for="category-{{ category.slug }}">{{ category.name }}</label>
+      </div>
+      {% endfor %}
+    {% endif %}
+    {% if publisher_list %}
+    <div class="p-drawer--bottom__group-name">
+      Publisher
+    </div>
+      {% for publisher in publisher_list %}
+      <div class="p-drawer--bottom__item">
+        <input type="checkbox" id="publisher-{{ publisher.slug }}" value="publisher-{{ publisher.slug }}">
+        <label for="publisher-{{ publisher.slug }}">{{ publisher.name }}</label>
+      </div>
+      {% endfor %}
+    {% endif %}
+    <div class="p-drawer--bottom__controls">
+      <a href="/store" class="p-button--neutral">Reset</input>
+      <a href="#" class="p-button--positive">Show results (22)</a>
+    </div>
+  </form>
+</div>
 <section class="p-strip--main">
   <div class="row">
 
@@ -19,15 +72,20 @@
     <div class="col-9">
       <div class="row u-vertically-center">
         <div class="col-2">
-          <h4 class="p-muted-heading u-float-left">{{ results|length }} items</h4>
+          <ul class="p-inline-list">
+            <li class="p-inline-list__item p-muted-heading u-float-left">{{ results|length }} items</li>
+            <li class="p-inline-list__item u-float-right u-no-margin--right u-hide--medium u-hide--large"><a href="#"><i class="p-icon--drag"></i>Filters (4)</a></li>
+            <!-- <li class="p-inline-list__item u-float-right u-hide--medium u-hide--large"><a href="" data-js="mobile-sort-reveal-button"><i class="p-icon--collapse"></i>Sort by</a></li> -->
+            <li class="p-inline-list__item u-float-right u-hide--medium u-hide--large"><label for="mobile-sort-opener" class="p-link">Sort by</label></li>
+          </ul>
         </div>
         <div class="col-4 col-start-large-4">
           <form class="p-search-box" data-js="search-handler">
-            <input type="search" class="p-search-box__input" name="q" placeholder="Search" {% if q %}value="{{ q }}"{% endif %} />
+            <input type="search" class="p-search-box__input" name="q" placeholder="Search" {% if q %}value="{{ q }}" {% endif %} />
             <button type="submit" class="p-search-box__button" alt="Search"><i class="p-icon--search"></i></button>
           </form>
         </div>
-        <div class="col-2">
+        <div class="col-2 u-hide--small u-hide--medium">
           <select name="sort" data-js="sort-handler" value="{{ sort }}">
             <option disabled="disabled" value="">Sort by</option>
             <option value="featured">Featured</option>
@@ -39,14 +97,15 @@
         </div>
       </div>
       <div class="row">
-      {% if results %}
+        {% if results %}
         {% for package in results %}
-          {% include "partial/_entity-card.html" %}
+        {% include "partial/_entity-card.html" %}
         {% endfor %}
-      {% endif %}
+        {% endif %}
       </div>
     </div>
 </section>
+
 {% endblock %}
 
 {% block page_scripts %}
@@ -56,7 +115,9 @@
     new charmhub.store.Filters({
       filter: "[data-js='filter-handler']",
       search: "[data-js='search-handler']",
-      sort: "[data-js='sort-handler']"
+      sort: "[data-js='sort-handler']",
+      sortMobile: "[data-js='mobile-sort-handler']"
+      // sortMobileButton: "[data-js='mobile-sort-reveal-button']"
     });
   });
 </script>

--- a/templates/store.html
+++ b/templates/store.html
@@ -11,8 +11,7 @@
     <p>Find and deploy <a href="" class="p-link--inverted">Juju</a> solutions.</p>
   </div>
 </section>
-<div class="p-drawer--bottom u-hide" data-js="mobile-sort-handler">
-  <input type="checkbox" id="mobile-sort-opener" hidden>
+<div class="p-drawer--bottom" data-js="mobile-sort-handler">
   <div class="p-drawer--bottom__title">
     Sort by
   </div>
@@ -31,36 +30,36 @@
     </div>
   </form>
 </div>
-<div class="p-drawer--bottom u-hide">
+<div class="p-drawer--bottom" data-js="mobile-filter-handler">
   <div class="p-drawer--bottom__title">
-    Filter (22)
+    Filter ({{ results|length }})
   </div>
   <form class="p-drawer--bottom__content">
     {% if categories %}
     <div class="p-drawer--bottom__group-name">
       Categories
     </div>
-      {% for category in categories %}
-      <div class="p-drawer--bottom__item">
-        <input type="checkbox" id="category-{{ category.slug }}" value="category-{{ category.slug }}">
-        <label for="category-{{ category.slug }}">{{ category.name }}</label>
-      </div>
-      {% endfor %}
+    {% for category in categories %}
+    <div class="p-drawer--bottom__item">
+      <input type="checkbox" id="{{ category.slug }}" value="{{ category.slug }}" data-filter-type="category" data-js="filter" {% if active_filter('category', category.slug) %}checked{% endif %}>
+      <label for="{{ category.slug }}">{{ category.name }}</label>
+    </div>
+    {% endfor %}
     {% endif %}
     {% if publisher_list %}
     <div class="p-drawer--bottom__group-name">
       Publisher
     </div>
-      {% for publisher in publisher_list %}
-      <div class="p-drawer--bottom__item">
-        <input type="checkbox" id="publisher-{{ publisher.slug }}" value="publisher-{{ publisher.slug }}">
-        <label for="publisher-{{ publisher.slug }}">{{ publisher.name }}</label>
-      </div>
-      {% endfor %}
+    {% for publisher in publisher_list %}
+    <div class="p-drawer--bottom__item">
+      <input type="checkbox" id="{{ publisher.slug }}" value="{{ publisher.slug }}" data-filter-type="publisher" data-js="filter" {% if active_filter('publisher', publisher.slug) %}checked{% endif %}">
+      <label for="{{ publisher.slug }}">{{ publisher.name }}</label>
+    </div>
+    {% endfor %}
     {% endif %}
     <div class="p-drawer--bottom__controls">
-      <a href="/store" class="p-button--neutral">Reset</input>
-      <a href="#" class="p-button--positive">Show results (22)</a>
+      <button type="reset" class="p-button--neutral" data-js="filter-reset">Reset</button>
+      <button class="p-button--positive" data-js="filter-submit">Show results ({{ results|length }})</button>
     </div>
   </form>
 </div>
@@ -74,9 +73,8 @@
         <div class="col-2">
           <ul class="p-inline-list">
             <li class="p-inline-list__item p-muted-heading u-float-left">{{ results|length }} items</li>
-            <li class="p-inline-list__item u-float-right u-no-margin--right u-hide--medium u-hide--large"><a href="#"><i class="p-icon--drag"></i>Filters (4)</a></li>
-            <!-- <li class="p-inline-list__item u-float-right u-hide--medium u-hide--large"><a href="" data-js="mobile-sort-reveal-button"><i class="p-icon--collapse"></i>Sort by</a></li> -->
-            <li class="p-inline-list__item u-float-right u-hide--medium u-hide--large"><label for="mobile-sort-opener" class="p-link">Sort by</label></li>
+            <li class="p-inline-list__item u-float-right u-no-margin--right u-hide--medium u-hide--large"><a href="/store" data-js="mobile-filter-reveal-button" class="has-icon"><i class="p-icon--filter"></i>Filters (4)</a></li>
+            <li class="p-inline-list__item u-float-right u-hide--medium u-hide--large"><a href="/store" data-js="mobile-sort-reveal-button" class="has-icon"><i class="p-icon--sort"></i>Sort by</a></li>
           </ul>
         </div>
         <div class="col-4 col-start-large-4">
@@ -85,7 +83,7 @@
             <button type="submit" class="p-search-box__button" alt="Search"><i class="p-icon--search"></i></button>
           </form>
         </div>
-        <div class="col-2 u-hide--small u-hide--medium">
+        <div class="col-2 u-hide--small">
           <select name="sort" data-js="sort-handler" value="{{ sort }}">
             <option disabled="disabled" value="">Sort by</option>
             <option value="featured">Featured</option>
@@ -116,8 +114,10 @@
       filter: "[data-js='filter-handler']",
       search: "[data-js='search-handler']",
       sort: "[data-js='sort-handler']",
-      sortMobile: "[data-js='mobile-sort-handler']"
-      // sortMobileButton: "[data-js='mobile-sort-reveal-button']"
+      sortMobile: "[data-js='mobile-sort-handler']",
+      sortMobileButton: "[data-js='mobile-sort-reveal-button']",
+      filterMobile: "[data-js='mobile-filter-handler']",
+      filterMobileButton: "[data-js='mobile-filter-reveal-button']"
     });
   });
 </script>

--- a/webapp/store/content/data.py
+++ b/webapp/store/content/data.py
@@ -525,7 +525,7 @@ def mock_missing_properties(package):
                 d[k] = v
         return d
 
-    if package["package-type"] == "charm":
+    if package["type"] == "charm":
         fake_package = get_fake_charm()
     else:
         fake_package = get_fake_bundle()

--- a/webapp/store/content/data.py
+++ b/webapp/store/content/data.py
@@ -30,7 +30,6 @@ mock_categories = [
 
 mock_publisher_list = [
     {"name": "Charmers", "slug": "charmers"},
-    {"name": "Containers", "slug": "containers"},
     {"name": "Bigdata-charmers", "slug": "bigdata-charmers"},
     {"name": "Omnivector", "slug": "omnivector"},
     {"name": "Spicule", "slug": "spicule"},


### PR DESCRIPTION
## Done

- Update store page with mobile `filters` and `sorting`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045/store
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [design](https://app.zeplin.io/project/5d3f1850b938ee0dc24c60c4/dashboard?sid=5e85aa643c398c44cc03ac9d) - scroll down on zeplin to get to the mobile designs
- Change to mobile layout. Click on `Sort by` link to open/close filter. Select a filter and see the url change. Change to desktop layput and see the same filter is selected in the dropdown
- Change to mobile layout. Click on `Filter` link to open/close filters. Select a filter and see the url changing. Click `Reset` button to reset any filter selection. Clicking `Show results` will just hide the filter drawer.

_Note: the filters on mobile are not linked to the ones on desktop (i.e. it will not update both based on one being changed) as the side nav will need to be re-implemented and then is when I can link them_ 


## Issue / Card

Fixes 