### PR TITLE
Add debug mode and requests logs

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,7 @@
 PORT=8045
+ENVIRONMENT=devel
 FLASK_DEBUG=true
+DEVEL=True
 SECRET_KEY=local_development_fake_key
 
 # Temporal to use staging APIs

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,16 +1,16 @@
+import talisker.requests
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.store_api.stores.charmstore import CharmStore
 from flask import make_response, redirect, render_template, request, session
 
 from webapp import authentication, config
+from webapp.docs.views import init_docs
+from webapp.extensions import csrf
 from webapp.handlers import set_handlers
 from webapp.login.views import login
-from webapp.store.views import store
-from webapp.docs.views import init_docs
-from webapp.tutorials.views import init_tutorials
 from webapp.publisher.views import publisher
-from webapp.extensions import csrf
-
+from webapp.store.views import store
+from webapp.tutorials.views import init_tutorials
 
 app = FlaskBase(
     __name__,
@@ -20,7 +20,7 @@ app = FlaskBase(
     template_404="404.html",
     template_500="500.html",
 )
-app.store_api = CharmStore()
+app.store_api = CharmStore(session=talisker.requests.get_session())
 
 set_handlers(app)
 csrf.init_app(app)


### PR DESCRIPTION
## Done

Add debug mode for better reading on terminal
Add logging of requests for better tracking or requests we are making.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/jenkins
- Checkout the terminal how cool it became
- Check that you are getting logs like this one:

```
2020-09-20 20:31:28.406Z INFO talisker.requests "http request" url=https://api.staging.snapcraft.io/v2/charms/info/jenkins? qs=? qs_size=7 method=GET host=api.staging.snapcraft.io status_code=200 view=snapdevicegw.webapi_info_charm.charm_info server=gunicorn/19.7.1 duration_ms=285.793 response_type=application/json response_size=59391 service=charmhub.io request_id=da91bbc9-0cf3-4aa8-bda7-2057335edd8d
```