### PR TITLE
Add swap between channel easy

### DIFF
--- a/static/js/src/public/details/channelMap.js
+++ b/static/js/src/public/details/channelMap.js
@@ -23,27 +23,11 @@ const init = (packageName, channelMapButton) => {
   );
 
   const selectChannel = (channel, version) => {
-    const selected = document.querySelector(
-      `[data-channel-map-channel="${channelMapState.channel}"]`
-    );
-
-    selected.classList.remove("is-active");
-
-    channelMapState.channel = channel;
-    channelMapState.version = version;
-
-    const newSelected = document.querySelector(
-      `[data-channel-map-channel="${channel}"]`
-    );
-
-    newSelected.classList.add("is-active");
-
-    currentChannel.innerHTML = `${channel} ${version}`;
-
-    if (channel === "latest/stable") {
-      channelCli.innerText = packageName;
+    if (channel === "stable") {
+      window.location.href = `/${packageName}`;
     } else {
-      channelCli.innerText = `${packageName} --channel=${channel}`;
+      let channelName = channel.replace("latest/", "");
+      window.location.href = `/${packageName}?channel=${channelName}`;
     }
   };
 

--- a/static/js/src/public/details/channelMap.js
+++ b/static/js/src/public/details/channelMap.js
@@ -23,11 +23,12 @@ const init = (packageName, channelMapButton) => {
   );
 
   const selectChannel = (channel, version) => {
+    var page = window.location.pathname;
     if (channel === "stable") {
-      window.location.href = `/${packageName}`;
+      window.location.href = `${page}`;
     } else {
       let channelName = channel.replace("latest/", "");
-      window.location.href = `/${packageName}?channel=${channelName}`;
+      window.location.href = `${page}?channel=${channelName}`;
     }
   };
 

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -64,6 +64,7 @@
             </div>
           </div>
         </div>
+        {% include "partial/_channel-map.html" %}
         <p class="p-charm-header__code"><code>juju deploy <span data-js="channel-cli">{{ package.name }}</span></code></p>
       </div>
     </div>

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -65,7 +65,7 @@
           </div>
         </div>
         {% include "partial/_channel-map.html" %}
-        <p class="p-charm-header__code"><code>juju deploy <span data-js="channel-cli">{{ package.name }}</span></code></p>
+        <p class="p-charm-header__code"><code>juju deploy <span data-js="channel-cli">{{ package.name }}</span>{% if package["channel_selected"]["channel"]["name"] and package["channel_selected"]["channel"]["name"] != "stable" %} --channel {{ package["channel_selected"]["channel"]["name"] }}{% endif %}</code></p>
       </div>
     </div>
     <div class="col-4">

--- a/templates/details/_details-tab-navigation.html
+++ b/templates/details/_details-tab-navigation.html
@@ -2,16 +2,16 @@
   <nav class="p-tabs" data-js="tabs">
     <ul class="p-tabs__list" role="tablist">
       <li class="p-tabs__item" role="presentation">
-        <a href="/{{ package.name }}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'overview' %}aria-selected="true" {% endif %}>Overview</a>
+        <a href="/{{ package.name }}{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'overview' %}aria-selected="true" {% endif %}>Overview</a>
       </li>
       <li class="p-tabs__item" role="presentation">
-        <a href="/{{ package.name }}/docs" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'docs' %}aria-selected="true" {% endif %}>Docs</a>
+        <a href="/{{ package.name }}/docs{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'docs' %}aria-selected="true" {% endif %}>Docs</a>
       </li>
       <li class="p-tabs__item" role="presentation">
-        <a href="/{{ package.name }}/configure" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'configure' %}aria-selected="true" {% endif %}>Configure</a>
+        <a href="/{{ package.name }}/configure{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'configure' %}aria-selected="true" {% endif %}>Configure</a>
       </li>
       <li class="p-tabs__item" role="presentation">
-        <a href="/{{ package.name }}/actions" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'actions' %}aria-selected="true" {% endif %}>Actions</a>
+        <a href="/{{ package.name }}/actions{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'actions' %}aria-selected="true" {% endif %}>Actions</a>
       </li>
     </ul>
   </nav>

--- a/templates/details/actions.html
+++ b/templates/details/actions.html
@@ -70,5 +70,11 @@
 {% endblock%}
 
 {% block page_scripts %}
