### PR TITLE
Add /about/publishing page

### DIFF
--- a/templates/about/publishing.html
+++ b/templates/about/publishing.html
@@ -1,10 +1,45 @@
 {% extends 'about/about_layout.html' %}
 
-<!-- TO DO - add copy doc and description -->
-{% block meta_copydoc %}{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1tUoM9lA5GaJ7gsT-qfbwD-bpSfsTkYOk0MV9hDPIagM{% endblock meta_copydoc %}
 
-{% block meta_description %}{% endblock %}
+{% block meta_description %}Registration, visibility, channels and revisions{% endblock %}
 
 {% block about_content %}
-<h2>Publishing page</h2>
+  <h2>Operator Publication</h2>
+  <h4>Registration and visibility</h4>
+  <h5>Operator names</h5>
+  <p>Register a name for an operator with the <code>charmcraft register</code> command. Some names may be reserved or registered already, just ask on the community forum if you think a reserved name should be used for your operator.</p>
+  <p>When you register a name, bear in mind the &lsquo;principle of least surprise&rsquo; which is that you may not use a well&dash;known name unless you intend to publish your operator for anybody to use to drive that well&dash;known workload. A common convention if you are not sure is to prefix your own name to the application name, for example &lsquo;frblix&dash;wmdmon&rsquo;; we can rename your operator to drop the suffix once there is consensus it should be the main operator for that well&dash;known name.</p>
+  <h5>Private operators</h5>
+  <p>Anybody may use this site to host their own private operators. There are no special requirements or restrictions for private operators, other than the expectation that usage of the site is in line with the goals of the community.</p>
+  <p>Private operators live in the same namespace as public operators and their names may not conflict. To store a private operator here, just register the name.</p>
+  <p>A private operator will not show up in listings or on web pages, and can only be retrieved by its publisher and contributors. So a single developer, or a group of developers, can push/release/deploy/update that charm for their own purposes, but it is private to them.</p>
+  <h5>Public operators</h5>
+  <p>Public operators can be retrieved by anybody. Their list of channels and released revisions is visible to everybody. The designated maintainer&rsquo;s name and contact information are visible and they should be accountable for the operator and responsive to bug reports and pull requests.</p>
+  <p>We encourage public operator maintainers to release beta and release candidate revisions into the appropriate channels, and to maintain separate tracks for major and minor releases, but not point releases, following semantic versioning where possible.</p>
+  <h4>Channels</h4>
+  <p>Operators are published in channels with a fixed naming convention: track, stability, and branch. Examples might include:</p>
+  <ul class="p-list">
+    <li class="p-list__item"><code>1.2/stable/hotfix-342443</code></li>
+    <li class="p-list__item"><code>2.9/beta</code></li>
+    <li class="p-list__item"><code>3.0/rc</code></li>
+    <li class="p-list__item"><code>latest/stable</code></li>
+    <li class="p-list__item"><code>lates</code></li>
+  </ul>
+  <p>In general channel looks like this:</p>
+  <ul class="p-list">
+    <li class="p-list__item"><code>track/stability/branch</code></li>
+  </ul>
+  <p>A given deployment remembers the channel name, and updates will come from the same channel. So if you deploy from the release candidate channel, and then do an update, you can expect to get the latest release candidate if one is available.</p>
+  <h5>Tracks</h5>
+  <p>The track represents the version of the operator. In general, track names tend to follow the upstream application version name, or be related to it in an obvious way. We recommend that tracks use major.minor semantic versioning. There is always a &lsquo;latest&rsquo; track, which doesn&rsquo;t have a particular version associated with it. The version you get from the latest track will change based on the preferences of the publisher. Use the latest track to keep up with the flow in cases where you don&rsquo;t necessarily care to hard lock a major version.</p>
+  <p>One track can be designated the default track for that operator, which means that deploying the operator without specifying a track will result in that track being selected (and remembered as if it had been deployed explicitly). The latest track is the default if no default has been specified.</p>
+  <h5>Stability</h5>
+  <p>The four stability options in channel names are <code>stable</code>, <code>rc</code>, <code>beta</code> and <code>edge</code>. It is good practice for the publisher to keep these populated whenever they have code that reasonably conforms to expectations of those levels of stability. The edge stability should be auto&dash;updated with daily builds after CI tests have passed, so that it reflects current development whenever tests are passing. Beta and RC channels are a way for users to test pre&dash;release versions of operators; these channels should be populated when such versions exist, and closed otherwise.</p>
+  <p>When an edge, beta or RC channel is closed, the operator will be drawn from the next&dash;more&dash;stable channel. If you have deployed a beta version, and there is currently no beta but there is an RC, then you will get the RC. If there is currently no RC, you will get the stable channel. You will never get a less-stable channel, only a more&dash;stable channel.</p>
+  <p>If no stability is specified then the stable channel is assumed. So deploying &lsquo;1.2&rsquo; will in effect deploy &lsquo;1.2/stable&rsquo;.</p>
+  <h5>Branches</h5>
+  <p>Most deployments will not use a branch name; branches are optional and are typically only used during development to enable feature branch testing, and in production for the distribution of very specific hotfixes that are not yet ready to be rolled out universally.</p>
+  <h4>Revisions</h4>
+  <p>When the publisher pushes a new version of an operator, a Docker image to be used with the operator, or another resource (such as a data set or trained machine learning model), a revision is assigned for that asset. The publisher can push new assets at any time and get new revisions, but those revisions are not considered released until the publisher makes an explicit decision to release them into a particular channel with the <code>charmcraft release</code> command. Publishers can test revisions before they decide to release them for wider consumption in a stable, rc, beta or edge channel.</p>
 {% endblock %}


### PR DESCRIPTION
## Done

- Add /about/publishing page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [copy](https://docs.google.com/document/d/1tUoM9lA5GaJ7gsT-qfbwD-bpSfsTkYOk0MV9hDPIagM/edit#)


## Issue / Card

Fixes #181 

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/92719917-c6bbee80-f35b-11ea-96bc-4c860a79c293.png)

