### PR TITLE
Navigation highlight update

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -45,7 +45,7 @@
             Discourse
           </a>
         </li>
-        <li class="p-navigation__item {% if request.path == '/collections' %}is-selected{% endif %}" role="menuitem">
+        <li class="p-navigation__item {% if request.path == '/store' %}is-selected{% endif %}" role="menuitem">
           <a href="/store" class="p-navigation__link">
             Store
           </a>


### PR DESCRIPTION
## Done

- highlight store in nav when on /store

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
