### PR TITLE
Fix mobile side nav z-index

### DIFF
--- a/static/sass/_pattern_p-navigation.scss
+++ b/static/sass/_pattern_p-navigation.scss
@@ -27,5 +27,6 @@
   .p-side-navigation {
     position: sticky;
     top: 3rem;
+    z-index: 101;
   }
 }


### PR DESCRIPTION
## Done

- Fix mobile side nav z-index

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/about
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Switch layout to mobile and open the side nav. Once open you should be able to see the dissmiss navigation button


## Issue / Card

Fixes #364 

## Screenshots

[if relevant, include a screenshot]
