### PR TITLE
Add highlight js for library color syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-jest": "23.20.0",
     "eslint-plugin-prettier": "3.1.4",
     "expose-loader": "1.0.0",
+    "highlight.js": "10.3.2",
     "lint-staged": "10.2.13",
     "postcss-cli": "7.1.2",
     "prettier": "2.1.1",

--- a/static/js/src/base/highlight.js
+++ b/static/js/src/base/highlight.js
@@ -1,0 +1,7 @@
+import hljs from 'highlight.js/lib/core';
+import python from 'highlight.js/lib/languages/python';
+import 'highlight.js/styles/github.css';
+
+hljs.registerLanguage('python', python);
+
+export { hljs };

--- a/templates/details/libraries/library.html
+++ b/templates/details/libraries/library.html
@@ -23,15 +23,18 @@
       <hr class="p-separator--medium">
       <h4>Source code</h4>
     </div>
-    <pre><code>{{ library["content"] }}</code></pre>
+    <pre id="python-code"><code>{{ library["content"] }}</code></pre>
   </div>
 {% endblock%}
 
 {% block page_scripts %}
 <script src="{{ versioned_static('js/dist/details_libraries.js') }}" defer></script>
+<script src="{{ versioned_static('js/dist/highlight-js.js') }}" defer></script>
 <script>
   window.addEventListener("DOMContentLoaded", function () {
     charmhub.details.libraries.init("[data-js='tab-button']", "[data-js='tab-content']");
+
+    charmhub.highlight.hljs.highlightBlock(document.getElementById('python-code'));
   });
 </script>
 {% endblock %}

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -13,4 +13,5 @@ module.exports = {
   listing: "./static/js/src/publisher/listing-page.js",
   settings: "./static/js/src/publisher/settings.js",
   "highlight-nav": "./static/js/src/libs/highlight-nav.js",
+  "highlight-js": "./static/js/src/base/highlight.js",
 };

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -36,6 +36,12 @@ module.exports = [
     use: ["expose-loader?exposes=charmhub.base", "babel-loader"],
   },
   {
+    test: require.resolve(
+        __dirname + "/static/js/src/base/highlight.js"
+    ),
+    use: ["expose-loader?exposes=charmhub.highlight", "babel-loader"],
+  },
+  {
     test: require.resolve(__dirname + "/static/js/src/public/store/index.js"),
     use: ["expose-loader?exposes=charmhub.store", "babel-loader"],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,6 +3551,11 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+highlight.js@10.3.2:
+  version "10.3.2"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.3.2.tgz#135fd3619a00c3cbb8b4cd6dbc78d56bfcbc46f1"
+  integrity sha512-3jRT7OUYsVsKvukNKZCtnvRcFyCJqSEIuIMsEybAXRiFSwpt65qjPd/Pr+UOdYt7WJlt+lj3+ypUsHiySBp/Jw==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
## Done

- Add highlight.js
- Add color for python code on libraries pages

## QA

- `dotrun`
- http://0.0.0.0:8045/activemq/libraries/charms.apache.v2.http
- Go on source code 
![image](https://user-images.githubusercontent.com/2707508/98174538-f23aff80-1eec-11eb-8a38-94e9c2b5b5f5.png)
- Make sure python code is well syntaxed colored.


## Issue / Card

Fixes #483 
