### PR TITLE
Update typography on charm libraries template

### DIFF
--- a/static/sass/_pattern_p-typography.scss
+++ b/static/sass/_pattern_p-typography.scss
@@ -12,5 +12,17 @@
     h5 + pre {
       margin-block-start: 1.1rem;
     }
+
+    &__divider {
+      margin: 2rem 0;
+    }
+
+    &__definition {
+      padding-left: 2rem;
+    }
+
+    &__label {
+      font-weight: 300;
+    }
   }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -293,7 +293,7 @@ body {
   max-width: 72rem;
 }
 
-// Override h3 font weight
+// Override h3 font weight based on design feedback from MS
 .p-heading--3,
 h3 {
   font-weight: 200;

--- a/templates/details/libraries/library.html
+++ b/templates/details/libraries/library.html
@@ -5,17 +5,43 @@
 {% block libraries_content %}
 
   <div id="docstrings" data-js="tab-content" class="p-docstring">
-    {{ docstrings['html'] | safe }}
+    <div class="p-docstring__intro">
+      {{ docstrings['html'] | safe }}
+    </div>
 
-    {% for group in docstrings['content'] %}
-      <h4>{{ group["name"]}} </h4>
-      {{ group["html"] | safe }}
+    <div class="p-docstring__docs">
+      {% for group in docstrings['content'] %}
+        <hr class="p-docstring__divider" />
+        <h4 class="p-docstring__heading">
+          <span class="u-text--muted p-docstring__label">{{ group["type"].lower()}} | </span>
+          {% if group["type"] == 'Function' %}
+            {{ group["name"] }}
+            {% if group["signature"].strip != "None" %}
+              {{ group["signature"] }}
+            {% endif %}
+          {% else %}
+            {{ group["name"]}}
+          {% endif %}
 
-      {% for item in group['content'] %}
-        <h5>{{ item["name"]}}</h5>
-        {{ item["html"] | safe }}
+        </h4>
+        <div class="p-docstring__definition">
+          {{ group["html"] | safe }}
+          {% for item in group['content'] %}
+            <h5>
+              <span class="u-text--muted p-docstring__label">{{ item["type"].lower()}} | </span>
+              {% if item["type"] == 'Function' %}
+                {{ item["name"] }}{{ item["signature"] }}
+              {% else %}
+                {{ item["name"]}}
+              {% endif %}
+            </h5>
+            <div class="p-docstring__definition">
+              {{ item["html"] | safe }}
+            </div>
+          {% endfor %}
+        </div>
       {% endfor %}
-    {% endfor %}
+    </div>
   </div>
 
   <div id="source-code" data-js="tab-content">


### PR DESCRIPTION
## Done

Update typography on charm libraries template

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045/ubuntu-qa/libraries/charms.apache.v2.http
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check template against design https://app.zeplin.io/project/5f92a9530029eeac84ae9589/screen/5f92a9b11267a560a4e173f8

## Issue / Card

Fixes #502
