### PR TITLE
Remove history navigation

### DIFF
--- a/templates/details/_details-tab-navigation.html
+++ b/templates/details/_details-tab-navigation.html
@@ -8,9 +8,6 @@
         <li class="p-tabs__item" role="presentation">
           <a href="/{{ package.name }}/configuration" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'configuration' %}aria-selected="true" {% endif %}>Configuration</a>
         </li>
-        <li class="p-tabs__item" role="presentation">
-          <a href="/{{ package.name }}/history" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'history' %}aria-selected="true" {% endif %}>History</a>
-        </li>
       </ul>
     </nav>
   </div>


### PR DESCRIPTION
## Done

For now the history tab is 500, hide it in the meantime

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/jenkins
- Tab History is not here anymore