### PR TITLE
Update details history page

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "terser-webpack-plugin": "4.1.0",
-    "vanilla-framework": "2.19.0",
+    "vanilla-framework": "2.19.1",
     "watch-cli": "0.2.3",
     "webpack": "4.44.1",
     "webpack-cli": "3.3.12"

--- a/static/js/src/public/details/history/index.js
+++ b/static/js/src/public/details/history/index.js
@@ -1,0 +1,15 @@
+import { TableShowMore } from "./tableShowMore";
+
+const init = (tableSelector) => {
+  const tableEl = document.querySelector(tableSelector);
+
+  if (tableEl) {
+    new TableShowMore(tableEl);
+  } else {
+    throw new Error(
+      `There is no element containing ${tableSelector} selector.`
+    );
+  }
+};
+
+export { init };

--- a/static/js/src/public/details/history/tableShowMore.js
+++ b/static/js/src/public/details/history/tableShowMore.js
@@ -1,0 +1,57 @@
+class TableShowMore {
+  constructor(el) {
+    this.tableFooter = el.querySelector("[data-js='table-footer']");
+    this.rows = [].slice.call(
+      el.querySelector("[data-js='table-body']").children
+    );
+    this.showMoreButton = el.querySelector("[data-js='show-more-button']");
+    this.showCurrent = el.querySelector("[data-js='table-show-current']");
+    this.showTotal = el.querySelector("[data-js='table-show-total']");
+    this.rowsToShow = 5;
+    this.init();
+  }
+
+  init() {
+    this.showRows();
+
+    this.showTotal.innerHTML = this.rows.length;
+
+    if (this.rowsToShow < this.rows.length) {
+      this.tableFooter.classList.remove("u-hide");
+    }
+
+    this.showMoreButton.addEventListener("click", () => {
+      this.showMoreButton.blur();
+      this.rowsToShow = this.rowsToShow + 5;
+      this.showRows(this.rowsToShow);
+    });
+  }
+
+  showRows(numberOfRows) {
+    if (numberOfRows) {
+      this.showCurrent.innerHTML =
+        numberOfRows < this.rows.length ? numberOfRows : this.rows.length;
+
+      if (numberOfRows >= this.rows.length) {
+        this.tableFooter.classList.add("u-hide");
+      }
+
+      for (const [i, el] of this.rows.entries()) {
+        if (i < numberOfRows) {
+          el.classList.remove("u-hide");
+        } else {
+          break;
+        }
+      }
+    } else {
+      this.showCurrent.innerHTML =
+        this.rowsToShow < this.rows.length ? this.rowsToShow : this.rows.length;
+
+      for (let i = this.rowsToShow; i < this.rows.length; i++) {
+        this.rows[i].classList.add("u-hide");
+      }
+    }
+  }
+}
+
+export { TableShowMore };

--- a/static/sass/_pattern_p-button.scss
+++ b/static/sass/_pattern_p-button.scss
@@ -15,6 +15,11 @@
     }
   }
 
