### PR TITLE
Remove fake data

### DIFF
--- a/webapp/store/content/data.py
+++ b/webapp/store/content/data.py
@@ -1,7 +1,7 @@
 # Dummy data for home page
 from faker import Faker
 from faker.providers import internet
-from random import shuffle, choice
+from random import choice
 import collections.abc
 
 
@@ -505,14 +505,6 @@ def get_fake_bundle():
             },
         ],
     }
-
-
-def gen_mock_data(merge_with=[]):
-    bundles = [get_fake_bundle() for i in range(fake.random_int(5, 15))]
-    charms = [get_fake_charm() for i in range(fake.random_int(5, 15))]
-    list_data = bundles + charms
-    shuffle(list_data)
-    return list_data
 
 
 def mock_missing_properties(package):

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -72,17 +72,17 @@ def convert_date(date_to_convert):
 
 
 def get_icons(package):
-    media = package[package["type"]]["media"]
+    media = package["charm"]["media"]
     return [m["url"] for m in media if m["type"] == "icon"]
 
 
 def add_store_front_data(package):
-    package_data = package[package["type"]]
     extra = {}
     extra["icons"] = get_icons(package)
-    extra["publisher_name"] = package_data["publisher"]["display-name"]
-    extra["summary"] = package_data["summary"]
-    extra["channel_map"] = convert_channel_maps(package["channel-map"])
+    extra["publisher_name"] = package["charm"]["publisher"]["display-name"]
+    extra["summary"] = package["charm"]["summary"]
+    if package.get("channel-map"):
+        extra["channel_map"] = convert_channel_maps(package["channel-map"])
     package["store_front"] = extra
 
     return package

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -19,16 +19,9 @@ def store_view():
     sort = request.args.get("sort", default="", type=str)
 
     if query:
-        api_search_results = app.store_api.find(query=query).get("results", [])
+        results = app.store_api.find(query=query).get("results", [])
     else:
-        api_search_results = app.store_api.find().get("results", [])
-
-    for i, item in enumerate(api_search_results):
-        api_search_results[i] = data.mock_missing_properties(
-            api_search_results[i]
-        )
-
-    results = api_search_results + data.gen_mock_data()
+        results = app.store_api.find().get("results", [])
 
     for i, item in enumerate(results):
         results[i] = logic.add_store_front_data(results[i])


### PR DESCRIPTION
## Done

- Remove fake data from `/store`
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045/store
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- You should only see 2 cards: 1 charm and 1 bundle


## Issue / Card

Fixes #224 

## Screenshots

[if relevant, include a screenshot]