+  <script src="{{ versioned_static('js/dist/details.js') }}" defer></script>
   <script src="{{ versioned_static('js/dist/highlight-nav.js') }}" defer></script>
+  <script>
+   window.addEventListener("DOMContentLoaded", function () {
+       charmhub.details.init("{{ package.name }}");
+   });
+  </script>
 {% endblock %}

--- a/templates/details/docs.html
+++ b/templates/details/docs.html
@@ -51,9 +51,11 @@
 {% endblock%}
 
 {% block page_scripts %}
+  <script src="{{ versioned_static('js/dist/details.js') }}" defer></script>
   <script src="{{ versioned_static('js/dist/details_docs.js') }}" defer></script>
   <script>
     window.addEventListener("DOMContentLoaded", function () {
+      charmhub.details.init("{{ package.name }}");
       charmhub.details.docs.initSideNav();
     });
   </script>

--- a/templates/details/empty-docs.html
+++ b/templates/details/empty-docs.html
@@ -16,9 +16,11 @@
 {% endblock%}
 
 {% block page_scripts %}
+  <script src="{{ versioned_static('js/dist/details.js') }}" defer></script>
   <script src="{{ versioned_static('js/dist/details_docs.js') }}" defer></script>
   <script>
     window.addEventListener("DOMContentLoaded", function () {
+      charmhub.details.init("{{ package.name }}");
       charmhub.details.docs.initSideNav();
     });
   </script>

--- a/templates/partial/_channel-map.html
+++ b/templates/partial/_channel-map.html
@@ -1,6 +1,6 @@
 <button class="p-button--neutral u-no-margin--bottom" data-controls="channel-map-versions" aria-controls="channel-map-versions" data-js="channel-map">
   <span data-js="channel-map-selected">
-    {{ package["default-release"].channel.name }} {{ package["default-release"].revision.version }}
+    {{ package["channel_selected"].channel.name }} {{ package["channel_selected"].revision.version }}
   </span>
   &nbsp;&nbsp;<i class="p-icon--contextual-menu"></i>
 </button>

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -79,25 +79,44 @@ def index():
 FIELDS = [
     "result.media",
     "default-release",
+    "default-release.revision.metadata-yaml",
+    "default-release.revision.readme-md",
     "result.categories",
     "result.publisher.display-name",
     "result.summary",
     "channel-map",
+    "channel-map.revision.readme-md",
 ]
 
 
-@store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>')
-def details_overview(entity_name):
+def get_package(entity_name, channel_request):
     # Get entity info from API
     package = app.store_api.get_item_details(entity_name, fields=FIELDS)
-    package = logic.add_store_front_data(package)
+
+    channel_selected = logic.get_current_channel(
+        package["channel-map"], channel_request
+    )
+
+    if not channel_selected:
+        channel_selected = package["default-release"]
+
+    package = logic.add_store_front_data(package, channel_selected)
+    package["channel_selected"] = channel_selected
 
     for channel in package["channel-map"]:
         channel["channel"]["released-at"] = logic.convert_date(
             channel["channel"]["released-at"]
         )
 
-    readme = package["default-release"]["revision"]["readme-md"]
+    return package
+
+
+@store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>')
+def details_overview(entity_name):
+    channel_request = request.args.get("channel", default=None, type=str)
+    package = get_package(entity_name, channel_request)
+
+    readme = package["channel_selected"]["revision"]["readme-md"]
 
     # Remove Markdown comments
     readme = re.sub("(<!--.*-->)", "", readme, flags=re.DOTALL)
@@ -110,17 +129,22 @@ def details_overview(entity_name):
         package=package,
         readme=readme,
         package_type=package["type"],
+        channel_requested=channel_request,
     )
 
 
 @store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/docs')
 @store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/docs/<slug>')
 def details_docs(entity_name, slug=None):
-    package = app.store_api.get_item_details(entity_name, fields=FIELDS)
-    package = logic.add_store_front_data(package)
+    channel_request = request.args.get("channel", default=None, type=str)
+    package = get_package(entity_name, channel_request)
 
     if not package["store_front"]["docs_topic"]:
-        return render_template("details/empty-docs.html", package=package)
+        return render_template(
+            "details/empty-docs.html",
+            package=package,
+            channel_requested=channel_request,
+        )
 
     docs_url_prefix = f"/{package['name']}/docs"
 
