### PR TITLE
Update suru on homepage to match holding page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
     <a href="" class="p-button--positive">Read our Manifesto</a>
   </div>
 </section>
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="u-fixed-width">
     <h2 class="p-heading--3">Featured Kubernetes Operators</h2>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
 {% block meta_description %}The Open Operator Collection{% endblock %}
 
 {% block content %}
-<section class="p-strip--charmhub is-dark">
+<section class="p-strip--suru-bottom has-accent is-dark p-strip--charmhub">
   <div class="u-fixed-width">
     <h1 class="p-heading--2">The Open Operator Collection</h1>
     <a href="" class="p-button--positive">Read our Manifesto</a>


### PR DESCRIPTION
## Done

- Fix the suru to match the new one from the holding page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- visit http://0.0.0.0:8045 in a private tab
- visit http://0.0.0.0:8045 while logged in
- both header suru's should match


## Issue / Card

Fixes #173 
