### PR TITLE
Use new discourse module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+canonicalwebteam.discourse==2.0.1
 canonicalwebteam.flask-base==0.6.3
-canonicalwebteam.discourse-docs==1.0.1
 canonicalwebteam.search==0.2.1
 canonicalwebteam.store-api==2.3.6
 django-openid-auth==0.16

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -1,11 +1,5 @@
 import talisker
-
-from canonicalwebteam.discourse_docs import (
-    DiscourseAPI,
-    DiscourseDocs,
-    DocParser,
-)
-
+from canonicalwebteam.discourse import DiscourseAPI, DocParser, Docs
 from canonicalwebteam.search import build_search_view
 
 
@@ -13,7 +7,7 @@ def init_docs(app, url_prefix):
     discourse_index_id = 3394
 
     session = talisker.requests.get_session()
-    discourse_docs = DiscourseDocs(
+    discourse_docs = Docs(
         parser=DocParser(
             api=DiscourseAPI(
                 base_url="https://discourse.juju.is/", session=session

--- a/webapp/tutorials/views.py
+++ b/webapp/tutorials/views.py
@@ -1,12 +1,8 @@
-import flask
 import math
-import talisker
 
-from canonicalwebteam.discourse_docs import (
-    DiscourseAPI,
-    DiscourseDocs,
-    DocParser,
-)
+import flask
+import talisker
+from canonicalwebteam.discourse import DiscourseAPI, DocParser, Docs
 
 
 def init_tutorials(app, url_prefix):
@@ -14,7 +10,7 @@ def init_tutorials(app, url_prefix):
     category_id = 30
 
     session = talisker.requests.get_session()
-    tutorials_docs = DiscourseDocs(
+    tutorials_docs = Docs(
         parser=DocParser(
             api=DiscourseAPI(
                 base_url="https://discourse.juju.is/", session=session


### PR DESCRIPTION
## Done

- Replace `canonicalwebteam.discourse_docs` with newer module `canonicalwebteam.discourse`.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check /docs and /tutorials are working as expected


## Issue / Card

Fixes #280 
