### PR TITLE
Add images to about pages

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -64,9 +64,11 @@
   <p>
     Operators in the collection declare endpoints that represent potential forms of integration. For example, a MySQL operator can say that it can provide a MySQL database, and that it can stream its logs with the rsyslog protocol.
   </p>
+  <img src="https://assets.ubuntu.com/v1/c6397fd4-1.svg" alt="" width="800" height="320">
   <p>
     Each endpoint has a <i>type</i> and a <i>direction</i>, it can be ‘inbound’ or ‘outbound’. You can only integrate two endpoints if they have the same type and opposite directions.
   </p>
+  <img src="https://assets.ubuntu.com/v1/41cead5c-2.svg" alt="" width="800" height="320">
   <p>
     Don’t confuse the name of the endpoint with the type of the endpoint. Just because an endpoint is named ‘mysql’ doesn’t mean that it has the type ‘mysql’. The type determines the nature of the handshaking that happens during integration. This allows an operator to have multiple endpoints that integrate the same way (‘the same type’) but for different purposes.
   </p>
@@ -76,9 +78,11 @@
   <p>
     When two endpoints are integrated, or related, the operators configure their workloads appropriately for that integration. Here is the simplest example of a relation between the endpoints on two operators:
   </p>
+  <img src="https://assets.ubuntu.com/v1/cd87f1c5-3.svg" alt="" width="800" height="320">
   <p>
     And of course, by repeating the process with different endpoints on different operators you can construct a rich application graph, or topology, of multiple operators, each of which is driving their own workload and aware of integration in the graph.
   </p>
+  <img src="https://assets.ubuntu.com/v1/a87a638d-4.svg" alt="" width="800" height="320">
   <p>
     Operators learn about the application graph at deployment time, and are expected to handle changes in the application graph dynamically. So you can deploy a topology of applications, and then evolve that topology by adding new applications and integrating them whenever you like.
   </p>


### PR DESCRIPTION
## Done

- Add images to about pages
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
