### PR TITLE
Add help icon to Publisher suggests in libraries tab

### DIFF
--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -5,7 +5,7 @@
 {% block details_content %}
   <div class="row is-wide p-details-tab__content">
     <div class="col-3 has-space--right">
-      <div class="p-side-navigation is-at-the-top" id="drawer">
+      <div class="p-side-navigation is-at-the-top" id="drawer" style="overflow-y: visible;">
         <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation
         </a>
@@ -23,7 +23,18 @@
           </ul>
           <ul class="p-side-navigation__list">
             <li class="p-side-navigation__item--title">
-              <span class="p-side-navigation__text">Publisher suggests</span>
+              <span class="p-side-navigation__text">
+                Publisher suggests
+                <div class="p-side-navigation__status u-hide--small">
+                  <span class="p-tooltip--right" aria-describedby="rght">
+                    <i class="p-icon--information" class="p-tooltip--right" aria-describedby="publisher-suggests-info"></i>
+                    <span class="p-tooltip__message" role="tooltip" id="publisher-suggests-info">These are libraries that the charm author has chosen to share
+with other developers to use in conjunction with this charm.
+The libraries recommended here could be from an older version
+than the latest.</span>
+                  </a>
+                </div>
+              </span>
             </li>
             {% for group in libraries.keys() %}
             <li class="p-side-navigation__item">


### PR DESCRIPTION
## Done
Add help icon to Publisher suggests to libraries tab

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/ubuntu-qa/libraries
- Hover over the info icon in the side navigation
- See that it displays a tooltip
- See the content matches [the design](https://app.zeplin.io/project/5f92a9530029eeac84ae9589/screen/5f96de35c9398211616ee30f)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/466

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/98295015-c54c2280-1fa8-11eb-9cbd-7d39e4692051.png)
