### PR TITLE
Discourse link to discourse.juju.is

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -40,8 +40,8 @@
             Tutorials
           </a>
         </li>
-        <li class="p-navigation__link {% if request.path == '/discourse' %}is-selected{% endif %}" role="menuitem">
-          <a href="/discourse" class="p-link--external">
+        <li class="p-navigation__link" role="menuitem">
+          <a href="https://discourse.juju.is" class="p-link--external">
             Discourse
           </a>
         </li>


### PR DESCRIPTION
## Done

- We're using discourse.juju.is, this updates the nav to link to it

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click the Discourse link and see that it goes to the right place
