### PR TITLE
Obtain library docstrings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ canonicalwebteam.flask-base==0.6.4
 canonicalwebteam.search==0.2.1
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.store-api==2.3.6
+docstring-extractor==0.1.1
 Flask-WTF==0.14.3
 humanize==2.6.0
 mistune==0.8.4

--- a/templates/details/libraries.html
+++ b/templates/details/libraries.html
@@ -1,0 +1,21 @@
+{% set current_tab = "libraries" %}
+
+{% extends '/details/details_layout.html' %}
+
+{% block details_content %}
+  <div class="u-fixed-width">
+    Sidebar:
+    {% for group in libraries.keys() %}
+    <div>{{ group }}</div>
+      {% for lib in libraries[group] %}
+      <div>- {{ lib["name"] }}</div>
+      {% endfor %}
+    {% endfor %}
+
+    Content:
+    {{ docstrings["charms.apache.v2.http"]["content"][0]["html"]|safe }}
+
+    Source:
+    <pre><code>{{ libraries["charms.apache"][0]["content"] }}</code></pre>
+  </div>
+{% endblock%}

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import os
 
+from mistune import Markdown, Renderer
 import humanize
 from canonicalwebteam.discourse import DiscourseAPI
 from dateutil import parser
@@ -23,6 +24,8 @@ discourse_api = DiscourseAPI(
 
 _yaml = YAML(typ="rt")
 _yaml_safe = YAML(typ="safe")
+
+md_parser = Markdown(renderer=Renderer(), hard_wrap=True)
 
 
 def get_yaml_loader(typ="safe"):

--- a/webapp/store/data/library_a.py
+++ b/webapp/store/data/library_a.py
@@ -1,0 +1,127 @@
+# Copyright 2020 Canonical Ltd.
+# Licensed under the Apache License, Version 2.0; see LICENCE file for details.
+
+import http.client
+import json
+import logging
+import ssl
+import sys
+
+from .version import version as __version__  # noqa: F401 (imported but unused)
+
+__all__ = ("get_pod_status", "APIServer", "PodStatus")
+
+logger = logging.getLogger()
+
+
+def get_pod_status(juju_model, juju_app, juju_unit):
+    """Left to not break people, but you should probably just do
+    `PodStatus.for_charm()` instead."""
+    return PodStatus.fetch(juju_model, juju_app, juju_unit)
+
+
+class APIServer:
+    """
+    Wraps the logic needed to access the k8s API server from inside a pod.
+    It does this by reading the service account token which is mounted onto
+    """
+
+    _SERVICE_ACCOUNT_CA = (
+        "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    )
+    _SERVICE_ACCOUNT_TOKEN = (
+        "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    )
+
+    def get(self, path):
+        return self.request("GET", path)
+
+    def request(self, method, path):
+        with open(
+            self._SERVICE_ACCOUNT_TOKEN, "rt", encoding="utf8"
+        ) as token_file:
+            kube_token = token_file.read()
+
+        # drop this when dropping support for 3.5
+        if sys.version_info < (3, 6):
+            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+        else:
+            ssl_context = ssl.SSLContext()
+
+        ssl_context.load_verify_locations(self._SERVICE_ACCOUNT_CA)
+
+        headers = {"Authorization": "Bearer {}".format(kube_token)}
+
+        host = "kubernetes.default.svc"
+        conn = http.client.HTTPSConnection(host, context=ssl_context)
+        logger.debug("%s %s/%s", method, host, path)
+        conn.request(method=method, url=path, headers=headers)
+        response = conn.getresponse()
+        logger.debug("%s %s/%s done: %s", method, host, path, response.status)
+
+        return json.load(response)
+
+
+class PodStatus(dict):
+    @classmethod
+    def for_charm(cls, charm):
+        """Fetch the status of the workload pod for the given charm."""
+        return cls.fetch(charm.model.name, charm.app.name, charm.unit.name)
+
+    @classmethod
+    def fetch(cls, juju_model, juju_app, juju_unit):
+        """Fetch the status of the pod for the given model, app and unit."""
+        logger.debug(
+            "getting pod status for %s/%s/%s", juju_model, juju_app, juju_unit
+        )
+        namespace = juju_model
+
+        path = "/api/v1/namespaces/{}/pods?labelSelector=juju-app={}".format(
+            namespace, juju_app
+        )
+
+        api_server = APIServer()
+        response = api_server.get(path)
+
+        status = cls()
+        try:
+            if response["kind"] == "PodList":
+                for item in response["items"]:
+                    if (
+                        item["metadata"]["annotations"]["juju.io/unit"]
+                        == juju_unit
+                    ):
+                        status.update(item)
+                        break
+        except KeyError:
+            pass
+
+        return status
+
+    @property
+    def is_ready(self):
+        if not self:
+            return False
+
+        try:
+            for condition in self["status"]["conditions"]:
+                if condition["type"] == "ContainersReady":
+                    return condition["status"] == "True"
+        except KeyError:
+            pass
+
+        return False
+
+    @property
+    def is_running(self):
+        if not self:
+            return False
+
+        try:
+            return self["status"]["phase"] == "Running"
+        except KeyError:
+            return False
+
+    @property
+    def is_unknown(self):
+        return not self

--- a/webapp/store/data/library_b.py
+++ b/webapp/store/data/library_b.py
@@ -1,0 +1,21 @@
+"""TEMPLATE FIXME: Add a proper docstring here.
+
+This is the main documentation of the library, will be shown by Charmhub after
+the lib is published.
+
+Markdown is supported.
+"""
+
+# Never change this field, it's the unique identifier to track the library in
+# all systems
+LIBID = "41a46725-70d8-463e-bf7f-69502484fea5"
+
+# Update this API version when introducing backwards incompatible
+# changes in the library.
+LIBAPI = 0
+
+# Update this version for every change in the library before (re)publishing it
+# (except for the initial content).
+LIBPATCH = 1
+
+# TEMPLATE FIXME: add your code here! Happy coding!

--- a/webapp/store/mock.py
+++ b/webapp/store/mock.py
@@ -95,3 +95,58 @@ mocked_actions = {
         "required": ["storage-uri"],
     },
 }
+
+
+def get_charm_libraries():
+    """
+    We don't know yet how the response from the API will be
+    """
+    with open("webapp/store/data/library_a.py", "r") as library_a_file:
+        library_1 = library_a_file.read()
+
+    with open("webapp/store/data/library_b.py", "r") as library_b_file:
+        library_2 = library_b_file.read()
+
+    return {
+        "charms.apache": [
+            {
+                "id": "97460193",
+                "name": ".v2.http",
+                "content": library_1,
+                "content_hash": "e0d123e5f316bef78bfdf5a008837577",
+                "created_at": "2020-08-04T16:32:00.938000+00:00",
+            }
+        ],
+        "charms.openstack_dashboard": [
+            {
+                "id": "97460194",
+                "name": ".v2.db",
+                "content": library_1,
+                "content_hash": "e0d123e5f316bef78bfdf5a008837577",
+                "created_at": "2020-08-04T16:32:00.938000+00:00",
+            },
+            {
+                "id": "97460194",
+                "name": ".v1.dashboard-plugin",
+                "content": library_2,
+                "content_hash": "e0d123e5f316bef78bfdf5a008837577",
+                "created_at": "2020-08-04T16:32:00.938000+00:00",
+            },
+            {
+                "id": "97460194",
+                "name": ".v1.nrpe_external_master",
+                "content": library_2,
+                "content_hash": "e0d123e5f316bef78bfdf5a008837577",
+                "created_at": "2020-08-04T16:32:00.938000+00:00",
+            },
+        ],
+        "charms.keystone": [
+            {
+                "id": "97460195",
+                "name": ".v2.websso_trusted",
+                "content": library_2,
+                "content_hash": "e0d123e5f316bef78bfdf5a008837577",
+                "created_at": "2020-08-04T16:32:00.938000+00:00",
+            },
+        ],
+    }


### PR DESCRIPTION
## Done

Parse python files to obtain their docstrings

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Mocked data is under http://localhost:8045/<charm>/libraries


## Issue / Card

Fixes #444