+  .is-small {
+    line-height: 1rem;
+    padding: calc(0.15rem - 1px) 0.5rem;
+  }
+
   .pagination__link--previous {
     @media screen and (min-width: $breakpoint-medium) {
       margin-block-end: 0;

--- a/templates/details/history.html
+++ b/templates/details/history.html
@@ -5,21 +5,44 @@
 {% block details_content %}
   <div class="u-fixed-width">
     <p>Displaying release history for the <strong>‘latest/stable’</strong> channel:</p>
-    <table class="p-table--mobile-card" role="grid">
+    <table class="p-table--mobile-card" role="grid" data-js="history-table">
       <thead>
         <tr role="row">
           <th>Date</th>
-          <th class="u-align--right">Version</th>
+          <th class="u-align--right">Charm version</th>
+          <th class="u-align--right">Theme</th>
         </tr>
       </thead>
-      <tbody>
+      <tbody data-js="table-body">
         {% for release in package.store_front.channel_map["latest"]["stable"] %}
         <tr role="row">
           <td role="rowheader" aria-label="Date">{{ release.released_at }}</td>
-          <td role="gridcell" aria-label="Version" class="u-align--right">{{ release.version }}</td>
+          <td role="gridcell" aria-label="Charm version" class="u-align--right">{{ release.version }}</td>
+          <td role="gridcell" aria-label="Theme" class="u-align--right">7</td>
         </tr>
         {% endfor %}
       </tbody>
+      <tfoot class="u-hide" data-js="table-footer">
+        <tr role="row">
+          <td role="gridcell" colspan="3">
+            <div class="u-align--right">
+              <small>
+                <span class="p-summary__text u-text--muted">Showing <span data-js="table-show-current"></span> out of <span data-js="table-show-total"></span> items.</span>
+                <button class="is-small is-dense p-button--neutral" data-js="show-more-button">Show more</button>
+              </small>
+            </div>
+          </td>
+        </tr>
+      </tfoot>
     </table>
   </div>
 {% endblock%}
+
+{% block page_scripts %}
+  <script src="{{ versioned_static('js/dist/details_history.js') }}" defer></script>
+  <script>
+    window.addEventListener("DOMContentLoaded", function () {
+      charmhub.details.history.init("[data-js='history-table']");
+    });
+  </script>
+{% endblock %}

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -5,6 +5,7 @@ module.exports = {
   base: "./static/js/src/base/base.js",
   details: "./static/js/src/public/details/index.js",
   details_docs: "./static/js/src/public/details/docs/index.js",
+  details_history: "./static/js/src/public/details/history/index.js",
   store: "./static/js/src/public/store/index.js",
   list: "./static/js/src/publisher/list-page.js",
   listing: "./static/js/src/publisher/listing-page.js",

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -42,6 +42,12 @@ module.exports = [
     use: ["expose-loader?exposes=charmhub.details.docs", "babel-loader"],
   },
   {
+    test: require.resolve(
+      __dirname + "/static/js/src/public/details/history/index.js"
+    ),
+    use: ["expose-loader?exposes=charmhub.details.history", "babel-loader"],
+  },
+  {
     test: require.resolve(__dirname + "/static/js/src/publisher/list-page.js"),
     use: ["expose-loader?exposes=charmhub.publisher.list", "babel-loader"],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9334,10 +9334,10 @@ vanilla-framework@2.13.0:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.13.0.tgz#ac73e745150bcef183eb35e3ee47f3fd079ddd3e"
   integrity sha512-EuxlGxO4SmCGL4GVzcye5aas2HGVqRhPxlTHg84Lfw1e1E4F/Coxs78i3xxkPGw3LOcfea0KU096ar1PnLNuXQ==
 
-vanilla-framework@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.19.0.tgz#c499d5ca59818595732733e45ef4c9e7fea71302"
-  integrity sha512-0qtFmzDBdgZ5JmKysBbIjQ224CDBtVWSdHvCzay3udBHlcbfJJTXIozLvOFk6zt78GClrNN2dwLLIpYPDWcaZQ==
+vanilla-framework@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.19.1.tgz#f071deed5504a5fe2104d6d9b087ce654e190881"
+  integrity sha512-y79SKAwertvgHVAf1PbGxiq6QvVxNI78txilSgESx80HUWBrooT1nXCDUuHC/ySGEq+JUpmVIv0PrmXXilYWdg==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

- Update details history page
- Upgrade vanilla to 2.19.1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/<charm>/history
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Perhaps you might need to run this locally and add the code below 10 times in the `history.html` table
```
<tr role="row">
  <td role="rowheader" aria-label="Date">test</td>
  <td role="gridcell" aria-label="Charm version" class="u-align--right">123</td>
  <td role="gridcell" aria-label="Theme" class="u-align--right">7</td>
</tr>
```


## Issue / Card

Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/3126

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/96873843-5bdaf880-146d-11eb-86ae-0c70c06aa2d4.png)

