### PR TITLE
Add tutorials id

### DIFF
--- a/webapp/tutorials/views.py
+++ b/webapp/tutorials/views.py
@@ -10,8 +10,8 @@ from canonicalwebteam.discourse_docs import (
 
 
 def init_tutorials(app, url_prefix):
-    discourse_index_id = 2628
-    category_id = 34
+    discourse_index_id = 3393
+    category_id = 30
 
     session = talisker.requests.get_session()
     tutorials_docs = DiscourseDocs(


### PR DESCRIPTION
## Done

Add correct IDs for charmcraft tutorials

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/tutorials
- there should be one tutorial for now.
