### PR TITLE
Changes for new API response

### DIFF
--- a/templates/details.html
+++ b/templates/details.html
@@ -9,7 +9,7 @@
       <div class="p-charm-header">
         <div class="p-media-object--medium u-no-margin--bottom">
           <div class="{% if package_type == "bundle" %}p-bundle-icons{% endif %}">
-            {% for media in package.charm.media %}
+            {% for media in package.result.media %}
             {% if media.type == "icon" %}
             <img src="{{ media.url }}" class="{% if package_type == "bundle"%}p-bundle-icons__image{% else %}p-media-object__image{% endif %}" alt="" />
             {% endif %}

--- a/templates/partial/_tab-overview.html
+++ b/templates/partial/_tab-overview.html
@@ -2,7 +2,7 @@
   <div class="col-3">
     <p><strong>Latest release</strong><br />{{ package.store_front.last_release }}</p>
     <p><strong>Deployments</strong><br /></p>
-    <p><strong>License</strong><br />{{ package.charm.license }}</p>
+    <p><strong>License</strong><br />{{ package.result.license }}</p>
     <hr class="p-separator--shallow">
     <h4 class="p-heading--5 u-no-margin--bottom">Relevant links</h4>
     <ul class="p-list">

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -72,7 +72,7 @@ def convert_date(date_to_convert):
 
 
 def get_icons(package):
-    media = package["charm"]["media"]
+    media = package["result"]["media"]
     return [m["url"] for m in media if m["type"] == "icon"]
 
 
@@ -109,12 +109,12 @@ def get_categories(categories_json):
 def add_store_front_data(package):
     extra = {}
     extra["icons"] = get_icons(package)
-    extra["categories"] = get_categories(package["charm"]["categories"])
-    extra["publisher_name"] = package["charm"]["publisher"]["display-name"]
+    extra["categories"] = get_categories(package["result"]["categories"])
+    extra["publisher_name"] = package["result"]["publisher"]["display-name"]
     extra["last_release"] = convert_date(
         package["default-release"]["channel"]["released-at"]
     )
-    extra["summary"] = package["charm"]["summary"]
+    extra["summary"] = package["result"]["summary"]
     if package.get("channel-map"):
         extra["channel_map"] = convert_channel_maps(package["channel-map"])
     package["store_front"] = extra


### PR DESCRIPTION
## Done

- The API response has changed. Replace `charm` key with `result`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
