### PR TITLE
Use large summary for non charm pages

### DIFF
--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -11,7 +11,9 @@
 
     <meta property="og:title" content="{{ self.title() }}" />
     <meta property="og:description" content="{{ self.meta_description() }}" />
-    <meta property="og:image" content="{% block meta_image %}https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_200/https://assets.ubuntu.com/v1/3f1974e5-CH+Logo+Metadata.jpg{% endblock %}" />
+    <meta property="og:image" content="{% block meta_image %}https://assets.ubuntu.com/v1/3f1974e5-CH+Logo+Metadata.jpg{% endblock %}" />
+    <meta property="og:image:width" content="{% block meta_image_width %}1080{% endblock %}" />
+    <meta property="og:image:height" content="{% block meta_image_height %}512{% endblock %}" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://charmhub.io{{ request.path }}" />
     <meta property="twitter:title" content="{{ self.title() }}">

--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -11,9 +11,10 @@
 
     <meta property="og:title" content="{{ self.title() }}" />
     <meta property="og:description" content="{{ self.meta_description() }}" />
-    <meta property="og:image" content="{% block meta_image %}https://assets.ubuntu.com/v1/3f1974e5-CH+Logo+Metadata.jpg{% endblock %}" />
+    <meta property="og:image" content="{% block meta_image %}https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_1080,h_512/https://assets.ubuntu.com/v1/3f1974e5-CH+Logo+Metadata.jpg{% endblock %}" />
     <meta property="og:image:width" content="{% block meta_image_width %}1080{% endblock %}" />
     <meta property="og:image:height" content="{% block meta_image_height %}512{% endblock %}" />
+    <meta property="og:image:alt" content="{% block meta_image_alt %}Charmhub banner{% endblock %}" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://charmhub.io{{ request.path }}" />
     <meta property="twitter:title" content="{{ self.title() }}">

--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -16,7 +16,7 @@
     <meta property="og:url" content="https://charmhub.io{{ request.path }}" />
     <meta property="twitter:title" content="{{ self.title() }}">
     <meta property="twitter:description" content="{{ self.meta_description() }}">
-    <meta property="twitter:card" content="summary">
+    <meta property="twitter:card" content="{% block meta_twitter_card %}summary_large_image{% endblock %}">
     <meta property="twitter:site" content="@ubuntucloud">
     <meta property="twitter:creator" content="@ubuntucloud">
     <meta property="twitter:image" content="{{ self.meta_image() }}">

--- a/templates/details/details_layout.html
+++ b/templates/details/details_layout.html
@@ -4,6 +4,8 @@
 {% block meta_description %}Deploy the latest version of {{ format_slug(package.name) }} as a Kubernetes Operator on any cloud. {{ package.result.summary }}{% endblock %}
 {% block meta_image %}{% if package["store_front"]["icons"] %}https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_200,h_200/{{ package.store_front.icons[0] }}{% else %}"https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg"{% endif %}{% endblock %}
 {% block meta_twitter_card %}summary{% endblock %}
+{% block meta_image_width %}200{% endblock %}
+{% block meta_image_height %}200{% endblock %}
 
 {% block content %}
   {% include "details/_details-header.html" %}

--- a/templates/details/details_layout.html
+++ b/templates/details/details_layout.html
@@ -3,6 +3,7 @@
 {% block title %}Deploy {{ format_slug(package.name) }} using Charmhub - The Open Operator Collection{% endblock %}
 {% block meta_description %}Deploy the latest version of {{ format_slug(package.name) }} as a Kubernetes Operator on any cloud. {{ package.result.summary }}{% endblock %}
 {% block meta_image %}{% if package["store_front"]["icons"] %}https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_200,h_200/{{ package.store_front.icons[0] }}{% else %}"https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg"{% endif %}{% endblock %}
+{% block meta_twitter_card %}summary{% endblock %}
 
 {% block content %}
   {% include "details/_details-header.html" %}

--- a/templates/details/details_layout.html
+++ b/templates/details/details_layout.html
@@ -6,6 +6,7 @@
 {% block meta_twitter_card %}summary{% endblock %}
 {% block meta_image_width %}200{% endblock %}
 {% block meta_image_height %}200{% endblock %}
+{% block meta_image_alt %}{{ format_slug(package.name) }} charm logo{% endblock %}
 
 {% block content %}
   {% include "details/_details-header.html" %}


### PR DESCRIPTION
## Done

On pages that are not charm pages: use `summary_large_image` to display a large rectangle image
eg
![image](https://user-images.githubusercontent.com/2707508/98481527-d38d7f00-21f2-11eb-9f00-f56224d23ee8.png)

On charm pages use `summary` to show just the icon (square)
eg 
![image](https://user-images.githubusercontent.com/2707508/98481058-a25f7f80-21ef-11eb-98e6-273899585011.png)


## QA

https://developers.facebook.com/tools/debug/?q=charmhub.io%2Fceph
https://cards-dev.twitter.com/validator

Test with a few links from demo
