### PR TITLE
Fix channel map on libraries tab

### DIFF
--- a/templates/details/libraries/library.html
+++ b/templates/details/libraries/library.html
@@ -53,6 +53,9 @@
 {% endblock%}
 
 {% block page_scripts %}
+
+{{ super() }}
+
 <script src="{{ versioned_static('js/dist/details_libraries.js') }}" defer></script>
 <script src="{{ versioned_static('js/dist/highlight-js.js') }}" defer></script>
 <script>


### PR DESCRIPTION
## Done

- Fix channel map on libraries tab

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click on the channel map button under http://0.0.0.0:8045/ceph/libraries/testlibfacu1, it should work

## Issue / Card

Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/535
