### PR TITLE
Fix up charm actions tab

### DIFF
--- a/static/sass/_pattern_p-list.scss
+++ b/static/sass/_pattern_p-list.scss
@@ -30,7 +30,7 @@
     }
   }
 
-  .p-list--divided.has-sparator-centered {
+  .p-list--divided.has-separator-centered {
     .p-list__item {
       &:not(:first-of-type) {
         margin-block-start: $spv-inner--medium;

--- a/templates/details/actions.html
+++ b/templates/details/actions.html
@@ -20,7 +20,7 @@
         </div>
       </div>
       <div class="col-9 col-large-6">
-        <ul class="p-list--divided has-sparator-centered">
+        <ul class="p-list--divided has-separator-centered">
           {% for action, action_data in package.store_front.actions.items() %}
             <li class="p-list__item action-section" id="{{ action }}">
               <p class="p-heading--4">{{ action }}</p>

--- a/templates/details/actions.html
+++ b/templates/details/actions.html
@@ -22,35 +22,40 @@
       <div class="col-9 col-large-6">
         <ul class="p-list--divided has-separator-centered">
           {% for action, action_data in package.store_front.actions.items() %}
-            <li class="p-list__item action-section" id="{{ action }}">
+            <li class="p-list__item" style="margin-bottom: 1rem;" id="{{ action }}">
               <p class="p-heading--4">{{ action }}</p>
               {% if action_data.description %}
                 <p class="u-no-padding--top">{{ action_data.description }}</p>
               {% endif %}
               {% if action_data.params %}
-                <table class="p-table--no-borders">
-                  <tr>
-                    <td class="u-align--right u-text--muted" style="width: 25%;">Params</td>
-                    <td>
+                <dl>
+                  <dt>Params</dt>
+                  <dl>
+                    <ul class="p-list action-list" style="margin-left: 1rem;">
                       {% for param, param_data in action_data.params.items() %}
-                        <p class="u-no-padding--top"><strong class="vertical-separator">{{ param }}</strong>{{ param_data.type }}</p>
+                      <li>
+                        <p>
+                          <span class="vertical-separator">{{ param }}</span>
+                          <span class="u-text--muted">{{ param_data.type }}</span>
+                        </p>
                         <p class="u-no-padding--top">{{ param_data.description }}</p>
+                      </li>
                       {% endfor %}
+                    </ul>
+                  </dl>
+                </dl>
+                {% if action_data.required %}
+                  <tr>
+                    <td class="u-align--right u-text--muted" style="width: 25%;">Required</td>
+                    <td>
+                      <p class="u-no-padding--top u-no-margin--bottom">
+                        {% for item in action_data.required %}
+                          {{ item }}{% if not loop.last %},{% endif %}
+                        {% endfor %}
+                      </p>
                     </td>
                   </tr>
-                  {% if action_data.required %}
-                    <tr>
-                      <td class="u-align--right u-text--muted" style="width: 25%;">Required</td>
-                      <td>
-                        <p class="u-no-padding--top u-no-margin--bottom">
-                          {% for item in action_data.required %}
-                            {{ item }}{% if not loop.last %},{% endif %}
-                          {% endfor %}
-                        </p>
-                      </td>
-                    </tr>
-                  {% endif %}
-                </table>
+                {% endif %}
               {% endif %}
             </li>
           {% endfor %}

--- a/templates/details/configure.html
+++ b/templates/details/configure.html
@@ -20,7 +20,7 @@
       </div>
     </div>
     <div class="col-9 col-large-6">
-      <ul class="p-list--divided has-sparator-centered">
+      <ul class="p-list--divided has-separator-centered">
         {% for key, value in package.store_front.config.options.items() %}
         <li class="p-list__item" id="{{ key }}">
           <p class="p-heading--4">{{ key }} <span class="u-text--muted">&VerticalLine; {{ value.type }}</span></p>


### PR DESCRIPTION
## Done

- Fix typo
- Fix up charm actions tab to match design

## QA

- Check out this feature branch
- Run the site using instructions here: https://github.com/canonical-web-and-design/charmhub.io/issues/479
- View the site locally in your web browser at: http://localhost:8045/ubuntu-qa/actions
- Cross ref with design here: https://zpl.io/Vx7y57R

Note: `ubuntu-qa` only has one action so you will need to add extra list items via dev tools

<img width="1257" alt="Screenshot 2020-11-05 at 14 00 33" src="https://user-images.githubusercontent.com/505570/98250435-51d9ef00-1f6f-11eb-96dd-56ac0be859a2.png">

## Issue / Card

Fixes #479