### PR TITLE
Replace charmhub with charm hub

### DIFF
--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -7,7 +7,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- TO DO - update description and google drive link -->
-    <meta name="description" content="{% block meta_description %}Charmhub{% endblock %}" />
+    <meta name="description" content="{% block meta_description %}Charm Hub{% endblock %}" />
     <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/u/1/folders/1gqxew2MS9-OkQF5bTStPgmyLS35JpztF{% endblock %}">
     <meta name="author" content="Canonical Ltd" />
 

--- a/templates/details.html
+++ b/templates/details.html
@@ -1,6 +1,6 @@
 {% extends 'base_layout.html' %}
 
-{% block meta_description %}Charmhub: The app store for clouds{% endblock %}
+{% block meta_description %}Charm Hub: The app store for clouds{% endblock %}
 
 {% block content %}
 <div class="p-strip--header is-shallow">

--- a/templates/holding.html
+++ b/templates/holding.html
@@ -7,7 +7,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- TO DO - update description and google drive link -->
-    <meta name="description" content="{% block meta_description %}Charmhub{% endblock %}" />
+    <meta name="description" content="{% block meta_description %}Charm Hub{% endblock %}" />
     <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/u/1/folders/1gqxew2MS9-OkQF5bTStPgmyLS35JpztF{% endblock %}">
     <meta name="author" content="Canonical Ltd" />
 
@@ -51,7 +51,7 @@
             <a class="p-navigation__link" href="/">
               <img class="p-navigation__image"
                    src="https://assets.ubuntu.com/v1/1f8628d2-Charmhub_white-orange_hex.svg" width="175" height="31"
-                   alt="Charmhub" />
+                   alt="Charm Hub" />
             </a>
           </div>
         </div>
@@ -70,7 +70,7 @@
     <main>
       <section class="p-strip">
         <div class="u-fixed-width">
-          <h2>Charmhub will be coming soon.</h2>
+          <h2>Charm Hub will be coming soon.</h2>
           <a href="/login" class="p-button--positive">Login</a>
         </div>
       </section>

--- a/templates/store.html
+++ b/templates/store.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1WcNN2RlQQrbLSP5ZgcIsAeQAHj5h_yDW6Yd5oBMmU3M{% endblock meta_copydoc %}
 
-{% block meta_description %}Charmhub description{% endblock %}
+{% block meta_description %}Charm Hub description{% endblock %}
 
 {% block content %}
 {#<section class="p-strip p-strip--charmhub is-dark is-shallow">


### PR DESCRIPTION
## Done

- Replace charmhub with charm hub

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
