### PR TITLE
Fix alignment at the top of /store page

### DIFF
--- a/static/sass/_charmhub_p-filter.scss
+++ b/static/sass/_charmhub_p-filter.scss
@@ -1,5 +1,7 @@
 @mixin p-charmhub-filter {
   .p-filter {
+    padding-block-start: 0.625rem;
+
     @media screen and(max-width: $breakpoint-medium - 1) {
       background-color: $color-x-light;
       bottom: 0;
@@ -7,6 +9,7 @@
       left: 0;
       max-height: 75%;
       overflow-y: scroll;
+      padding-block-start: 0;
       position: fixed;
       right: 0;
       transform: translateY(100%);

--- a/static/sass/_charmhub_p-store.scss
+++ b/static/sass/_charmhub_p-store.scss
@@ -7,6 +7,14 @@
   .p-store__items-left {
     align-items: center;
     justify-content: space-between;
+
+    .p-store__text {
+      padding-block-start: 0;
+
+      @media screen and(max-width: $breakpoint-medium - 1) {
+        padding-block-start: 0.25rem;
+      }
+    }
   }
 
   .p-store__search {


### PR DESCRIPTION
## Done

- Fix alignment at the top of /store page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the words `FILTERS`, `2 ITEMS` & `Search` are all aligned


## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1547

## Screenshots

[if relevant, include a screenshot]
