### PR TITLE
Fix sort drop-down width in FF

### DIFF
--- a/static/sass/_charmhub_p-store.scss
+++ b/static/sass/_charmhub_p-store.scss
@@ -40,8 +40,8 @@
     }
 
     .p-form__control {
-      min-width: 7rem;
-      width: 7rem;
+      min-width: 8rem;
+      width: 8rem;
     }
   }
 


### PR DESCRIPTION
## Done

- Fix sort drop-down width in FF

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/store
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Open the page in FF and see that all the sorting text is visible

## Issue / Card

Fixes #

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/92905684-c97e1880-f41b-11ea-8c0c-025297dd90f8.png)

