### PR TITLE
Highlight active page with white background

### DIFF
--- a/static/sass/_pattern_p-navigation.scss
+++ b/static/sass/_pattern_p-navigation.scss
@@ -1,0 +1,12 @@
+@mixin p-charmhub-navigation {
+  @media screen and (min-width: $breakpoint-navigation-threshold) {
+    .p-navigation .p-navigation__item.is-selected {
+      background-color: $color-x-light;
+    }
+
+    .p-navigation .p-navigation__item.is-selected > .p-navigation__link {
+      color: $color-dark;
+      opacity: 1;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -65,6 +65,10 @@ $theme-default-nav: dark;
 
 @include p-charmhub-link;
 
+@import "pattern_p-navigation";
+
+@include p-charmhub-navigation;
+
 @import "pattern_p-media-object";
 
 @include p-charmhub-media-object;

--- a/templates/about/about_layout.html
+++ b/templates/about/about_layout.html
@@ -1,11 +1,7 @@
 {% extends 'base_layout.html' %}
 
 {% block content %}
-<section class="p-strip--charmhub is-shallow is-dark">
-  <div class="u-fixed-width">
-    <h1 class="p-heading--2">About Open Operators Collection</h1>
-  </div>
-</section>
+<h1 class="u-off-screen">About Open Operators Collection</h1>
 <section class="p-strip--main">
   <div class="row">
     <div class="col-2">


### PR DESCRIPTION
## Done

- Highlight active page with white background in the navigation
- Remove the banner from about page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045/store and http://0.0.0.0:8045/about
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Note the highlighted page has white background, and on /about there is no suru banner


## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1548

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/86005071-10a76080-ba0c-11ea-8178-633cc029d0aa.png)

![image](https://user-images.githubusercontent.com/40214246/86005132-21f06d00-ba0c-11ea-8f32-203ffc2ee150.png)

**Looks ugly on ~800px wide screens**
![image](https://user-images.githubusercontent.com/40214246/86005801-fd48c500-ba0c-11ea-859f-bfaeca67d7bf.png)
