### PR TITLE
Remove link to charm listing page from /charms

### DIFF
--- a/templates/publisher/charms.html
+++ b/templates/publisher/charms.html
@@ -24,14 +24,14 @@
           {% for published_charm in published %}
           <tr role="row">
             <td role="rowheader" class="p-table--mobile-card__header">
-              <a href="/spark/listing" class="p-heading-icon--x-small">
+              <div class="p-heading-icon--x-small">
                 <span class="p-heading-icon__header">
                   <img src="https://dashboard.snapcraft.io/site_media/appmedia/2020/04/products-hero-ubuntu.svg.png" width="24" height="24" class="p-heading-icon__img">
                   <p class="u-no-margin--bottom u-no-padding--top">
                     {{ published_charm.name }}
                   </p>
                 </span>
-              </a>
+              </div>
             </td>
             <td role="gridcell" aria-label="visibility">
               {% if published_charm.private %}


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
