### PR TITLE
Fix error

### DIFF
--- a/static/sass/_pattern_p-strip.scss
+++ b/static/sass/_pattern_p-strip.scss
@@ -214,7 +214,16 @@
 
     background-image: url('https://assets.ubuntu.com/v1/a9dab044-suru-right.svg'), linear-gradient(266deg, #044f66, #022935);
     background-position: right center;
-    background-size: auto 100%, cover;
+    background-size: 100% auto;
+
+    &.is-dark {
+      color: $color-x-light;
+
+      .link--light {
+        color: $color-x-light;
+        text-decoration: underline;
+      }
+    }
   }
 
   .p-strip--header {

--- a/templates/details.html
+++ b/templates/details.html
@@ -9,7 +9,7 @@
       <div class="p-charm-header">
         <div class="p-media-object--medium u-no-margin--bottom">
           <div class="{% if package_type == "bundle" %}p-bundle-icons{% endif %}">
-            {% for media in package.info.media %}
+            {% for media in package.charm.media %}
             {% if media.type == "icon" %}
             <img src="{{ media.url }}" class="{% if package_type == "bundle"%}p-bundle-icons__image{% else %}p-media-object__image{% endif %}" alt="" />
             {% endif %}

--- a/templates/partial/_entity-card.html
+++ b/templates/partial/_entity-card.html
@@ -1,4 +1,4 @@
-{% if package["package-type"] == "bundle" %}
+{% if package["type"] == "bundle" %}
 {% set isBundle = True %}
 {% endif %}
 <div class="col-3">

--- a/templates/store.html
+++ b/templates/store.html
@@ -5,7 +5,7 @@
 {% block meta_description %}Charmhub description{% endblock %}
 
 {% block content %}
-<section class="p-strip--charmhub is-shallow is-dark">
+<section class="p-strip p-strip--charmhub is-dark is-shallow">
   <div class="u-fixed-width">
     <h1 class="p-heading--2">The app store for clouds</h1>
     <p>Find and deploy <a href="" class="p-link--inverted">Juju</a> solutions.</p>

--- a/webapp/store/content/data.py
+++ b/webapp/store/content/data.py
@@ -92,7 +92,7 @@ def get_fake_channel_map_entry(risk, revision):
 
 def get_fake_charm():
     return {
-        "package-type": "charm",
+        "type": "charm",
         "id": "charmCHARMcharmCHARMcharmCHARM" + str(fake.random_int(10, 99)),
         "name": fake.domain_word(),
         "charm": {
@@ -386,7 +386,7 @@ def get_fake_charm():
 
 def get_fake_bundle():
     return {
-        "package-type": "bundle",
+        "type": "bundle",
         "id": "bundleBUNDLEbundleBUNDLEbundle" + str(fake.random_int(10, 99)),
         "name": fake.domain_word(),
         "bundle": {
@@ -525,7 +525,7 @@ def mock_missing_properties(package):
                 d[k] = v
         return d
 
-    if package["package-type"] == "charm":
+    if package["type"] == "charm":
         fake_package = get_fake_charm()
     else:
         fake_package = get_fake_bundle()

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -72,12 +72,12 @@ def convert_date(date_to_convert):
 
 
 def get_icons(package):
-    media = package[package["package-type"]]["media"]
+    media = package[package["type"]]["media"]
     return [m["url"] for m in media if m["type"] == "icon"]
 
 
 def add_store_front_data(package):
-    package_data = package[package["package-type"]]
+    package_data = package[package["type"]]
     extra = {}
     extra["icons"] = get_icons(package)
     extra["publisher_name"] = package_data["publisher"]["display-name"]

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -60,9 +60,7 @@ def details(entity_name):
         )
 
     # Put the information in a generic key for cleaner templates
-    package["info"] = package[package["package-type"]]
-    del package[package["package-type"]]
 
     return render_template(
-        "details.html", package=package, package_type=package["package-type"]
+        "details.html", package=package, package_type=package["type"]
     )


### PR DESCRIPTION
## Done

- Fix `package-type` key to `type` for store and details pages
- Update Suru on store page (noticed after fix done)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- http://0.0.0.0:8045/store and http://0.0.0.0:8045/wordpress should both load


## Issue / Card

Fixes #175 
