### PR TITLE
Publisher: Show publisher email in Account details

### DIFF
--- a/templates/publisher/account-details.html
+++ b/templates/publisher/account-details.html
@@ -29,5 +29,16 @@
       </p>
     </div>
   </div>
+  <div class="row">
+    <div class="col-2">
+    Email address:
+    </div>
+    <div class="col-6">
+      <p class="u-no-padding--top"><strong>{{ publisher["email"] }}</strong></p>
+      <p class="p-form-help-text">
+      Your email address will not be shared publicly.
+      </p>
+    </div>
+  </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Done

- Added publisher email in Account details

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Logged as a publisher check http://localhost:8045/account/details

## Screenshots

![image](https://user-images.githubusercontent.com/6353928/92142238-6d0f6d80-ee0b-11ea-9e08-b4d353524858.png)

