### PR TITLE
Fix squircle icons black edge

### DIFF
--- a/static/sass/_charmhub_p-header.scss
+++ b/static/sass/_charmhub_p-header.scss
@@ -21,6 +21,20 @@
         width: 4rem;
       }
 
+      .p-media-object__image-container {
+        border-radius: 50%;
+        height: 4rem;
+        margin-inline-end: 1rem;
+        max-height: 4rem;
+        max-width: 4rem;
+        overflow: hidden;
+        width: 4rem;
+
+        .p-media-object__image {
+          transform: scale(1.1);
+        }
+      }
+
       .p-media-object__title {
         @extend %vf-heading-2;
 

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -62,6 +62,18 @@
       width: 2.5rem;
     }
 
+    .p-card__thumbnail-container {
+      border-radius: 50%;
+      height: 2.5rem;
+      margin-block-end: 0.375rem;
+      overflow: hidden;
+      width: 2.5rem;
+
+      .p-card__thumbnail {
+        transform: scale(1.1);
+      }
+    }
+
     .p-card__content {
       max-height: 4.25rem;
       overflow: hidden;

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -12,6 +12,7 @@
             {% endfor %}
           </div>
           {% else %}
+          <div class="p-media-object__image-container">
             {% if package["store_front"]["icons"] %}
               {{
                 image(
@@ -37,6 +38,7 @@
                 ) | safe
               }}
             {% endif %}
+          </div>
           {% endif %}
           <div class="p-media-object__details">
             <h1 class="p-media-object__title">

--- a/templates/partial/_entity-card.html
+++ b/templates/partial/_entity-card.html
@@ -5,31 +5,33 @@
   <a href="/{{ package.name }}" class="p-card--button">
     <div class="p-card__header">
       <div class="{% if isBundle %}p-bundle-icons{% endif %}">
-        {% if package["store_front"]["icons"] %}
-          {{
-            image(
-              url=package.store_front.icons[0],
-              alt=package.title,
-              width="40",
-              height="40",
-              hi_def=True,
-              fill=True,
-              attrs={"class": "p-card__thumbnail"},
-            ) | safe
-          }}
-        {% else %}
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg",
-              alt=package.title,
-              width="40",
-              height="40",
-              hi_def=True,
-              fill=True,
-              attrs={"class": "p-card__thumbnail"},
-            ) | safe
-          }}
-        {% endif %}
+        <div class="p-card__thumbnail-container">
+          {% if package["store_front"]["icons"] %}
+            {{
+              image(
+                url=package.store_front.icons[0],
+                alt=package.title,
+                width="40",
+                height="40",
+                hi_def=True,
+                fill=True,
+                attrs={"class": "p-card__thumbnail"},
+              ) | safe
+            }}
+          {% else %}
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg",
+                alt=package.title,
+                width="40",
+                height="40",
+                hi_def=True,
+                fill=True,
+                attrs={"class": "p-card__thumbnail"},
+              ) | safe
+            }}
+          {% endif %}
+        </div>
         {% if isBundle %}
         <img src="{{ package.store_front.icons[0] }}" alt="{{ package.title}}" class="p-card__thumbnail">
         <img src="{{ package.store_front.icons[0] }}" alt="{{ package.title}}" class="p-card__thumbnail">


### PR DESCRIPTION
## Done

- Fix squircle icons black edge

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the charm icons have no black edges


## Issue / Card

Fixes #365 

## Screenshots

[if relevant, include a screenshot]
