### PR TITLE
Fix filter colour on hover

### DIFF
--- a/static/sass/_charmhub_p-filter.scss
+++ b/static/sass/_charmhub_p-filter.scss
@@ -74,7 +74,7 @@
 
       @media screen and(min-width: $breakpoint-medium + 1) {
         &:hover {
-          background-color: $color-light;
+          background-color: #e4e9eb;
         }
       }
 
@@ -160,6 +160,16 @@
   .p-filter__list {
     @extend %vf-list;
 
+    &.has-links {
+      @media screen and(max-width: $breakpoint-medium) {
+        display: none;
+      }
+
+      .p-filter__item:hover {
+        background-color: $color-accent;
+      }
+    }
+
     & + & {
       @extend %vf-pseudo-border--top;
 
@@ -176,8 +186,12 @@
     background:
       linear-gradient($color-x-light 30%, rgba(255, 255, 255, 0)),
       linear-gradient(rgba(255, 255, 255, 0), $color-x-light 70%) 0 100%,
-      radial-gradient(farthest-side at 50% 0, rgba(151, 151, 151, 0.5), rgba(0, 0, 0, 0)),
-      radial-gradient(farthest-side at 50% 100%, rgba(151, 151, 151, 0.5), rgba(0, 0, 0, 0)) 0 100%;
+      radial-gradient(
+        farthest-side at 50% 0,
+        rgba(151, 151, 151, 0.5),
+        rgba(0, 0, 0, 0)
+      ),
+      radial-gradient(farthest-side at 50% 100% rgba(151, 151, 151, 0.5), rgba(0, 0, 0, 0)) 0 100%;
     background-attachment: local, local, scroll, scroll;
     background-color: $color-x-light;
     background-repeat: no-repeat;

--- a/static/sass/_charmhub_p-header.scss
+++ b/static/sass/_charmhub_p-header.scss
@@ -14,6 +14,7 @@
       @extend %p-media-object;
 
       .p-media-object__image {
+        border-radius: 50%;
         max-height: 4rem;
         max-width: 4rem;
       }

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -61,6 +61,8 @@
     }
 
     .p-card__content {
+      max-height: 2.75rem;
+      overflow: hidden;
       padding: 0 $spv-inner--large $spv-inner--large $spv-inner--large;
     }
 

--- a/templates/details/_details-tab-navigation.html
+++ b/templates/details/_details-tab-navigation.html
@@ -1,14 +1,12 @@
-<div class="u-position--sticky">
-  <div class="u-fixed-width">
-    <nav class="p-tabs" data-js="tabs">
-      <ul class="p-tabs__list" role="tablist">
-        <li class="p-tabs__item" role="presentation">
-          <a href="/{{ package.name }}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'overview' %}aria-selected="true" {% endif %}>Overview</a>
-        </li>
-        <li class="p-tabs__item" role="presentation">
-          <a href="/{{ package.name }}/configuration" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'configuration' %}aria-selected="true" {% endif %}>Configuration</a>
-        </li>
-      </ul>
-    </nav>
-  </div>
+<div class="u-fixed-width">
+  <nav class="p-tabs" data-js="tabs">
+    <ul class="p-tabs__list" role="tablist">
+      <li class="p-tabs__item" role="presentation">
+        <a href="/{{ package.name }}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'overview' %}aria-selected="true" {% endif %}>Overview</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
+        <a href="/{{ package.name }}/configuration" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'configuration' %}aria-selected="true" {% endif %}>Configuration</a>
+      </li>
+    </ul>
+  </nav>
 </div>

--- a/templates/details/configuration.html
+++ b/templates/details/configuration.html
@@ -9,10 +9,6 @@
     <div class="col-3">
       <div class="p-side-navigation" data-js="{{ section_slug }}">
         <ul class="p-side-navigation__list">
-          <li class="p-side-navigation__item--title">
-            <span class="p-side-navigation__text">Contents</span>
-          </li>
-
           {% for config in package.store_front.config.options.keys() %}
           <li class="p-side-navigation__item">
             <a href="#{{ config }}" class="p-side-navigation__link" role="tab" aria-controls="{{ config }}" {% if loop.index == 1 %}aria-selected="false" {% endif %}>

--- a/templates/partial/_filters.html
+++ b/templates/partial/_filters.html
@@ -18,15 +18,12 @@
           {% endfor %}
         </ul>
         {% endif %}
-        <ul class="p-filter__list">
+        <ul class="p-filter__list has-links">
           <li class="p-filter__item--title u-sv1">
             Useful links
           </li>
           <li class="p-filter__item">
             <a href="/about" class="u-sv1">What is an operator?</a>
-          </li>
-          <li class="p-filter__item">
-            <a href="/manifesto" class="u-sv1">Legacy estate, really?</a>
           </li>
           <li class="p-filter__item">
             <a href="/publishing" class="u-sv1">How do I publish here?</a>


### PR DESCRIPTION
## Done

- Fix filter colour on hover - on store page
- Make charm icon circular on details page
- Make tab navigation not sticky in the details page
- Fix cards with multi line titles

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
