### PR TITLE
Add conditionals to overview page

### DIFF
--- a/templates/details/overview.html
+++ b/templates/details/overview.html
@@ -6,29 +6,36 @@
   <div class="row p-tabs__content" id="overview">
     <div class="col-3">
       <p><strong>Latest release</strong><br />{{ package.store_front.last_release }}</p>
-      <p><strong>Deployments</strong><br /></p>
       <p><strong>License</strong><br />{{ package.result.license }}</p>
-      <hr class="p-separator--shallow">
-      <h4 class="p-heading--5 u-no-margin--bottom">Relevant links</h4>
-      <ul class="p-list">
-        <li class="p-list__item u-no-margin--bottom">
-          <a href="{{ website }}"><i class="p-icon--home"></i>&nbsp;&nbsp;Homepage</a>
-        </li>
-        <li class="p-list__item">
-          <a href="{{ repository_url }}"><i class="p-icon--repository"></i>&nbsp;&nbsp;Repository</a>
-        </li>
-        <li class="p-list__item">
-          <!-- TO DO - what if the bugs are submitted to launchpad? -->
-          <a href="{{ repository_url }}/issues/new"><i class="p-icon--bug"></i>&nbsp;&nbsp;Submit a bug</a>
-        </li>
-        <li class="p-list__item">
-          <a href="{{ contact }}"><i class="p-icon--contact"></i>&nbsp;&nbsp;Contact</a>
-        </li>
-      </ul>
+      {% if package.result.website or package.result.repository or package.result.contact %}
+        <hr class="p-separator--shallow">
+        <h4 class="p-heading--5 u-no-margin--bottom">Relevant links</h4>
+        <ul class="p-list">
+        {% if package.result.website %}
+          <li class="p-list__item u-no-margin--bottom">
+            <a href="{{ package.result.website }}"><i class="p-icon--home"></i>&nbsp;&nbsp;Homepage</a>
+          </li>
+        {% endif %}
+        {% if package.result.repository %}
+          <li class="p-list__item">
+            <a href="{{ package.result.repository }}"><i class="p-icon--repository"></i>&nbsp;&nbsp;Repository</a>
+          </li>
+          <li class="p-list__item">
+            <!-- TO DO - what if the bugs are submitted to launchpad? -->
+            <a href="{{ package.result.repository }}/issues/new"><i class="p-icon--bug"></i>&nbsp;&nbsp;Submit a bug</a>
+          </li>
+        {% endif %}
+        {% if package.result.contact %}
+          <li class="p-list__item">
+            <a href="{{ package.result.contact }}"><i class="p-icon--contact"></i>&nbsp;&nbsp;Contact</a>
+          </li>
+        {% endif %}
+        </ul>
+      {% endif %}
       <hr class="p-separator--shallow">
       <h4 class="p-heading--5 u-no-margin--bottom">Discuss this {{ package.type }}</h4>
       <p>Share your thoughts on this charm with the community on discourse.</p>
-      <p><a class="p-button--neutral" href="#">Discuss this {{ package.type }}</a></p>
+      <p><a class="p-button--neutral" href="https://discourse.juju.is/">Discuss this {{ package.type }}</a></p>
     </div>
     <div class="col-9">
       {{ readme | safe }}


### PR DESCRIPTION
## Done

- Add conditionals for website, repository & contact urls to overview page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
