### PR TITLE
Amend cards layout on x-small screens

### DIFF
--- a/static/sass/_pattern_grid.scss
+++ b/static/sass/_pattern_grid.scss
@@ -1,0 +1,16 @@
+@mixin p-charmhub-grid {
+  .col-x-small-1 {
+    @media (max-width: 450px) {
+      grid-column-end: span 4;
+    }
+  }
+
+  .row.has-small-gap {
+    grid-gap: 1rem;
+    margin-bottom: 1.2rem;
+  }
+
+  .u-equal-height {
+    display: flex;
+  }
+}

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -31,6 +31,7 @@
       background: $color-x-light;
       border-color: $color-mid-light;
       display: block;
+      margin-block-end: 0;
       text-align: left;
 
       &:hover,

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -6,10 +6,6 @@ $color-accent: #f0f5f7;
 // navigation settings
 $theme-default-nav: dark;
 
-// import settings
-
-// import custom mixins
-
 // Import Vanilla framework
 @import "vanilla-framework/scss/vanilla";
 
@@ -47,7 +43,6 @@ $theme-default-nav: dark;
 @include vf-u-align;
 @include vf-u-animations;
 @include vf-u-clearfix;
-@include vf-u-equal-height;
 @include vf-u-floats;
 @include vf-u-layout;
 @include vf-u-off-screen;
@@ -64,6 +59,10 @@ $theme-default-nav: dark;
 @import "pattern_p-link";
 
 @include p-charmhub-link;
+
+@import "pattern_grid";
+
+@include p-charmhub-grid;
 
 @import "pattern_p-navigation";
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,8 +11,8 @@
     <p>The Open Operator Collection is an open-source initiative to provide a large number of interoperable, easily integrated operators for common workloads. <a href="/about/manifesto">Read our manifesto&nbsp;&rsaquo;</a></p>
     <h2 class="p-heading--4">Featured Kubernetes Operators</h2>
   </div>
-  <div class="row">
-    <div class="col-3 u-equal-height">
+  <div class="row has-small-gap">
+    <div class="col-x-small-1 col-small-2 col-medium-2 col-3 u-equal-height">
       <a href="/wordpress" class="p-card p-button">
         <div>
           <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
@@ -24,7 +24,7 @@
         </div>
       </a>
     </div>
-    <div class="col-3 u-equal-height">
+    <div class="col-x-small-1 col-small-2 col-x-small-1 col-small-2 col-medium-2 col-3 u-equal-height">
       <a href="/wordpress" class="p-card p-button">
         <div>
           <img src="https://api.jujucharms.com/charmstore/v5/kafka-51/icon.svg" alt="" class="p-card__thumbnail">
@@ -36,7 +36,7 @@
         </div>
       </a>
     </div>
-    <div class="col-3 u-equal-height">
+    <div class="col-x-small-1 col-small-2 col-medium-2 col-3 u-equal-height">
       <a href="/wordpress" class="p-card p-button">
         <div>
           <img src="https://api.jujucharms.com/charmstore/v5/elasticsearch-43/icon.svg" alt="" class="p-card__thumbnail">
@@ -48,7 +48,7 @@
         </div>
       </a>
     </div>
-    <div class="col-3 u-equal-height">
+    <div class="col-x-small-1 col-small-2 col-medium-2 col-3 u-equal-height">
       <a href="/wordpress" class="p-card p-button">
         <div>
           <img src="https://api.jujucharms.com/charmstore/v5/prometheus-7/icon.svg" alt="" class="p-card__thumbnail">
@@ -60,7 +60,7 @@
         </div>
       </a>
     </div>
-    <div class="col-3 u-equal-height">
+    <div class="col-x-small-1 col-small-2 col-medium-2 col-3 u-equal-height">
       <a href="/wordpress" class="p-card p-button">
         <div>
           <img src="https://assets.ubuntu.com/v1/476aaa77-cassandra.svg" alt="" class="p-card__thumbnail">
@@ -72,7 +72,7 @@
         </div>
       </a>
     </div>
-    <div class="col-3 u-equal-height">
+    <div class="col-x-small-1 col-small-2 col-medium-2 col-3 u-equal-height">
       <a href="/wordpress" class="p-card p-button">
         <div>
           <img src="https://api.jujucharms.com/charmstore/v5/kafka-51/icon.svg" alt="" class="p-card__thumbnail">
@@ -84,7 +84,7 @@
         </div>
       </a>
     </div>
-    <div class="col-3 u-equal-height">
+    <div class="col-x-small-1 col-small-2 col-medium-2 col-3 u-equal-height">
       <a href="/wordpress" class="p-card p-button">
         <div>
           <img src="https://assets.ubuntu.com/v1/037a94e6-mongoDB.svg" alt="" class="p-card__thumbnail">
@@ -96,7 +96,7 @@
         </div>
       </a>
     </div>
-    <div class="col-3 u-equal-height">
+    <div class="col-x-small-1 col-small-2 col-medium-2 col-3 u-equal-height">
       <a href="/wordpress" class="p-card p-button">
         <div>
           <img src="https://api.jujucharms.com/charmstore/v5/prometheus-7/icon.svg" alt="" class="p-card__thumbnail">

--- a/templates/partial/_entity-card.html
+++ b/templates/partial/_entity-card.html
@@ -1,7 +1,7 @@
 {% if package["type"] == "bundle" %}
 {% set isBundle = True %}
 {% endif %}
-<div class="col-3 u-equal-height">
+<div class="col-x-small-1 col-small-2 col-medium-2 col-3 u-equal-height">
   <a href="/{{ package.name }}" class="p-button p-card">
     <div class="{% if isBundle %}p-bundle-icons{% endif %}">
       <img src="{{ package.store_front.icons[0] }}" alt="{{ package.title}}" class="p-card__thumbnail">

--- a/templates/partial/_filters.html
+++ b/templates/partial/_filters.html
@@ -68,7 +68,7 @@
       </select>
     </div>
   </div>
-  <div class="row">
+  <div class="row has-small-gap">
     {% if results %}
       {% for package in results %}
         {% include "partial/_entity-card.html" %}


### PR DESCRIPTION
## Done

- Amend cards layout on x-small screens
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045 & http://0.0.0.0:8045/store
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Resize the scree and see 1 card/row on x-small screens, 2 cards/row for small screens, 3 cards/row for medium and large screens


## Issue / Card

Fixes #231 

## Screenshots

[if relevant, include a screenshot]
