### PR TITLE
Fix broken details page

### DIFF
--- a/templates/partial/_tabs-navigation.html
+++ b/templates/partial/_tabs-navigation.html
@@ -10,7 +10,7 @@
           <a href="#configuration" class="p-tabs__link" tabindex="-1" role="tab"
             aria-controls="configuration">Configuration</a>
         </li>
-        {% if package["package-type"] == "charm" %}
+        {% if package["type"] == "charm" %}
         <li class="p-tabs__item" role="presentation">
           <a href="#actions" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="actions">Actions</a>
         </li>

--- a/webapp/store/content/data.py
+++ b/webapp/store/content/data.py
@@ -439,6 +439,26 @@ def get_fake_bundle():
             },
         ],
         "supported_os_list": ["18.04 LTS", "19.10"],
+        "overview": "<h4>Full feature web interface for interacting with "
+        "instances, images, volumes and networks.</h4>"
+        "<p>Kubernetes is an open-source platform for deploying, scaling,"
+        "and operations of application containers across a cluster of "
+        "hosts. Kubernetes is portable in that it works with public, "
+        "private, and hybrid clouds. Extensible through a pluggable "
+        "infrastructure. Self healing in that it will automatically "
+        "restart and place containers on healthy nodes if a node ever "
+        "goes away.</p>"
+        "<h4>Usage</h4>"
+        "<p>The OpenStack Dashboard is deployed and related to keystone:</p>"
+        "<pre><code>juju deploy openstack-dashboard"
+        "juju add-relation openstack-dashboard keystone</code></pre>"
+        "<p>The dashboard will use keystone for user authentication and"
+        "authorization and to interact with the catalog of services "
+        "within the cloud.</p>"
+        "<p>The dashboard is accessible on:</p>"
+        "<pre><code>http(s)://service_unit_address/horizon</code></pre>"
+        "<p>At a minimum, the cloud must provide Glance and Nova services."
+        "</p>",
         "configuration": [
             {
                 "name": "action-managed-upgrade",


### PR DESCRIPTION
## Done

- Fix broken details page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045/osm and http://0.0.0.0:8045/osm
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click on all tabs and see that every single one of them has content, and only the selected tab's content is visible


## Issue / Card

Fixes #227 

## Screenshots

[if relevant, include a screenshot]
