### PR TITLE
Add docs id

### DIFF
--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -31,6 +31,6 @@ def init_docs(app, url_prefix):
         "/docs/search",
         "docs-search",
         build_search_view(
-            site="snapcraft.io/docs", template_path="docs/search.html"
+            site="charmhub.io/docs", template_path="docs/search.html"
         ),
     )


### PR DESCRIPTION
## Done

Add correct ids for docs

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/docs
- Should have a homepage with not much data.
