### PR TITLE
Add link to tutorial for docs

### DIFF
--- a/templates/details/empty-docs.html
+++ b/templates/details/empty-docs.html
@@ -10,7 +10,7 @@
         Looks like you haven’t added any docs yet. Docs help your users learn how to use your charms, and encourage them to use them the way you intended.
       </p>
       <p>
-        <a class="p-button--positive" href="#">Learn how to add docs to your charm</a>
+        <a class="p-button--positive" href="https://charmhub.io/tutorials/add-documentation-to-your-charm">Learn how to add docs to your charm</a>
       </p>
   </div>
 {% endblock%}


### PR DESCRIPTION
## Done

- Add link to tutorial to add documentation to your site

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- http://0.0.0.0:8045/activemq/docs
- The button should link to the discourse tutorial (the tutorials on the site will be linked once tutorials are live)

## Issue / Card

Fixes #468 
