### PR TITLE
Remove links to docs and tutorials

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -24,16 +24,6 @@
             About
           </a>
         </li>
-        <li class="p-navigation__item {% if request.path == '/docs' %}is-selected{% endif %}" role="menuitem">
-          <a href="/docs" class="p-navigation__link">
-            Docs
-          </a>
-        </li>
-        <li class="p-navigation__item {% if request.path == '/tutorials' %}is-selected{% endif %}" role="menuitem">
-          <a href="/tutorials" class="p-navigation__link">
-            Tutorials
-          </a>
-        </li>
         <li class="p-navigation__item" role="menuitem">
           <a href="https://discourse.juju.is" class="p-link--external p-navigation__link">
             Discourse


### PR DESCRIPTION
## Done
Remove docs and tutorials links from navigation

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- The navigation shouldn't have docs and tutorials anymore
