### PR TITLE
Remove by from the publisher cards

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -31,7 +31,7 @@
         </div>
         <h5 class="p-card__title u-no-margin--bottom">Postgresql</h5>
         <div class="p-card__content">
-          <p class="u-text--subtle">by Postgresql Charmers</p>
+          <p class="u-text--subtle">Postgresql Charmers</p>
 
           <p><small>PostgreSQL is a powerful, open source object-relational database...</small></p>
         </div>
@@ -51,7 +51,7 @@
         </div>
         <h5 class="p-card__title u-no-margin--bottom">Kafka</h5>
         <div class="p-card__content">
-          <p class="u-text--subtle">by BigData Charmers</p>
+          <p class="u-text--subtle">BigData Charmers</p>
 
           <p><small>Kafka is a high-performance, scalable, distributed messaging...</small></p>
         </div>
@@ -71,7 +71,7 @@
         </div>
         <h5 class="p-card__title u-no-margin--bottom">Elasticsearch</h5>
         <div class="p-card__content">
-          <p class="u-text--subtle">by Llama Charmers</p>
+          <p class="u-text--subtle">Llama Charmers</p>
 
           <p><small>Distributed RESTful search and analytics.</small></p>
         </div>
@@ -91,7 +91,7 @@
         </div>
         <h5 class="p-card__title u-no-margin--bottom">Prometheus</h5>
         <div class="p-card__content">
-          <p class="u-text--subtle">by Prometheus Charmers</p>
+          <p class="u-text--subtle">Prometheus Charmers</p>
           <p><small>Prometheus is a systems and service monitoring system.</small></p>
         </div>
       </a>

--- a/templates/partial/_entity-card.html
+++ b/templates/partial/_entity-card.html
@@ -18,7 +18,7 @@
     </div>
     <h5 class="p-card__title u-no-margin--bottom">{{ package.name }}</h5>
     <div class="p-card__content">
-      <p class="u-text--subtle">by {{ package.store_front.publisher_name }}</p>
+      <p class="u-text--subtle">{{ package.store_front.publisher_name }}</p>
 
       <p><small>{{ package.store_front.summary|truncate(60, True) }}</small></p>
     </div>


### PR DESCRIPTION
## Done

- Remove "by" from the publisher cards

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045 & http://0.0.0.0:8045/store
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See there is no "by" in the cards


## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1544

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/85386992-30d2ad80-b53c-11ea-9ae3-9b3e82fdba2b.png)

