### PR TITLE
Update operator link in footer to point to /publishing

### DIFF
--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -1,7 +1,7 @@
 <footer>
   <hr>
   <div class="u-fixed-width is-wide">
-    <p class="u-no-padding--top" style="margin-block-end: 1rem;"><strong>List your own operator on Charmhub.</strong><a href="https://github.com/canonical/operator" class="p-link--external"> Submit your operator</a></p>
+    <p class="u-no-padding--top" style="margin-block-end: 1rem;"><strong>List your own operator on Charmhub.</strong><a href="/publishing"> Submit your operator</a></p>
   </div>
   <div class="p-footer">
     <div class="row is-wide">


### PR DESCRIPTION
## Done

Update operator link in footer to point to /publishing

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check operator link in footer
