### PR TITLE
Remove ubuntu and kubernetes icons from cards

### DIFF
--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -43,17 +43,5 @@
     &:hover .p-card__title {
       text-decoration: underline;
     }
-
-    .p-card__thumbnail--small {
-      filter: grayscale(100%);
-      height: 1.5rem;
-      margin-top: 0.5rem;
-      opacity: 0.18;
-
-      &:hover {
-        filter: none;
-        opacity: 1;
-      }
-    }
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,15 +19,8 @@
   <div class="row">
     <div class="col-3 u-equal-height">
       <a href="/wordpress" class="p-card p-button">
-        <div class="u-clearfix">
-          <div class="u-float-left ">
-            <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
-
-          </div>
-          <div class="u-float-right">
-            <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" alt="" class="p-card__thumbnail--small">
-            <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" alt="" class="p-card__thumbnail--small">
-          </div>
+        <div>
+          <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
         </div>
         <h5 class="p-card__title u-no-margin--bottom">Postgresql</h5>
         <div class="p-card__content">
@@ -39,15 +32,8 @@
     </div>
     <div class="col-3 u-equal-height">
       <a href="/wordpress" class="p-card p-button">
-        <div class="u-clearfix">
-          <div class="u-float-left ">
-            <img src="https://api.jujucharms.com/charmstore/v5/kafka-51/icon.svg" alt="" class="p-card__thumbnail">
-
-          </div>
-          <div class="u-float-right">
-            <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" alt="" class="p-card__thumbnail--small">
-            <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" alt="" class="p-card__thumbnail--small">
-          </div>
+        <div>
+          <img src="https://api.jujucharms.com/charmstore/v5/kafka-51/icon.svg" alt="" class="p-card__thumbnail">
         </div>
         <h5 class="p-card__title u-no-margin--bottom">Kafka</h5>
         <div class="p-card__content">
@@ -59,15 +45,8 @@
     </div>
     <div class="col-3 u-equal-height">
       <a href="/wordpress" class="p-card p-button">
-        <div class="u-clearfix">
-          <div class="u-float-left ">
-            <img src="https://api.jujucharms.com/charmstore/v5/elasticsearch-43/icon.svg" alt="" class="p-card__thumbnail">
-
-          </div>
-          <div class="u-float-right">
-            <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" alt="" class="p-card__thumbnail--small">
-            <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" alt="" class="p-card__thumbnail--small">
-          </div>
+        <div>
+          <img src="https://api.jujucharms.com/charmstore/v5/elasticsearch-43/icon.svg" alt="" class="p-card__thumbnail">
         </div>
         <h5 class="p-card__title u-no-margin--bottom">Elasticsearch</h5>
         <div class="p-card__content">
@@ -79,15 +58,8 @@
     </div>
     <div class="col-3 u-equal-height">
       <a href="/wordpress" class="p-card p-button">
-        <div class="u-clearfix">
-          <div class="u-float-left ">
-            <img src="https://api.jujucharms.com/charmstore/v5/prometheus-7/icon.svg" alt="" class="p-card__thumbnail">
-
-          </div>
-          <div class="u-float-right">
-            <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" alt="" class="p-card__thumbnail--small">
-            <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" alt="" class="p-card__thumbnail--small">
-          </div>
+        <div>
+          <img src="https://api.jujucharms.com/charmstore/v5/prometheus-7/icon.svg" alt="" class="p-card__thumbnail">
         </div>
         <h5 class="p-card__title u-no-margin--bottom">Prometheus</h5>
         <div class="p-card__content">

--- a/templates/partial/_entity-card.html
+++ b/templates/partial/_entity-card.html
@@ -3,18 +3,12 @@
 {% endif %}
 <div class="col-3 u-equal-height">
   <a href="/{{ package.name }}" class="p-button p-card">
-    <div class="u-clearfix">
-      <div class="u-float-left {% if isBundle %}p-bundle-icons{% endif %}">
-        <img src="{{ package.store_front.icons[0] }}" alt="{{ package.title}}" class="p-card__thumbnail">
-        {% if isBundle %}
-        <img src="{{ package.store_front.icons[0] }}" alt="{{ package.title}}" class="p-card__thumbnail">
-        <img src="{{ package.store_front.icons[0] }}" alt="{{ package.title}}" class="p-card__thumbnail">
-        {% endif %}
-      </div>
-      <div class="u-float-right">
-        <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" alt="" class="p-card__thumbnail--small">
-        <img src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" alt="" class="p-card__thumbnail--small">
-      </div>
+    <div class="{% if isBundle %}p-bundle-icons{% endif %}">
+      <img src="{{ package.store_front.icons[0] }}" alt="{{ package.title}}" class="p-card__thumbnail">
+      {% if isBundle %}
+      <img src="{{ package.store_front.icons[0] }}" alt="{{ package.title}}" class="p-card__thumbnail">
+      <img src="{{ package.store_front.icons[0] }}" alt="{{ package.title}}" class="p-card__thumbnail">
+      {% endif %}
     </div>
     <h5 class="p-card__title u-no-margin--bottom">{{ package.name }}</h5>
     <div class="p-card__content">


### PR DESCRIPTION
## Done

- Remove ubuntu and kubernetes icons from cards

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045 & http://0.0.0.0:8045/store
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the Ubuntu and Kubernetes (actually Juju) icons are no more in the cards


## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1543

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/85389017-c8390000-b53e-11ea-9acf-d79be6c28e7d.png)

