### PR TITLE
Change details pages layout to 90rem

### DIFF
--- a/static/sass/_pattern_grid.scss
+++ b/static/sass/_pattern_grid.scss
@@ -5,6 +5,12 @@
     }
   }
 
+  .col-large-6 {
+    @media (min-width: 1300px) {
+      grid-column-end: span 6;
+    }
+  }
+
   .row.has-small-gap {
     grid-gap: 1rem;
     margin-bottom: 1.2rem;

--- a/static/sass/charmhub_utils.scss
+++ b/static/sass/charmhub_utils.scss
@@ -19,7 +19,7 @@
 
   .col-3.has-space--right {
     @media screen and (min-width: $breakpoint-large) {
-      margin-inline-end: 2rem;
+      margin-inline-end: 4rem;
     }
   }
 

--- a/static/sass/charmhub_utils.scss
+++ b/static/sass/charmhub_utils.scss
@@ -17,18 +17,21 @@
     display: flex;
   }
 
+  .col-3.has-space--right {
+    @media screen and (min-width: $breakpoint-large) {
+      margin-inline-end: 2rem;
+    }
+  }
+
+  .is-wide {
+    max-width: $grid-max-width !important;
+  }
+
   .u-position--sticky {
     background-color: $color-x-light;
     position: sticky;
     top: 0;
     z-index: 10;
-  }
-
-  // XXX Ant - 11.03.20: This can be removed once this issue is closed.
-  // https://github.com/canonical-web-and-design/vanilla-framework/issues/2922
-  .u-text--subtle {
-    color: $color-mid-dark;
-    font-size: 0.875rem;
   }
 
   .u-extra-space {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -258,14 +258,10 @@ body {
 }
 
 // Fix pre width on details pages for Desktop
-.p-tabs__content {
-  pre {
-    max-width: 40rem;
+.p-details-tab__content {
+  p {
+    max-width: unset;
   }
-}
-
-.is-wide {
-  max-width: $grid-max-width !important;
 }
 
 .row,

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -1,5 +1,5 @@
 <div class="p-strip--header is-shallow">
-  <div class="row">
+  <div class="row is-wide">
     <div class="col-8">
       <div class="p-charm-header">
         <div class="p-media-object--medium u-no-margin--bottom">

--- a/templates/details/_details-tab-navigation.html
+++ b/templates/details/_details-tab-navigation.html
@@ -1,4 +1,4 @@
-<div class="u-fixed-width">
+<div class="u-fixed-width is-wide">
   <nav class="p-tabs" data-js="tabs">
     <ul class="p-tabs__list" role="tablist">
       <li class="p-tabs__item" role="presentation">

--- a/templates/details/actions.html
+++ b/templates/details/actions.html
@@ -3,10 +3,10 @@
 {% extends '/details/details_layout.html' %}
 
 {% block details_content %}
-<div class="row p-tabs__content" id="actions">
+<div class="row is-wide p-details-tab__content">
   {% if package.store_front.actions %}
-    <div class="row">
-      <div class="col-3">
+    <div class="row is-wide">
+      <div class="col-3 has-space--right">
         <div class="p-side-navigation">
           <ul class="p-side-navigation__list">
             {% for action in package.store_front.actions %}
@@ -19,7 +19,7 @@
           </ul>
         </div>
       </div>
-      <div class="col-9">
+      <div class="col-9 col-large-6">
         <ul class="p-list--divided has-sparator-centered">
           {% for action, action_data in package.store_front.actions.items() %}
             <li class="p-list__item action-section" id="{{ action }}">

--- a/templates/details/configure.html
+++ b/templates/details/configure.html
@@ -3,10 +3,10 @@
 {% extends '/details/details_layout.html' %}
 
 {% block details_content %}
-<div class="row p-tabs__content" id="configure">
-  <div class="row">
+<div class="row is-wide p-details-tab__content">
+  <div class="row is-wide">
     {% if package.store_front.config.options %}
-    <div class="col-3">
+    <div class="col-3 has-space--right">
       <div class="p-side-navigation" data-js="{{ section_slug }}">
         <ul class="p-side-navigation__list">
           {% for config in package.store_front.config.options.keys() %}
@@ -19,7 +19,7 @@
         </ul>
       </div>
     </div>
-    <div class="col-9">
+    <div class="col-9 col-large-6">
       <ul class="p-list--divided has-sparator-centered">
         {% for key, value in package.store_front.config.options.items() %}
         <li class="p-list__item" id="{{ key }}">

--- a/templates/details/docs.html
+++ b/templates/details/docs.html
@@ -3,10 +3,10 @@
 {% extends '/details/details_layout.html' %}
 
 {% block details_content %}
-  <div class="u-fixed-width">
+  <div class="u-fixed-width is-wide p-details-tab__content">
     {% if navigation and body_html %}
-      <div class="row u-no-padding--left u-no-padding--right">
-        <div class="col-3">
+      <div class="row is-wide u-no-padding--left u-no-padding--right">
+        <div class="col-3 has-space--right">
           <nav class="p-side-navigation--raw-html" id="drawer">
             <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
               Toggle side navigation
@@ -22,7 +22,7 @@
             </div>
           </nav>
         </div>
-        <div class="col-9">
+        <div class="col-9 col-large-6">
           {{ body_html | safe }}
           <div class="u-fixed-width">
             <hr class="p-separator--medium">

--- a/templates/details/history.html
+++ b/templates/details/history.html
@@ -3,7 +3,7 @@
 {% extends '/details/details_layout.html' %}
 
 {% block details_content %}
-  <div class="u-fixed-width">
+  <div class="u-fixed-width is-wide p-details-tab__content">
     <p>Displaying release history for the <strong>‘latest/stable’</strong> channel:</p>
     <table class="p-table--mobile-card" role="grid" data-js="history-table">
       <thead>

--- a/templates/details/libraries.html
+++ b/templates/details/libraries.html
@@ -3,7 +3,7 @@
 {% extends '/details/details_layout.html' %}
 
 {% block details_content %}
-  <div class="u-fixed-width">
+  <div class="u-fixed-width is-wide">
     Sidebar:
     {% for group in libraries.keys() %}
     <div>{{ group }}</div>

--- a/templates/details/overview.html
+++ b/templates/details/overview.html
@@ -3,8 +3,8 @@
 {% extends '/details/details_layout.html' %}
 
 {% block details_content %}
-  <div class="row p-tabs__content" id="overview">
-    <div class="col-3">
+  <div class="row is-wide p-details-tab__content">
+    <div class="col-3 has-space--right">
       {% if package.result.license %}
         <p><span class="u-text--muted">License</span><br />{{ package.result.license }}</p>
       {% endif %}
@@ -37,7 +37,7 @@
       <p>Share your thoughts on this charm with the community on discourse.</p>
       <p><a class="p-button--neutral" href="https://discourse.juju.is/">Join the discussion</a></p>
     </div>
-    <div class="col-9">
+    <div class="col-9 col-large-6">
       {{ readme | safe }}
     </div>
   </div>

--- a/templates/partial/_entity-card.html
+++ b/templates/partial/_entity-card.html
@@ -38,7 +38,7 @@
         {% endif %}
       </div>
       <h3 class="p-card__title p-heading--4 u-no-margin--bottom">{{ format_slug(package.name) }}</h3>
-      <p class="u-text--subtle u-no-padding--top">{{ package["result"]["publisher"]["display-name"] }}</p>
+      <p class="u-text--muted u-no-padding--top">{{ package["result"]["publisher"]["display-name"] }}</p>
     </div>
 
     {% if package["result"]["summary"] %}

--- a/templates/publisher/bundles.html
+++ b/templates/publisher/bundles.html
@@ -10,7 +10,7 @@
   <div class="u-fixed-width">
     {% include "partial/_tabs-publisher-packages.html" %}
   </div>
-  <div class="p-tabs__content" id="bundles">
+  <div class="p-details-tab__content" id="bundles">
     <div class="u-fixed-width">
       <ul class="p-inline-list u-no-margin--bottom">
         <li class="p-inline-list__item">

--- a/templates/publisher/charms.html
+++ b/templates/publisher/charms.html
@@ -10,7 +10,7 @@
   <div class="u-fixed-width">
     {% include "partial/_tabs-publisher-packages.html" %}
   </div>
-  <div class="p-tabs__content">
+  <div class="p-details-tab__content">
     {% include "partial/_header-publisher-packages.html" %}
     <div class="u-fixed-width">
       <table class="p-table--mobile-card" role="grid">

--- a/templates/topics/kubernetes.html
+++ b/templates/topics/kubernetes.html
@@ -29,7 +29,7 @@
             <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
           </div>
           <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
-          <p class="u-text--subtle">postgresql-charmers</p>
+          <p class="u-text--muted">postgresql-charmers</p>
         </div>
         <div class="p-card__content">
           <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>
@@ -47,7 +47,7 @@
             <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
           </div>
           <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
-          <p class="u-text--subtle">postgresql-charmers</p>
+          <p class="u-text--muted">postgresql-charmers</p>
         </div>
         <div class="p-card__content">
           <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>
@@ -65,7 +65,7 @@
             <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
           </div>
           <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
-          <p class="u-text--subtle">postgresql-charmers</p>
+          <p class="u-text--muted">postgresql-charmers</p>
         </div>
         <div class="p-card__content">
           <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>
@@ -83,7 +83,7 @@
             <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
           </div>
           <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
-          <p class="u-text--subtle">postgresql-charmers</p>
+          <p class="u-text--muted">postgresql-charmers</p>
         </div>
         <div class="p-card__content">
           <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>
@@ -174,7 +174,7 @@
                   <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
                 </div>
                 <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
-                <p class="u-text--subtle">postgresql-charmers</p>
+                <p class="u-text--muted">postgresql-charmers</p>
               </div>
               <div class="p-card__content">
                 <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>
@@ -192,7 +192,7 @@
                   <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
                 </div>
                 <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
-                <p class="u-text--subtle">postgresql-charmers</p>
+                <p class="u-text--muted">postgresql-charmers</p>
               </div>
               <div class="p-card__content">
                 <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>
@@ -210,7 +210,7 @@
                   <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
                 </div>
                 <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
-                <p class="u-text--subtle">postgresql-charmers</p>
+                <p class="u-text--muted">postgresql-charmers</p>
               </div>
               <div class="p-card__content">
                 <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>
@@ -228,7 +228,7 @@
                   <img src="https://api.jujucharms.com/charmstore/v5/postgresql-203/icon.svg" alt="" class="p-card__thumbnail">
                 </div>
                 <h3 class="p-card__title p-heading--4 u-no-margin--bottom">Postgresql</h3>
-                <p class="u-text--subtle">postgresql-charmers</p>
+                <p class="u-text--muted">postgresql-charmers</p>
               </div>
               <div class="p-card__content">
                 <p><small>Access a relational database management system with extensibility and SQL compliance.</small></p>


### PR DESCRIPTION
## Done

- Change details pages layout to 90rem
- Replace `u-text--subtle` with vanilla's `u-text--muted`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit all details pages and make sure they all look good: `overview`, `configure`, `actions`, `docs`, `history`


## Issue / Card

Fixes #454 

## Screenshots

[if relevant, include a screenshot]
