### PR TITLE
Update charm overview tab

### DIFF
--- a/static/sass/_pattern_p-separator.scss
+++ b/static/sass/_pattern_p-separator.scss
@@ -1,0 +1,6 @@
+@mixin p-charmhub-separator {
+  .p-separator--shallow {
+    margin-block-end: 1.5rem;
+    margin-block-start: 1.5rem;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -171,6 +171,10 @@ $theme-default-nav: dark;
 
 @include p-charmhub-tooltip;
 
+@import "pattern_p-separator";
+
+@include p-charmhub-separator;
+
 .p-channel-map {
   position: absolute;
   z-index: 11;

--- a/templates/partial/_tab-overview.html
+++ b/templates/partial/_tab-overview.html
@@ -1,17 +1,12 @@
 <div class="row p-tabs__content" id="overview">
-  <div class="col-8">
-    <noscript>
-      <h2>Overview</h2>
-    </noscript>
-    {{ package.overview | safe }}
-  </div>
-  <div class="col-4">
+  <div class="col-3">
     <h4 class="p-muted-heading">{{ package_type|capitalize}} information</h4>
     <p>Latest release<br /><strong>{{ package.store_front.last_release }}</strong></p>
     <p>Deployments<br /><strong></strong></p>
-    <p>License<br /><strong>{{ package.charm.license }}</strong></p>
+    <p style="margin-block-end: 1.5rem;">License<br /><strong>{{ package.charm.license }}</strong></p>
+    <hr class="p-separator--shallow">
     <ul class="p-list">
-      <li class="p-list__item">
+      <li class="p-list__item u-no-margin--bottom">
         <a href="{{ website }}"><i class="p-icon--share"></i>&nbsp;&nbsp;Homepage</a>
       </li>
       <li class="p-list__item">
@@ -25,9 +20,16 @@
         <a href="{{ contact }}"><i class="p-icon--code"></i>&nbsp;&nbsp;Contact</a>
       </li>
     </ul>
+    <hr class="p-separator--shallow">
     <h4 class="p-muted-heading">Share this {{ package_type }}</h4>
     <p>Generate an embeddable card to be shared on external websites.</p>
     <!-- TO DO - Needs an embed this charm overlay implemented -->
     <p><a class="p-button--neutral" href="">Share this {{ package_type }}</a></p>
+  </div>
+  <div class="col-9">
+    <noscript>
+      <h2>Overview</h2>
+    </noscript>
+    {{ package.overview | safe }}
   </div>
 </div>


### PR DESCRIPTION
## Done

- Update charms overview tab

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/wordpress
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [design](https://app.zeplin.io/project/5d3f1850b938ee0dc24c60c4/screen/5f3256356f36794fd09ca340)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3033

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/91959151-2d0f9400-ed00-11ea-9a0b-8cfa02ec8244.png)

