### PR TITLE
Add missing ca-certificate library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ WORKDIR /srv
 FROM ubuntu:focal
 
 # Install python and import python dependencies
-RUN apt-get update && apt-get install --no-install-recommends --yes python3-lib2to3 python3-pkg-resources
+RUN apt-get update && apt-get install --no-install-recommends --yes python3-lib2to3 python3-pkg-resources ca-certificates
 COPY --from=python-dependencies /root/.local/lib/python3.8/site-packages /root/.local/lib/python3.8/site-packages
 COPY --from=python-dependencies /root/.local/bin /root/.local/bin
 ENV PATH="/root/.local/bin:${PATH}"

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -21,7 +21,6 @@ open_id = OpenID(
 @login.route("/login", methods=["GET", "POST"])
 @open_id.loginhandler
 def login_handler():
-    print(flask.session)
     if authentication.is_authenticated(flask.session):
         return flask.redirect(open_id.get_next_url())
 


### PR DESCRIPTION
## Done

Add missing ca-certificate library necessary when doing openid transactions (SSL libraries required)
Remove oops print :smile: 

## QA

- `DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag charmhub.io .`
- `docker run -ti -p "8006:80" --env SECRET_KEY=secret_key charmhub.io`