### PR TITLE
Add metadata for tutorials pages

### DIFF
--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -9,7 +9,7 @@
 
     <title>{% block title %}Charmhub - The Open Operator Collection{% endblock title %}</title>
 
-    <meta property="description" content="{{ self.meta_description() }}" />
+    <meta name="description" content="{{ self.meta_description() }}" />
     <meta property="og:title" content="{{ self.title() }}" />
     <meta property="og:description" content="{{ self.meta_description() }}" />
     <meta property="og:image" content="{% block meta_image %}https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_1080,h_512/https://assets.ubuntu.com/v1/3f1974e5-CH+Logo+Metadata.jpg{% endblock %}" />

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -2,6 +2,10 @@
 
 {% block title %}Learn Kubernetes operators by example with our community tutorials{% endblock %}
 
+{% block meta_description %}Tutorials for Charmhub - The Open Operator Collection{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1CfwkYsuBqDXgII02_HFMfqJNNZYkcA_XS-w5ySR09lY{% endblock meta_copydoc %}
+
 {% block content %}
 <section class="p-strip--accent is-shallow">
   <div class="u-fixed-width">

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -2,6 +2,8 @@
 
 {% block title %}{{ document["title"] }} | Charmhub{% endblock %}
 
+{% block meta_description %}Tutorials for Charmhub - The Open Operator Collection{% endblock %}
+
 {% block content %}
 
 <section class="p-strip--accent is-shallow">


### PR DESCRIPTION
## Done

Fix meta for tutorial pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/tutorials
- Make sure pages still work
