### PR TITLE
Fix error page

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -1,6 +1,8 @@
 {% extends 'base_layout.html' %}
 
-{% block title %}500: Server error{% endblock %}
+{% set status_code = status_code|default("500", true) %}
+
+{% block title %}{{ status_code }}: Server error{% endblock %}
 
 {% block meta_description %}Something&rsquo;s gone wrong.{% endblock %}
 
@@ -20,7 +22,7 @@
       }}
     </div>
     <div class="col-7 col-start-large-6">
-      <h1 class="p-heading--2">500: This page isn’t working</h1>
+      <h1 class="p-heading--2">{{ status_code }}: This page isn’t working</h1>
       <p>
         <strong>We are sorry, the page you requested isn't currently available.</strong>
         Our servers may be having some issues loading this page. This could be because we are doing some maintenance and the site will be up soon. Please try again later.

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -41,28 +41,52 @@ def set_handlers(app):
     # ===
     @app.errorhandler(StoreApiTimeoutError)
     def handle_store_api_timeout(e):
-        render_template("500.html", error_message=str(e)), 504
+        status_code = 504
+        return (
+            render_template(
+                "500.html", error_message=str(e), status_code=status_code
+            ),
+            status_code,
+        )
 
     @app.errorhandler(StoreApiCircuitBreaker)
     def handle_store_api_circuit_breaker_exception(e):
-        render_template("500.html", error_message=str(e)), 503
+        status_code = 503
+        return (
+            render_template(
+                "500.html", error_message=str(e), status_code=status_code
+            ),
+            status_code,
+        )
 
     @app.errorhandler(StoreApiResponseErrorList)
     def handle_store_api_error_list(e):
         if e.status_code == 404:
             return render_template("404.html", message="Entity not found"), 404
 
+        status_code = 502
         if e.errors:
-            errors = ", ".join(e.errors.key())
+            errors = ", ".join([e.get("message") for e in e.errors])
             return (
-                render_template("500.html", error_message=errors),
-                502,
+                render_template(
+                    "500.html", error_message=errors, status_code=status_code
+                ),
+                status_code,
             )
 
-        return render_template("500.html"), 502
+        return (
+            render_template("500.html", status_code=status_code),
+            status_code,
+        )
 
     @app.errorhandler(StoreApiResponseDecodeError)
     @app.errorhandler(StoreApiResponseError)
     @app.errorhandler(StoreApiError)
     def handle_store_api_error(e):
-        return render_template("500.html", error_message=str(e)), 502
+        status_code = 502
+        return (
+            render_template(
+                "500.html", error_message=str(e), status_code=status_code
+            ),
+            status_code,
+        )


### PR DESCRIPTION
## Done

- Show real status codes on the 500 error template
- Fix for API error response 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Run the project locally, the homepage should return a 502 error (It's okay, the staging API has changed)
