### PR TITLE
Override mobile menu nav visibility toggle

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -6,8 +6,8 @@
           <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/c3b8cc72-Charmhub_white_hex.svg" width="166" height="32" alt="Charmhub" />
         </a>
       </div>
-      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+      <a href="#navigation" class="p-navigation__toggle p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav">
       <span class="u-off-screen">
@@ -38,3 +38,26 @@
     </nav>
   </div>
 </header>
+
+{% block page_scripts %}
+<!-- This JS override of the Vanilla pattern with uses CSS :target to toggle visibility
+is because the Charmhub filters rely the URL string and the default CSS toggle uses
+a hash in the URL which causes a conflict -->
+<script>
+  window.addEventListener("DOMContentLoaded", function () {
+    const menuToggles = document.querySelectorAll('.p-navigation__toggle');
+    const menuNav = document.querySelector('.p-navigation__nav');
+    menuToggles.forEach((menuToggle) => {
+        menuToggle.addEventListener('click', (e) => {
+         e.preventDefault();
+         menuNav.classList.toggle('nav-active');
+      })
+    })
+  });
+</script>
+<style>
+  .nav-active {
+    display: flex;
+  }
+</style>
+{% endblock %}


### PR DESCRIPTION


## Done

This fixes a bug where the mobile nav toggling was interfering with the charm filtering/sorting on the homepage as they both rely on the url for state by disabling the targetting via the url and toggling the nav with JS instead.

Note, this is not the ideal fix for this systemic problem.. it's more of a sticky plaster.

The code for the filtering/sorting is quite fragile as it uses both the instance variable `this._filters` and query params in the URL for state at different points. To make this more robust to deal with hashes in the url requires a significant refactor or rewrite which I don't have the bandwidth for at this time - I'm also conscious this is quite a significant bug currently on production.

I've created a separate issue for the code smell here: https://github.com/canonical-web-and-design/charmhub.io/issues/421

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Change resolution to small screen
- Toggle nav
- Toggle filters
- Toggle nav
- Toggle filters
- Ensure no errors

## Issue / Card

Fixes #369
