### PR TITLE
Remove discoures authentication

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -13,16 +13,6 @@ env:
   - name: CANDID_API_URL
     value: https://api.staging.jujucharms.com/identity/
 
-  - name: DISCOURSE_API_KEY
-    secretKeyRef:
-      key: discourse-api-key
-      name: charmhub-io
-
-  - name: DISCOURSE_API_USERNAME
-    secretKeyRef:
-      key: discourse-api-username
-      name: charmhub-io
-
   - name: SEARCH_API_KEY
     secretKeyRef:
       key: google-custom-search-key

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -1,7 +1,6 @@
 import datetime
 import re
 import json
-import os
 
 from bs4 import BeautifulSoup
 from mistune import Markdown, Renderer
@@ -12,16 +11,11 @@ from flask import request
 from ruamel.yaml import YAML
 from talisker import requests
 
-DISCOURSE_API_KEY = os.getenv("DISCOURSE_API_KEY")
-DISCOURSE_API_USERNAME = os.getenv("DISCOURSE_API_USERNAME")
-
 
 session = requests.get_session()
 discourse_api = DiscourseAPI(
     base_url="https://discourse.charmhub.io/",
     session=session,
-    api_key=DISCOURSE_API_KEY,
-    api_username=DISCOURSE_API_USERNAME,
 )
 
 _yaml = YAML(typ="rt")


### PR DESCRIPTION
## Done

- Remove authentication for discourse since not required anymore

## QA

- File `.env.local `
```
CHARMSTORE_API_URL=https://api.staging.snapcraft.io/
```
- `dotrun`
- 0.0.0.0:8045/mattermost-charmers-mattermost/docs
-  Should work as usual


## Issue / Card

Fixes #516
