### PR TITLE
Add logo for docsstring

### DIFF
--- a/static/sass/_pattern_p-icon.scss
+++ b/static/sass/_pattern_p-icon.scss
@@ -79,4 +79,16 @@
 
     background-image: url("https://assets.ubuntu.com/v1/2f401159-Code.svg");
   }
+
+  .p-icon--update {
+    @extend %icon;
+
+    background-image: url("https://assets.ubuntu.com/v1/81ea67af-Update.svg");
+  }
+
+  .p-icon--docstrings {
+    @extend %icon;
+
+    background-image: url("https://assets.ubuntu.com/v1/434fb519-Docstrings.svg");
+  }
 }

--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -51,7 +51,9 @@
             <div class="p-button-group">
               <div class="p-button-group__inner">
                 <div class="p-button-group__buttons">
-                  <a href="#docstrings" class="p-button-group__button" data-js="tab-button" data-href="#docstrings"><i class="p-icon--menu">Docstrings</i><span>Docstrings</span></a>
+                  <a href="#docstrings" class="p-button-group__button" data-js="tab-button" data-href="#docstrings">
+                    <i class="p-icon--docstrings">Docstrings</i><span>Docstrings</span>
+                  </a>
                   <a href="#source-code" class="p-button-group__button" data-js="tab-button" data-href="#source-code"><i class="p-icon--code">Code</i><span>Source code</span></a>
                 </div>
               </div>
@@ -63,20 +65,10 @@
                 <a href="#" class="is-always-color-link has-icon"><i class="p-icon--download">Download</i><span>Download</span></a>
               </li>
               <li class="p-inline-list__item has-icon">
-                <i class="p-icon--revision">Last revision</i>26 June 2019
+                <i class="p-icon--update">Last updated</i>26 June 2019
               </li>
-              <li class="p-inline-list__item">
-                <form class="p-form p-form--inline">
-                  <label for="version">Library version</label>
-                  <select name="version" id="version" class="u-no-margin--bottom" onChange="this.form.submit()">
-                    <option value="2.93">2.93</option>
-                    <option value="1.9">1.9</option>
-                    <option value="1.2">1.2</option>
-                  </select>
-                  <noscript>
-                    <input type="submit" class="p-button--neutral" style="margin-inline-start: 0.5rem;">
-                  </noscript>
-                </form>
+              <li class="p-inline-list__item has-icon">
+                <i class="p-icon--revision">Revision</i>Library version 2.93
               </li>
             </ul>
           </li>


### PR DESCRIPTION
## Done

- Add logo for docs string
- Add logo for update date

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- http://0.0.0.0:8045/activemq/libraries/charms.apache.v2.http
- Make sure it matches the design: https://zpl.io/2pEQzWE

![image](https://user-images.githubusercontent.com/2707508/98129267-d87bc700-1eb0-11eb-8b45-cbee77c0cdcd.png)


## Issue / Card

Fixes #482 