### PR TITLE
Highlight channel on hover

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -241,6 +241,12 @@ $theme-default-nav: dark;
     table tr.is-active td {
       font-weight: 400;
     }
+
+    tbody tr {
+      &:hover {
+        background-color: $color-light;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Done

- Highlight the channel on `hover` on the channelmap on details page

## QA

- `dotrun`
- http://0.0.0.0:8045/minio
- Click on the channel map 
![image](https://user-images.githubusercontent.com/2707508/98234610-9dcd6980-1f58-11eb-8b09-68b0095f8402.png)
- Make sure that when you hover a channel you get a light grey on the row
![image](https://user-images.githubusercontent.com/2707508/98234725-be95bf00-1f58-11eb-8295-7d12380ace81.png)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1676
