### PR TITLE
Add link to edit docs to charm details docs

### DIFF
--- a/templates/details/docs.html
+++ b/templates/details/docs.html
@@ -24,6 +24,13 @@
         </div>
         <div class="col-9">
           {{ body_html | safe }}
+          <div class="u-fixed-width">
+            <div class="p-notification--information">
+              <p class="p-notification__response">
+                Last updated {{ last_update }}. <a href="{{ topic_url }}">Help improve this document in the forum</a>.
+              </p>
+            </div>
+          </div>
         </div>
       </div>
     {% else %}

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -9,7 +9,10 @@ from webapp.store import logic
 from webapp.store.data import wordpress_charm
 
 store = Blueprint(
-    "store", __name__, template_folder="/templates", static_folder="/static",
+    "store",
+    __name__,
+    template_folder="/templates",
+    static_folder="/static",
 )
 
 
@@ -83,6 +86,8 @@ def details_docs(entity_name, slug=None):
     docs.parse()
     body_html = docs.index_document["body_html"]
 
+    topic_url = f'{docs.api.base_url}{docs.index_document["topic_path"]}'
+
     if slug:
         topic_id = docs.resolve_path(slug)
         # topic = docs.api.get_topic(topic_id)
@@ -94,11 +99,16 @@ def details_docs(entity_name, slug=None):
         )
         slug_docs.parse()
         body_html = slug_docs.index_document["body_html"]
+        topic_url = (
+            f'{docs.api.base_url}{slug_docs.index_document["topic_path"]}'
+        )
 
     context = {
         "package": package,
         "navigation": docs.navigation,
         "body_html": body_html,
+        "last_update": docs.index_document["updated"],
+        "topic_url": topic_url,
     }
 
     return render_template("details/docs.html", **context)


### PR DESCRIPTION
## Done

- Add link to edit docs to charm details docs

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/wordpress/docs
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See there are links at the bottom of the page to discourse


## Issue / Card

Fixes #

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/93590064-c8159880-f9a5-11ea-8ec8-26c02254b21d.png)

