### PR TITLE
Remove useless tag

### DIFF
--- a/static/js/src/public/details/integrate/index.js
+++ b/static/js/src/public/details/integrate/index.js
@@ -251,38 +251,6 @@ function buildChart(data) {
       return `translate(0, ${40 * i})`;
     });
 
-  // connecting lines headings
-  const headingsGroup = bounds.append("g").attr("transform", () => {
-    const yPos = 21 * data.groups.length;
-    return `translate(0, ${yPos < 0 ? yPos : -yPos})`;
-  });
-
-  headingsGroup
-    .append("text")
-    .attr("x", iconContainerRadius * 2.5)
-    .attr("y", chartHeight / 2)
-    .attr("font-family", "'Ubuntu', sans-serif")
-    .attr("font-size", "14px")
-    .attr("fill", "#666666");
-
-  headingsGroup
-    .append("text")
-    .attr("x", chartWidth / 2)
-    .attr("y", chartHeight / 2)
-    .attr("font-family", "'Ubuntu', sans-serif")
-    .attr("font-size", "14px")
-    .attr("fill", "#666666")
-    .attr("text-anchor", "middle");
-
-  headingsGroup
-    .append("text")
-    .attr("x", chartWidth - iconContainerRadius * 2.5)
-    .attr("y", chartHeight / 2)
-    .attr("font-family", "'Ubuntu', sans-serif")
-    .attr("font-size", "14px")
-    .attr("fill", "#666666")
-    .attr("text-anchor", "end");
-
   // connecting lines text
   data.groups.forEach((group, i) => {
     const textGroup = bounds.append("g").attr("transform", () => {

--- a/static/js/src/public/details/integrate/index.js
+++ b/static/js/src/public/details/integrate/index.js
@@ -263,8 +263,7 @@ function buildChart(data) {
     .attr("y", chartHeight / 2)
     .attr("font-family", "'Ubuntu', sans-serif")
     .attr("font-size", "14px")
-    .attr("fill", "#666666")
-    .text("Endpoint");
+    .attr("fill", "#666666");
 
   headingsGroup
     .append("text")
@@ -273,8 +272,7 @@ function buildChart(data) {
     .attr("font-family", "'Ubuntu', sans-serif")
     .attr("font-size", "14px")
     .attr("fill", "#666666")
-    .attr("text-anchor", "middle")
-    .text("Interface");
+    .attr("text-anchor", "middle");
 
   headingsGroup
     .append("text")
@@ -283,8 +281,7 @@ function buildChart(data) {
     .attr("font-family", "'Ubuntu', sans-serif")
     .attr("font-size", "14px")
     .attr("fill", "#666666")
-    .attr("text-anchor", "end")
-    .text("Endpoint");
+    .attr("text-anchor", "end");
 
   // connecting lines text
   data.groups.forEach((group, i) => {


### PR DESCRIPTION
We are removing the label because this is an obvious and guessable label not required

![image](https://user-images.githubusercontent.com/2707508/97866815-94e45a00-1d04-11eb-9921-1f5846158c51.png)

- `dotrun`
- http://0.0.0.0:8045/activemq/integrate
- http://0.0.0.0:8045/advanced-routing/integrate
- http://0.0.0.0:8045/ambassador/integrate
- http://0.0.0.0:8045/aodh/integrate
- http://0.0.0.0:8045/apache-flume-hdfs/integrate
- Try the integration popup for each and make sure they don't have the title anymore