### PR TITLE
Fix charms overview tab icons and style

### DIFF
--- a/static/sass/_pattern_p-icon.scss
+++ b/static/sass/_pattern_p-icon.scss
@@ -37,4 +37,28 @@
   .p-icon--delete:hover {
     @include vf-icon-delete($color-negative);
   }
+
+  .p-icon--home {
+    @extend %icon;
+
+    background-image: url("https://assets.ubuntu.com/v1/9bce0bc3-home.svg");
+  }
+
+  .p-icon--repository {
+    @extend %icon;
+
+    background-image: url("https://assets.ubuntu.com/v1/42a073e3-repo.svg");
+  }
+
+  .p-icon--bug {
+    @extend %icon;
+
+    background-image: url("https://assets.ubuntu.com/v1/2947d8db-bug.svg");
+  }
+
+  .p-icon--contact {
+    @extend %icon;
+
+    background-image: url("https://assets.ubuntu.com/v1/8e5d3c7e-contact.svg");
+  }
 }

--- a/templates/partial/_tab-overview.html
+++ b/templates/partial/_tab-overview.html
@@ -1,30 +1,30 @@
 <div class="row p-tabs__content" id="overview">
   <div class="col-3">
-    <h4 class="p-muted-heading">{{ package_type|capitalize}} information</h4>
-    <p>Latest release<br /><strong>{{ package.store_front.last_release }}</strong></p>
-    <p>Deployments<br /><strong></strong></p>
-    <p style="margin-block-end: 1.5rem;">License<br /><strong>{{ package.charm.license }}</strong></p>
+    <p><strong>Latest release</strong><br />{{ package.store_front.last_release }}</p>
+    <p><strong>Deployments</strong><br /></p>
+    <p><strong>License</strong><br />{{ package.charm.license }}</p>
     <hr class="p-separator--shallow">
+    <h4 class="p-heading--5 u-no-margin--bottom">Relevant links</h4>
     <ul class="p-list">
       <li class="p-list__item u-no-margin--bottom">
-        <a href="{{ website }}"><i class="p-icon--share"></i>&nbsp;&nbsp;Homepage</a>
+        <a href="{{ website }}"><i class="p-icon--home"></i>&nbsp;&nbsp;Homepage</a>
       </li>
       <li class="p-list__item">
-        <a href="{{ repository_url }}"><i class="p-icon--user"></i>&nbsp;&nbsp;Repository</a>
+        <a href="{{ repository_url }}"><i class="p-icon--repository"></i>&nbsp;&nbsp;Repository</a>
       </li>
       <li class="p-list__item">
         <!-- TO DO - what if the bugs are submitted to launchpad? -->
-        <a href="{{ repository_url }}/issues/new"><i class="p-icon--search"></i>&nbsp;&nbsp;Submit a bug</a>
+        <a href="{{ repository_url }}/issues/new"><i class="p-icon--bug"></i>&nbsp;&nbsp;Submit a bug</a>
       </li>
       <li class="p-list__item">
-        <a href="{{ contact }}"><i class="p-icon--code"></i>&nbsp;&nbsp;Contact</a>
+        <a href="{{ contact }}"><i class="p-icon--contact"></i>&nbsp;&nbsp;Contact</a>
       </li>
     </ul>
     <hr class="p-separator--shallow">
-    <h4 class="p-muted-heading">Share this {{ package_type }}</h4>
+    <h4 class="p-heading--5 u-no-margin--bottom">Share this {{ package_type }}</h4>
     <p>Generate an embeddable card to be shared on external websites.</p>
     <!-- TO DO - Needs an embed this charm overlay implemented -->
-    <p><a class="p-button--neutral" href="">Share this {{ package_type }}</a></p>
+    <p><a class="p-button--neutral" href="#">Share this {{ package_type }}</a></p>
   </div>
   <div class="col-9">
     <noscript>


### PR DESCRIPTION
## Done

- Fix charms overview tab icons and style

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/wordpress
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [design](https://app.zeplin.io/project/5d3f1850b938ee0dc24c60c4/screen/5f3256356f36794fd09ca340)


![image](https://user-images.githubusercontent.com/40214246/91996096-842d5d00-ed30-11ea-9f90-546aacad49ed.png)

