### PR TITLE
Remove channel map from details page

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -42,7 +42,6 @@
             </div>
           </div>
         </div>
-        {% include "partial/_channel-map.html" %}
         <p class="p-charm-header__code"><code>juju deploy <span data-js="channel-cli">{{ package.name }}</span></code></p>
       </div>
     </div>


### PR DESCRIPTION
## Done
Remove channel map

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/jenkins
- No channel map