### PR TITLE
Get real Discourse docs for Charms

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -79,18 +79,23 @@ jobs:
           sudo apt-get update && sudo apt-get install --yes python3-setuptools
           sudo pip3 install -r requirements.txt
 
+      - name: Install dotrun
+        run: |
+          sudo snap install dotrun
+          sudo chown root:root /
+
       - name: Install dependencies
         run: sudo pip3 install coverage
 
       - name: Install node dependencies
-        run: yarn install --immutable
+        run: /snap/bin/dotrun install
 
       - name: Build resources
-        run: yarn build
+        run: /snap/bin/dotrun build
 
-      - name: Run tests with coverage
+      - name: Run python tests with coverage
         run: |
-          coverage run  --source=. -m unittest discover tests
+          /snap/bin/dotrun exec coverage run --source=. -m unittest discover tests
           bash <(curl -s https://codecov.io/bash) -cF python
 
   test-js:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build-js": "yarn run build-js-bundle",
     "build-js-bundle": "webpack",
     "format-python": "black --line-length 79 webapp",
-    "lint-python": "flake8 webapp tests && black --check --line-length 79 webapp tests",
+    "lint-python": "flake8 --extend-ignore=E203 webapp tests && black --check --line-length 79 webapp tests",
     "lint-js": "eslint static/js/src/**/*.js",
     "lint-scss": "stylelint static/**/*.scss",
     "serve": "./entrypoint 0.0.0.0:${PORT}",

--- a/templates/details/_details-tab-navigation.html
+++ b/templates/details/_details-tab-navigation.html
@@ -5,6 +5,9 @@
         <a href="/{{ package.name }}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'overview' %}aria-selected="true" {% endif %}>Overview</a>
       </li>
       <li class="p-tabs__item" role="presentation">
+        <a href="/{{ package.name }}/docs" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'docs' %}aria-selected="true" {% endif %}>Docs</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
         <a href="/{{ package.name }}/configure" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'configure' %}aria-selected="true" {% endif %}>Configure</a>
       </li>
     </ul>

--- a/templates/details/empty-docs.html
+++ b/templates/details/empty-docs.html
@@ -1,0 +1,25 @@
+{% set current_tab = "docs" %}
+
+{% extends '/details/details_layout.html' %}
+
+{% block details_content %}
+  <div class="u-fixed-width is-wide p-details-tab__content">
+    <div class="u-fixed-width">
+      <h4>Add docs to your charm</h4>
+      <p>
+        Looks like you haven’t added any docs yet. Docs help your users learn how to use your charms, and encourage them to use them the way you intended.
+      </p>
+      <p>
+        <a class="p-button--positive" href="#">Learn how to add docs to your charm</a>
+      </p>
+  </div>
+{% endblock%}
+
+{% block page_scripts %}
+  <script src="{{ versioned_static('js/dist/details_docs.js') }}" defer></script>
+  <script>
+    window.addEventListener("DOMContentLoaded", function () {
+      charmhub.details.docs.initSideNav();
+    });
+  </script>
+{% endblock %}

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -43,7 +43,7 @@ def index():
             results[i]["default-release"]["channel"]["released-at"]
         )
 
-        if results[i]["result"]["categories"]:
+        if results[i]["result"].get("categories"):
             results[i]["store_front"]["categories"] = logic.get_categories(
                 results[i]["result"]["categories"]
             )
@@ -126,19 +126,19 @@ def details_overview(entity_name):
 def details_docs(entity_name, slug=None):
     package = app.store_api.get_item_details(entity_name, fields=FIELDS)
     package = logic.add_store_front_data(package)
-    docs_url_prefix = f"/{package['name']}/docs"
 
-    # Fake package discourse topic
-    package["docs_topic"] = 3568
+    if not package["store_front"]["docs_topic"]:
+        return render_template("details/empty-docs.html", package=package)
+
+    docs_url_prefix = f"/{package['name']}/docs"
 
     docs = DocParser(
         api=discourse_api,
-        index_topic_id=package["docs_topic"],
+        index_topic_id=package["store_front"]["docs_topic"],
         url_prefix=docs_url_prefix,
     )
     docs.parse()
     body_html = docs.index_document["body_html"]
-
     topic_path = docs.index_document["topic_path"]
 
     if slug:


### PR DESCRIPTION
## Done

Get real Discourse docs for Charms, fixes #442 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Switch to the staging API:
`.env.local`
```
CHARMSTORE_API_URL=https://api.staging.snapcraft.io/
```
- The first charm with docs defined is: http://0.0.0.0:8045/fran-wordpress/docs
- Any other charms should 404 when visiting `/docs`