### PR TITLE
Update account details page

### DIFF
--- a/templates/publisher/account-details.html
+++ b/templates/publisher/account-details.html
@@ -1,8 +1,6 @@
 {% extends 'publisher/publisher_layout.html' %}
 
 {% block title %}Account details{% endblock %}
-<!-- TO DO - add copy doc -->
-{% block meta_copydoc %}{% endblock %}
 
 {% block content %}
 <section class="p-strip">
@@ -31,41 +29,5 @@
       </p>
     </div>
   </div>
-  <div class="row">
-    <div class="col-2">
-      Email address:
-    </div>
-    <div class="col-6">
-      <!-- TO DO - get email dynamically -->
-      <p class="u-no-padding--top"><strong>test@email.com</strong></p>
-      <p class="p-form-help-text">
-        Your email address will not be shared publicly.
-      </p>
-    </div>
-  </div>
-  <!-- TO DO - get subscriptions dynamically -->
-  {% with subscriptions = true %}
-    {% if subscriptions %}
-    <div class="row">
-      <div class="col-2">
-        Email preferences:
-      </div>
-      <div class="col-6">
-        <!-- TO DO - update form details and add any missing fields -->
-        <form method="post">
-          <input type="checkbox" {% if subscriptions.newsletter %}checked{% endif %} name="newsletter" id="newsletter">
-          <label for="newsletter">
-            Blog posts delivered
-          </label>
-          <p class="p-form-help-text">
-            Get our latest and greatest blog posts delivered to your inbox.
-          </p>
-          <p>Please note, you will still recieve required platform related emails such as registration of charm names, the review status of a charm or any security vulnerabilities.</p>
-          <button type="submit" class="p-button--positive">Save email preferences</button>
-        </form>
-      </div>
-    </div>
-    {% endif %}
-  {% endwith %}
 </section>
 {% endblock %}


### PR DESCRIPTION
## Done

- Remove email and email preferences from the account details page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/account/details
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See there is only username and display name (i.e. everything we get from candid at the moment)


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
