### PR TITLE
Remove details docs tab

### DIFF
--- a/templates/details/_details-tab-navigation.html
+++ b/templates/details/_details-tab-navigation.html
@@ -6,9 +6,6 @@
           <a href="/{{ package.name }}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'overview' %}aria-selected="true" {% endif %}>Overview</a>
         </li>
         <li class="p-tabs__item" role="presentation">
-          <a href="/{{ package.name }}/docs" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'docs' %}aria-selected="true" {% endif %}>Docs</a>
-        </li>
-        <li class="p-tabs__item" role="presentation">
           <a href="/{{ package.name }}/configuration" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'configuration' %}aria-selected="true" {% endif %}>Configuration</a>
         </li>
         <li class="p-tabs__item" role="presentation">

--- a/templates/details/details_layout.html
+++ b/templates/details/details_layout.html
@@ -4,7 +4,7 @@
 
 {% block content %}
   {% include "details/_details-header.html" %}
-  {% include "details/_details-tabs.html" %}
+  {% include "details/_details-tab-navigation.html" %}
 
   <div class="p-strip is-deep u-no-padding--top">
     {% block tab_content %} {% endblock %}


### PR DESCRIPTION
## Done

- Remove details docs tab

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/prometheus
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See there is no `docs` tab


## Issue / Card

Fixes #

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/93758315-1b832300-fc00-11ea-80e5-1167a2b87f97.png)

