### PR TITLE
Fix Charms with Kubernetes as series

### DIFF
--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -41,7 +41,6 @@ UBUNTU_SERIES = {
     "eoan": "19.10",
     "focal": "20.04 LTS",
     "groovy": "20.10",
-    "all": "All",
 }
 
 CATEGORIES = {
@@ -193,7 +192,7 @@ def convert_series_to_ubuntu_versions(series):
         str|list: Ubuntu version
     """
     if isinstance(series, str):
-        return UBUNTU_SERIES[series]
+        return UBUNTU_SERIES.get(series, series.capitalize())
     elif isinstance(series, list):
         result = []
         for s in series:


### PR DESCRIPTION
## Done

Fix Charms with Kubernetes as series

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- http://localhost:8045/pipelines-ui
