### PR TITLE
Fix closing of integrate modal

### DIFF
--- a/templates/details/integrate.html
+++ b/templates/details/integrate.html
@@ -141,7 +141,13 @@
       toggleModal(modal);
     });
 
-    innerModal.addEventListener("click", (e) => e.stopPropagation());
+    innerModal.addEventListener("click", (e) => {
+      if (!e.target.getAttribute("aria-controls") === "modal") {
+        e.stopPropagation();
+      } else {
+        toggleModal(modal);
+      }
+    });
 
     function setModalContent(options) {
       if (options.package) {


### PR DESCRIPTION
- Go to http://localhost:8045/apache-flume-hdfs/integrate
- Click on an integration
- Click outside the modal and check that it closes
- Click on an integration
- Click on the close modal button (X) and check that it closes