### PR TITLE
Update the logo to use the two words

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -4,8 +4,8 @@
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="/">
           <img class="p-navigation__image"
-            src="https://assets.ubuntu.com/v1/1f8628d2-Charmhub_white-orange_hex.svg" width="175" height="31"
-            alt="Charmhub" />
+            src="https://assets.ubuntu.com/v1/7da29260-Charm+hub_white-orange_hex.svg" width="175" height="31"
+            alt="Charm Hub" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open"


### PR DESCRIPTION
## Done

- Update the logo to use the new 2 words logo

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the logo says "Charm Hub"


## Issue / Card

Fixes #221 

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/85740540-9cae4500-b6f9-11ea-898b-7f0627a2bcaa.png)

