### PR TITLE
Add /topics/kubernetes template page

### DIFF
--- a/static/sass/_pattern_grid.scss
+++ b/static/sass/_pattern_grid.scss
@@ -1,4 +1,8 @@
 @mixin p-charmhub-grid {
+  .row {
+    grid-gap: 2rem;
+  }
+
   .col-x-small-1 {
     @media (max-width: 450px) {
       grid-column-end: span 4;

--- a/static/sass/_pattern_p-image.scss
+++ b/static/sass/_pattern_p-image.scss
@@ -5,4 +5,8 @@
       margin-bottom: 2rem;
     }
   }
+
+  .p-image--full-width {
+    width: 100%;
+  }
 }

--- a/static/sass/_pattern_p-separator.scss
+++ b/static/sass/_pattern_p-separator.scss
@@ -3,4 +3,9 @@
     margin-block-end: 1.5rem;
     margin-block-start: 1.5rem;
   }
+
+  .p-separator--deep {
+    margin-block-end: 4rem;
+    margin-block-start: 4rem;
+  }
 }

--- a/static/sass/_pattern_p-strip.scss
+++ b/static/sass/_pattern_p-strip.scss
@@ -224,6 +224,21 @@
 }
 
 @mixin charmhub-p-strip {
+  .p-strip--overlap {
+    @extend %vf-strip;
+
+    padding-block-end: 9rem;
+
+    & + .p-strip--overlap {
+      margin-block-start: -11rem;
+      padding-block-end: 4rem;
+    }
+
+    @media screen and (min-width: $breakpoint-large) {
+      padding-block-end: 7rem;
+    }
+  }
+
   .p-strip--charmhub {
     @extend %vf-strip;
 
@@ -254,6 +269,33 @@
         color: $color-x-light;
         text-decoration: underline;
       }
+    }
+  }
+
+  .p-strip-topic--kubernetes {
+    @extend %vf-strip;
+
+    background-image:
+      linear-gradient(
+        to bottom right,
+        rgba(255, 255, 255, 0.1) 0,
+        rgba(255, 255, 255, 0.1) 49.9%,
+        transparent 50%
+      ),
+      linear-gradient(
+        to top right,
+        rgba(255, 255, 255, 0.1) 0,
+        rgba(255, 255, 255, 0.1) 49.9%,
+        transparent 50%
+      ),
+      linear-gradient(110deg, #014bd1 45%, #4279f4 91%);
+    background-position: top left, bottom left, 0% 0%;
+    background-repeat: no-repeat;
+    background-size: 75% 85%, 15% 100%, auto;
+    color: $color-x-light;
+
+    @media screen and (max-width: $breakpoint-medium) {
+      background-size: 75% 85%, 35% 100%, auto;
     }
   }
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -53,6 +53,7 @@ $theme-default-nav: dark;
 @include vf-u-margin-collapse;
 @include vf-u-padding-collapse;
 @include vf-u-vertically-center;
+@include vf-u-vertical-spacing;
 
 // Import site specific patterns and overrides
 @import "pattern_p-card";

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -3,37 +3,33 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="/">
-          <img class="p-navigation__image"
-            src="https://assets.ubuntu.com/v1/7da29260-Charm+hub_white-orange_hex.svg" width="175" height="31"
-            alt="Charm Hub" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/7da29260-Charm+hub_white-orange_hex.svg" width="175" height="31" alt="Charm Hub" />
         </a>
       </div>
-      <a href="#navigation" class="p-navigation__toggle--open"
-        title="menu">Menu</a>
-      <a href="#navigation-closed" class="p-navigation__toggle--close"
-        title="close menu">Close menu</a>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav">
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>
       </span>
-      <!-- TO DO - update navigation -->
       <ul class="p-navigation__items" role="menu">
         <li class="p-navigation__item {% if request.path == '/store' %}is-selected{% endif %}" role="menuitem">
           <a href="/store" class="p-navigation__link">
             Store
           </a>
         </li>
-        <li
-          class="p-navigation__item {% if request.path == '/docs' %}is-selected{% endif %}"
-          role="menuitem">
+        <li class="p-navigation__item {% if request.path.startswith('/about') %}is-selected{% endif %}" role="menuitem">
+          <a href="/about" class="p-navigation__link">
+            About
+          </a>
+        </li>
+        <li class="p-navigation__item {% if request.path == '/docs' %}is-selected{% endif %}" role="menuitem">
           <a href="/docs" class="p-navigation__link">
             Docs
           </a>
         </li>
-        <li
-          class="p-navigation__item {% if request.path == '/tutorials' %}is-selected{% endif %}"
-          role="menuitem">
+        <li class="p-navigation__item {% if request.path == '/tutorials' %}is-selected{% endif %}" role="menuitem">
           <a href="/tutorials" class="p-navigation__link">
             Tutorials
           </a>
@@ -43,16 +39,9 @@
             Discourse
           </a>
         </li>
-        <li
-          class="p-navigation__item {% if request.path.startswith('/about') %}is-selected{% endif %}"
-          role="menuitem">
-          <a href="/about" class="p-navigation__link">
-            About
-          </a>
-        </li>
       </ul>
       <ul class="p-navigation__items" role="menu">
-      {% if publisher %}
+        {% if publisher %}
         <li class="p-navigation__item p-subnav" role="menuitem" id="link-1">
           <a class="p-subnav__toggle p-navigation__link" aria-controls="account-menu">
             {{ publisher["display-name"] }}
@@ -69,11 +58,11 @@
             </li>
           </ul>
         </li>
-      {% else %}
+        {% else %}
         <li class="p-navigation__item" role="menuitem">
           <a href="/publisher/login" class="p-navigation__link"><i class="p-icon--user"></i> Login</a>
         </li>
-      {% endif %}
+        {% endif %}
       </ul>
     </nav>
   </div>

--- a/templates/topics/kubernetes.html
+++ b/templates/topics/kubernetes.html
@@ -1,0 +1,315 @@
+{% extends 'base_layout.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1YfwpLVaS-VybYAhrb9JIsj8pKiLYRhezvr-p9qWN4rw{% endblock meta_copydoc %}
+
+{% block meta_description %}The Open Operator Collection{% endblock %}
+
+{% block content %}
+<section class="p-strip--overlap p-strip-topic--kubernetes">
+  <div class="u-fixed-width">
+    <h1 class="p-muted-heading" style="color: #fff; font-weight: 300;">Charmed Kubernetes</h1>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <h2 class="p-heading--1">Architectural freedom.<br>Fully automated operations.<br>Extensible Kubernetes for all.</h2>
+      <p>The easiest way to automate the deployment, scaling, lifecycle and management of your applications. Operate the latest Kubernetes, from the experts behind Ubuntu and the Kubernetes community.</p>
+      <h3 class="p-heading--4">Our Kubernetes operator collection</h3>
+    </div>
+    <div class="col-4 u-align--center u-hide--medium u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/331f3baf-kubernetes-logo.svg" alt="" width="165" height="163">
+    </div>
+  </div>
+</section>
+<section class="p-strip--overlap">
+  <div class="row">
+    <div class="col-x-small-1 col-small-2 col-medium-3 col-3 u-equal-height">
+      <a href="/wordpress" class="p-card--button">
+        <div class="p-card__header">
+          <div>
+            <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
+          </div>
+          <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
+          <p class="u-text--subtle">postgresql-charmers</p>
+        </div>
+        <div class="p-card__content">
+          <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>
+        </div>
+        <div class="p-card__footer">
+          <div class="p-item--left">Databases</div>
+          <div class="p-item--right"><i class="p-icon--revisions"></i>12 days ago</div>
+        </div>
+      </a>
+    </div>
+    <div class="col-x-small-1 col-small-2 col-medium-3 col-3 u-equal-height">
+      <a href="/wordpress" class="p-card--button">
+        <div class="p-card__header">
+          <div>
+            <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
+          </div>
+          <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
+          <p class="u-text--subtle">postgresql-charmers</p>
+        </div>
+        <div class="p-card__content">
+          <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>
+        </div>
+        <div class="p-card__footer">
+          <div class="p-item--left">Databases</div>
+          <div class="p-item--right"><i class="p-icon--revisions"></i>12 days ago</div>
+        </div>
+      </a>
+    </div>
+    <div class="col-x-small-1 col-small-2 col-medium-3 col-3 u-equal-height">
+      <a href="/wordpress" class="p-card--button">
+        <div class="p-card__header">
+          <div>
+            <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
+          </div>
+          <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
+          <p class="u-text--subtle">postgresql-charmers</p>
+        </div>
+        <div class="p-card__content">
+          <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>
+        </div>
+        <div class="p-card__footer">
+          <div class="p-item--left">Databases</div>
+          <div class="p-item--right"><i class="p-icon--revisions"></i>12 days ago</div>
+        </div>
+      </a>
+    </div>
+    <div class="col-x-small-1 col-small-2 col-medium-3 col-3 u-equal-height">
+      <a href="/wordpress" class="p-card--button">
+        <div class="p-card__header">
+          <div>
+            <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
+          </div>
+          <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
+          <p class="u-text--subtle">postgresql-charmers</p>
+        </div>
+        <div class="p-card__content">
+          <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>
+        </div>
+        <div class="p-card__footer">
+          <div class="p-item--left">Databases</div>
+          <div class="p-item--right"><i class="p-icon--revisions"></i>12 days ago</div>
+        </div>
+      </a>
+    </div>
+  </div>
+</section>
+<div class="u-fixed-width">
+  <hr>
+</div>
+<section class="p-strip">
+  <div class="row">
+    <div class="col-4">
+      <img src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" style="max-width: 2.5rem;" alt="">
+      <h4>Pure upstream</h4>
+      <p>Charmed Kubernetes is a well integrated, turn-key, conformant Kubernetes platform,optimised for your multi-cloud environments.</p>
+      <p>Get started now and take advantage of our rapidly growing automation tooling ecosystem that is consistent across all infrastructures. Charmed Kubernetes provides users with a standardised workflow to develop, test and promote their cloud native apps up to production environments.</p>
+    </div>
+    <div class="col-4">
+      <img src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" style="max-width: 2.5rem;" alt="">
+      <h4>Automated Kubernetes updates</h4>
+      <p>Developers demand the latest features as Kubernetes evolves rapidly in the open source community. On Bare-Metal, VMs or as a service - Charmed Kubernetes will keep your cluster up to date.</p>
+      <p>Using snaps, point releases of Kubernetes are automatically installed. And whenever there is a new major version, Juju charms make upgrading easy.</p>
+    </div>
+    <div class="col-4">
+      <img src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" style="max-width: 2.5rem;" alt="">
+      <h4>Managed Kubernetes</h4>
+      <p>Predictable OpEx for organisations looking to adopt production-ready Kubernetes. Focus on your business while we take care of your Kubernetes cluster.</p>
+      <p>Canonical provides managed services for Kubernetes on-premises or on public clouds.</p>
+    </div>
+  </div>
+  <div class="p-strip u-no-padding--bottom">
+    <div class="u-fixed-width">
+      <h2>Portable, validated, scalable</h2>
+    </div>
+    <div class="row">
+      <div class="col-6">
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Contains all the operational tooling needed to manage a production cluster — including upgrades and elastic scaling</li>
+          <li class="p-list__item is-ticked">Upgrade, pause and resume, snapshot and restore your nodes</li>
+          <li class="p-list__item is-ticked">Extensible and self-healing system</li>
+        </ul>
+      </div>
+      <div class="col-6">
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Tested on a wide range of infrastructures so you can avoid cloud lock-in and federate workloads between clouds or on-premise</li>
+          <li class="p-list__item is-ticked">Optimised portability across all environments</li>
+          <li class="p-list__item is-ticked">100% validated against the Kubernetes Conformance Tests</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2 class="u-sv3">Get started with charmed Kubernetes</h2>
+    <ol class="p-stepped-list">
+      <li class="p-stepped-list__item">
+        <h4 class="p-stepped-list__title">Pick your cluster from production-grade blueprints</h4>
+        <div class="row u-no-padding--left u-no-padding--right">
+          <div class="col-6">
+            <img class="p-image--bordered p-image--full-width" src="https://assets.ubuntu.com/v1/584903f3-iot-drone.png" alt="">
+            <p class="p-heading--4 u-no-margin--bottom"><a href="/">Staging cluster</a></p>
+            <p class="p-stepped-list__content">Start with a Kubernetes cluster of two machines — one master node and one worker node.</p>
+          </div>
+          <div class="col-6">
+            <img class="p-image--bordered p-image--full-width" src="https://assets.ubuntu.com/v1/584903f3-iot-drone.png" alt="">
+            <p class="p-heading--4 u-no-margin--bottom"><a href="/">Production cluster</a></p>
+            <p class="p-stepped-list__content">Progress to a highly available Kubernetes cluster — 2 masters, 3 workers, 3 etc nodes and API load balancer.</p>
+          </div>
+        </div>
+
+      </li>
+
+      <li class="p-stepped-list__item">
+        <h4 class="p-stepped-list__title">Add extra components</h4>
+        <div class="row u-no-padding--left u-no-padding--right">
+          <div class="col-x-small-1 col-small-2 col-medium-3 col-3 u-equal-height">
+            <a href="/wordpress" class="p-card--button">
+              <div class="p-card__header">
+                <div>
+                  <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
+                </div>
+                <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
+                <p class="u-text--subtle">postgresql-charmers</p>
+              </div>
+              <div class="p-card__content">
+                <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>
+              </div>
+              <div class="p-card__footer">
+                <div class="p-item--left">Databases</div>
+                <div class="p-item--right"><i class="p-icon--revisions"></i>12 days ago</div>
+              </div>
+            </a>
+          </div>
+          <div class="col-x-small-1 col-small-2 col-medium-3 col-3 u-equal-height">
+            <a href="/wordpress" class="p-card--button">
+              <div class="p-card__header">
+                <div>
+                  <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
+                </div>
+                <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
+                <p class="u-text--subtle">postgresql-charmers</p>
+              </div>
+              <div class="p-card__content">
+                <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>
+              </div>
+              <div class="p-card__footer">
+                <div class="p-item--left">Databases</div>
+                <div class="p-item--right"><i class="p-icon--revisions"></i>12 days ago</div>
+              </div>
+            </a>
+          </div>
+          <div class="col-x-small-1 col-small-2 col-medium-3 col-3 u-equal-height">
+            <a href="/wordpress" class="p-card--button">
+              <div class="p-card__header">
+                <div>
+                  <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
+                </div>
+                <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
+                <p class="u-text--subtle">postgresql-charmers</p>
+              </div>
+              <div class="p-card__content">
+                <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>
+              </div>
+              <div class="p-card__footer">
+                <div class="p-item--left">Databases</div>
+                <div class="p-item--right"><i class="p-icon--revisions"></i>12 days ago</div>
+              </div>
+            </a>
+          </div>
+          <div class="col-x-small-1 col-small-2 col-medium-3 col-3 u-equal-height">
+            <a href="/wordpress" class="p-card--button">
+              <div class="p-card__header">
+                <div>
+                  <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
+                </div>
+                <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
+                <p class="u-text--subtle">postgresql-charmers</p>
+              </div>
+              <div class="p-card__content">
+                <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>
+              </div>
+              <div class="p-card__footer">
+                <div class="p-item--left">Databases</div>
+                <div class="p-item--right"><i class="p-icon--revisions"></i>12 days ago</div>
+              </div>
+            </a>
+          </div>
+        </div>
+        <a href="/" class="p-button--neutral" style="margin-block-start: 2rem;">Browse more Kubernetes charms</a>
+      </li>
+
+      <li class="p-stepped-list__item">
+        <h4 class="p-stepped-list__title">
+          Put your cluster to work
+        </h4>
+        <div class="row u-no-padding--left u-no-padding--right">
+          <div class="col-4">
+            <p class="p-heading--4">
+              <a href="/">The easy way to commoditise GPUs for Kubernetes</a>
+            </p>
+            <p>Setting up your Deep Learning framework is now easier than ever with the new GPU integration of the Charmed Distribution of Kubernetes*. Perfect for production grade, on bare metal or in the cloud.</p>
+          </div>
+          <div class="col-4">
+            <p class="p-heading--4">
+              <a href="/">Build a transcoding platform
+                in minutes</a>
+            </p>
+            <p>The Charmed Distribution of Kubernetes enables automatic discovery of GPU devices. Work as well with LXD to get a fine grain control mechanism to orchestrate video workflows and maximise the throughput of your clusters.</p>
+          </div>
+          <div class="col-4">
+            <p class="p-heading--4">
+              <a href="/">Transform your solution into a private PaaS</a>
+            </p>
+            <p>Kubernetes can be complemented by another layer to transform it into a PaaS, to maximise the proficiency of the development teams. It will provide complete freedom to deploy and manage your applications.</p>
+          </div>
+        </div>
+      </li>
+    </ol>
+  </div>
+</section>
+<section class="p-strip u-extra-space">
+  <div class="u-fixed-width">
+    <h2>Charmed Kubernetes fits perfectly on top of OpenStack, VMware, and bare metal</h2>
+    <p>There’s no doubt that Kubernetes is the new standard operational layer for every multi-cloud business. Canonical enables K8s on demand for your DevOps teams — on OpenStack, VMware, public clouds, and bare metal clusters with MAAS.</p>
+    <p>With Charmed Kubernetes, you can deliver ‘Containers as a Service’ across the enterprise, to enable each project to spin up a standardised K8s environment of arbitrary scale, on demand, with centralised operational control.</p>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator--deep">
+  </div>
+  <div class="u-fixed-width">
+    <h2>Networking</h2>
+    <p>Kubernetes imposes fundamental requirements on your networking implementation including:</p>
+    <ul class="p-list">
+      <li class="p-list__item is-ticked">All containers have to communicate with all other containers without NAT</li>
+      <li class="p-list__item is-ticked">All nodes have to communicate with all containers (and vice-versa) without NAT</li>
+      <li class="p-list__item is-ticked">The IP that a container sees itself as needs to be the same IP that others see it as</li>
+    </ul>
+    <p>Kubernetes uses Container Network Interface (CNI) as an interface between network providers and Kubernetes networking. CNI is a library definition and a set of tools, under the umbrella of the Cloud Native Computing Foundation project.</p>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator--deep">
+  </div>
+  <div class="u-fixed-width">
+    <h2>Storage</h2>
+    <p>Kubernetes comes with a powerful volume plugin system that enables many different types of storage systems to:</p>
+    <ul class="p-list">
+      <li class="p-list__item is-ticked">Automatically create storage when required</li>
+      <li class="p-list__item is-ticked">Make storage available to containers wherever they’re scheduled</li>
+      <li class="p-list__item is-ticked">Automatically delete the storage when no longer needed</li>
+    </ul>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator--deep">
+  </div>
+  <div class="u-fixed-width">
+    <h2>Logging and monitoring</h2>
+    <p>Kubernetes comes with a powerful volume plugin system that enables many different types of storage systems to:</p>
+    <p>Operations in highly coherent large-scale distributed clusters require a new level of operational monitoring and observability. Charmed Kubernetes provides a standardised set of open source log aggregation and systems monitoring dashboards with every cloud, using Prometheus, the Elasticsearch and Kibana stack (ELK), and Nagios.</p>
+  </div>
+</section>
+{% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -57,6 +57,11 @@ def index():
     return response
 
 
+@app.route("/topics/kubernetes")
+def kubernetes():
+    return render_template("topics/kubernetes.html")
+
+
 @app.route("/about")
 def about():
     return render_template("about/index.html")


### PR DESCRIPTION
## Done

- Add /topics/kubernetes template page
- Move `About` in the navigation to be after `Store` to be consistent with snapcraft.io

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/topics/kubernetes
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [design](https://app.zeplin.io/project/5d3f1850b938ee0dc24c60c4/screen/5f57b10f2a182b1a0650e8de) and [copy](https://docs.google.com/document/d/1YfwpLVaS-VybYAhrb9JIsj8pKiLYRhezvr-p9qWN4rw/edit) - _note the copy is not final_
- See how it looks on small screens


## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1623

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/93185071-e58ffb80-f734-11ea-9717-6f2a8d25b794.png)

