### PR TITLE
Fix None signature

### DIFF
--- a/templates/details/libraries/library.html
+++ b/templates/details/libraries/library.html
@@ -16,9 +16,7 @@
           <span class="u-text--muted p-docstring__label">{{ group["type"].lower()}} | </span>
           {% if group["type"] == 'Function' %}
             {{ group["name"] }}
-            {% if group["signature"].strip != "None" %}
-              {{ group["signature"] }}
-            {% endif %}
+            {% if group["signature"].strip %}{{ group["signature"] }}{% else %}(){% endif %}
           {% else %}
             {{ group["name"]}}
           {% endif %}
@@ -30,7 +28,8 @@
             <h5>
               <span class="u-text--muted p-docstring__label">{{ item["type"].lower()}} | </span>
               {% if item["type"] == 'Function' %}
-                {{ item["name"] }}{{ item["signature"] }}
+                {{ item["name"] }}
+                {% if item["signature"].strip %}{{ item["signature"] }}{% else %}(){% endif %}
               {% else %}
                 {{ item["name"]}}
               {% endif %}


### PR DESCRIPTION
## Done

When no signature just display `()`

## QA

- `dotrun`
- http://0.0.0.0:8045/jenkins/libraries/charms.apache.v2.http

![image](https://user-images.githubusercontent.com/2707508/98286889-8dd77900-1f9c-11eb-8fcd-815e8153a3d5.png)
