### PR TITLE
Add discourse.juju.is url for old docs links

### DIFF
--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -372,10 +372,18 @@ def get_docs_topic_id(metadata_yaml):
     Return discourse topic ID or None
     """
     base_url = discourse_api.base_url
+    # TODO this is a temporary fix (the only charm is mattermost)
+    old_url = "https://discourse.juju.is"
     docs_link = metadata_yaml.get("docs")
 
-    if docs_link and docs_link.startswith(base_url):
-        topic_id = docs_link[len(base_url) :].split("/")[3]
+    if docs_link:
+        if docs_link.startswith(base_url):
+            topic_id = docs_link[len(base_url) :].split("/")[3]
+        elif docs_link.startswith(old_url):
+            topic_id = docs_link[len(old_url) :].split("/")[3]
+        else:
+            return None
+
         if topic_id.isnumeric():
             return topic_id
 


### PR DESCRIPTION
## Done

- Some charms are still using `discourse.juju.is` in their documentation link
- This is a temporary solution while the charmers update their URL

## QA

- On staging
- `dotrun`
- http://0.0.0.0:8045/mattermost-charmers-mattermost/docs
