### PR TITLE
Default empty readme to empty string

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -140,7 +140,9 @@ def details_overview(entity_name):
     channel_request = request.args.get("channel", default=None, type=str)
     package = get_package(entity_name, channel_request)
 
-    readme = package["channel_selected"]["revision"]["readme-md"]
+    readme = package["channel_selected"]["revision"].get(
+        "readme-md", "No readme available"
+    )
 
     # Remove Markdown comments
     readme = re.sub("(<!--.*-->)", "", readme, flags=re.DOTALL)


### PR DESCRIPTION
## Done

It seems that there is a way to have a charm without readme.
This is not a pattern that we want to encourage but currently the application 500.
Default the readme field to empty string to fix this.

## QA

     

- On file .env.local:
```
CHARMSTORE_API_URL=https://api.staging.snapcraft.io/
```
- `dotrun`
- http://0.0.0.0:8045/hasan-test


## Issue / Card

Fixes #497 
