### PR TITLE
Update design for configure tab

### DIFF
--- a/static/sass/_pattern_p-list.scss
+++ b/static/sass/_pattern_p-list.scss
@@ -30,6 +30,14 @@
     }
   }
 
+  .p-list--divided.has-sparator-centered {
+    .p-list__item {
+      &:not(:first-of-type) {
+        margin-block-start: $spv-inner--medium;
+      }
+    }
+  }
+
   .p-list--ordered {
     @extend %vf-list;
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -56,6 +56,7 @@ $theme-default-nav: dark;
 @include vf-u-padding-collapse;
 @include vf-u-vertically-center;
 @include vf-u-vertical-spacing;
+@include vf-u-text-muted;
 
 // Import site specific patterns and overrides
 @import "pattern_p-card";

--- a/templates/details/configuration.html
+++ b/templates/details/configuration.html
@@ -24,13 +24,12 @@
       </div>
     </div>
     <div class="col-9">
-      <ul class="p-list--divided">
+      <ul class="p-list--divided has-sparator-centered">
         {% for key, value in package.store_front.config.options.items() %}
         <li class="p-list__item" id="{{ key }}">
-          <p><strong>{{ key }}</strong></p>
-          <p><strong>Type:</strong> {{ value.type }}</p>
+          <p class="p-heading--4"><strong>{{ key }}</strong><span class="u-text--muted"> | {{ value.type }}</span></p>
           {% if value.default %}
-          <p><strong>Default:</strong> {{ value.default }}</p>
+          <p><span class="u-text--muted">Default:</span> {{ value.default }}</p>
           {% endif %}
           <p>{{ value.description | safe }}</p>
         </li>

--- a/templates/details/details_layout.html
+++ b/templates/details/details_layout.html
@@ -15,7 +15,6 @@
 <script src="{{ versioned_static('js/dist/details.js') }}" defer></script>
 <script>
   window.addEventListener("DOMContentLoaded", function () {
-    //charmhub.details.tabs("[data-js='tabs']");
     charmhub.details.init("{{ package.name }}");
   });
 </script>


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/verterok-apache2/configuration
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [design](https://app.zeplin.io/project/5d3f1850b938ee0dc24c60c4/screen/5f60b29fa9ddac7a25318904)


## Issue / Card

Fixes #

![image](https://user-images.githubusercontent.com/40214246/93767372-d9fa7400-fc0f-11ea-87f7-64ab7e6ca29a.png)


[if relevant, include a screenshot]
