### PR TITLE
Update about links

### DIFF
--- a/templates/about/about_layout.html
+++ b/templates/about/about_layout.html
@@ -44,16 +44,16 @@
               </ul>
             </li>
             <li class="p-side-navigation__item ">
-              <a class="p-side-navigation__link{% if request.path == '/about/manifesto' %} is-active{% endif %}" href="/about/manifesto">Manifesto</a>
+              <a class="p-side-navigation__link{% if request.path == '/manifesto' %} is-active{% endif %}" href="/manifesto">Manifesto</a>
             </li>
             <li class="p-side-navigation__item ">
-              <a class="p-side-navigation__link{% if request.path == '/about/publishing' %} is-active{% endif %}" href="/about/publishing">Publishing</a>
+              <a class="p-side-navigation__link{% if request.path == '/publishing' %} is-active{% endif %}" href="/publishing">Publishing</a>
             </li>
             <li class="p-side-navigation__item ">
-              <a class="p-side-navigation__link{% if request.path == '/about/governance' %} is-active{% endif %}" href="/about/governance">Governance</a>
+              <a class="p-side-navigation__link{% if request.path == '/governance' %} is-active{% endif %}" href="/governance">Governance</a>
             </li>
             <li class="p-side-navigation__item ">
-              <a class="p-side-navigation__link{% if request.path == '/about/glossary' %} is-active{% endif %}" href="/about/glossary">Glossary</a>
+              <a class="p-side-navigation__link{% if request.path == '/glossary' %} is-active{% endif %}" href="/glossary">Glossary</a>
             </li>
           </ul>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
 <section class="p-strip--accent is-slanted--right">
   <div class="u-fixed-width">
     <h1>The Open Operator Collection</h1>
-    <p>The Open Operator Collection is an open-source initiative to provide a large number of interoperable, easily integrated operators for common workloads. <a href="/about/manifesto">Read our manifesto&nbsp;&rsaquo;</a></p>
+    <p>The Open Operator Collection is an open-source initiative to provide a large number of interoperable, easily integrated operators for common workloads. <a href="/manifesto">Read our manifesto&nbsp;&rsaquo;</a></p>
     <h2 class="p-heading--4">Featured Kubernetes Operators</h2>
   </div>
   <div class="row has-small-gap">
@@ -228,7 +228,7 @@
       <h3 class="p-heading--4">A great place to share code and get things done</h3>
       <p>Welcome! This is an open community where new members and established experts share code, knowledge and ideas for the very best in devsecops.</p>
       <p>Our code of conduct and governance policy are ground rules for happy and productive work in the new world of Kubernetes operators. The Open Operator Manifesto sets the bar for the best in operator technology.</p>
-      <a href="/about/governance" class="p-button--neutral">Learn more about our governance</a>
+      <a href="/governance" class="p-button--neutral">Learn more about our governance</a>
     </div>
     <div class="col-6 col-start-large-7 u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/b25414b3-Community.svg" alt="" width="520" height="320">
@@ -275,7 +275,7 @@
     <div class="col-6 col-start-large-7">
       <p>Containers are amazing, with a lot of complexity and detail. It is hard to drive them correctly. The operator pattern is automation for speed and correctness.</p>
       <p>Think of an operator as a software robot that knows everything the world’s best admins know about running a particular workload. It captures in code the best practices for installing, integrating, upgrading, scaling and assessing that workload. Using the operator is like hiring the world’s best specialist administrator for that workload. Free.</p>
-      <p>Learn more about operators, and read our <a href="/about/manifesto" class="p-link--inverted">Open Operator Manifesto</a>, the critical factors for modern devsecops.</p>
+      <p>Learn more about operators, and read our <a href="/manifesto" class="p-link--inverted">Open Operator Manifesto</a>, the critical factors for modern devsecops.</p>
       <a href="/about" class="p-button--neutral">Find out more</a>
     </div>
   </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -67,21 +67,21 @@ def about():
     return render_template("about/index.html")
 
 
-@app.route("/about/manifesto")
+@app.route("/manifesto")
 def manifesto():
     return render_template("about/manifesto.html")
 
 
-@app.route("/about/publishing")
+@app.route("/publishing")
 def publishing():
     return render_template("about/publishing.html")
 
 
-@app.route("/about/governance")
+@app.route("/governance")
 def governance():
     return render_template("about/governance.html")
 
 
-@app.route("/about/glossary")
+@app.route("/glossary")
 def glossary():
     return render_template("about/glossary.html")


### PR DESCRIPTION
## Done

Update urls for about pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Test to click around in the /about links. All the links should be top level now