### PR TITLE
Fix typo in purposeful config section of manifesto

### DIFF
--- a/templates/about/manifesto.html
+++ b/templates/about/manifesto.html
@@ -38,7 +38,7 @@
     </li>
     <li>
       Purposeful config.
-      <p>Application software has many configurable capabilities, but most of those exist to support higher&dash;level goals or purposes. A good operator distinguishes between purpose and mechanism, offers hig&dash;-level purposeful config, and translates that to the many low&dash;level mechanism configs of the workload.</p>
+      <p>Application software has many configurable capabilities, but most of those exist to support higher&dash;level goals or purposes. A good operator distinguishes between purpose and mechanism, offers high&dash;level purposeful config, and translates that to the many low&dash;level mechanism configs of the workload.</p>
     </li>
     <li>
       Scale.


### PR DESCRIPTION
Fix typo in purposeful config section of manifesto