@@ -154,6 +178,7 @@ def details_docs(entity_name, slug=None):
         "last_update": docs.index_document["updated"],
         "forum_url": docs.api.base_url,
         "topic_path": topic_path,
+        "channel_requested": channel_request,
     }
 
     return render_template("details/docs.html", **context)
@@ -161,24 +186,32 @@ def details_docs(entity_name, slug=None):
 
 @store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/configure')
 def details_configuration(entity_name):
-    package = app.store_api.get_item_details(entity_name, fields=FIELDS)
-    package = logic.add_store_front_data(package)
+    channel_request = request.args.get("channel", default=None, type=str)
+    package = get_package(entity_name, channel_request)
 
-    return render_template("details/configure.html", package=package)
+    return render_template(
+        "details/configure.html",
+        package=package,
+        channel_requested=channel_request,
+    )
 
 
 @store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/actions')
 def details_actions(entity_name):
-    package = app.store_api.get_item_details(entity_name, fields=FIELDS)
-    package = logic.add_store_front_data(package)
+    channel_request = request.args.get("channel", default=None, type=str)
+    package = get_package(entity_name, channel_request)
 
-    return render_template("details/actions.html", package=package)
+    return render_template(
+        "details/actions.html",
+        package=package,
+        channel_requested=channel_request,
+    )
 
 
 @store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/libraries')
 def details_libraries(entity_name):
-    package = app.store_api.get_item_details(entity_name, fields=FIELDS)
-    package = logic.add_store_front_data(package)
+    channel_request = request.args.get("channel", default=None, type=str)
+    package = get_package(entity_name, channel_request)
 
     libraries = get_charm_libraries()
 
@@ -187,6 +220,7 @@ def details_libraries(entity_name):
         entity_name=entity_name,
         package=package,
         libraries=libraries,
+        channel_requested=channel_request,
     )
 
 
@@ -196,8 +230,8 @@ def details_libraries(entity_name):
     + '"):entity_name>/libraries/<string:library_name>'
 )
 def details_library(entity_name, library_name):
-    package = app.store_api.get_item_details(entity_name, fields=FIELDS)
-    package = logic.add_store_front_data(package)
+    channel_request = request.args.get("channel", default=None, type=str)
+    package = get_package(entity_name, channel_request)
 
     lib_parts = library_name.split(".")
     lib_group = ".".join(lib_parts[:-2])
@@ -218,20 +252,29 @@ def details_library(entity_name, library_name):
         libraries=libraries,
         library=library,
         docstrings=docstrings,
+        channel_requested=channel_request,
     )
 
 
 @store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/history')
 def details_history(entity_name):
-    package = app.store_api.get_item_details(entity_name, fields=FIELDS)
-    package = logic.add_store_front_data(package)
+    channel_request = request.args.get("channel", default=None, type=str)
+    package = get_package(entity_name, channel_request)
 
-    return render_template("details/history.html", package=package)
+    return render_template(
+        "details/history.html",
+        package=package,
+        channel_requested=channel_request,
+    )
 
 
 @store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/integrate')
 def details_integrate(entity_name):
-    package = app.store_api.get_item_details(entity_name, fields=FIELDS)
-    package = logic.add_store_front_data(package)
+    channel_request = request.args.get("channel", default=None, type=str)
+    package = get_package(entity_name, channel_request)
 
-    return render_template("details/integrate.html", package=package)
+    return render_template(
+        "details/integrate.html",
+        package=package,
+        channel_requested=channel_request,
+    )


### PR DESCRIPTION
## Done

- Refactor code for channel map
- Refactor code for details header page `get_package`
- Add ability to get the data for a specific channel
- Add back the channel map in header

## QA

- Use the staging API:
```
On file .env.local:

CHARMSTORE_API_URL=https://api.staging.snapcraft.io/
```
- `dotrun`
- http://0.0.0.0:8045/activemq?channel=stable
- Navigate in the pages and make sure that the channel doesn't change (see URL)
- http://0.0.0.0:8045/activemq
- Should work as usual too
- http://0.0.0.0:8045/activemq?channel=blablblablablabl
- Will default to the default channel (field from API) in most cases here `stable`

Unfortunately  there are no charms with different data between channels for now....

Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/113
