### PR TITLE
Stop indexing pages not ready

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -4,6 +4,8 @@
 
 {% block meta_description %}Documentation for Charmhub - The Open Operator Collection{% endblock %}
 
+{% block extra_meta %}<meta name="robots" content="noindex, nofollow">{% endblock %}
+
 {% block content %}
 
 {% include "partial/_docs-search.html" %}

--- a/templates/topics/kubernetes.html
+++ b/templates/topics/kubernetes.html
@@ -4,6 +4,8 @@
 
 {% block meta_description %}The Open Operator Collection{% endblock %}
 
+{% block extra_meta %}<meta name="robots" content="noindex, nofollow">{% endblock %}
+
 {% block content %}
 <section class="p-strip--overlap p-strip-topic--kubernetes">
   <div class="u-fixed-width">

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -6,6 +6,8 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1CfwkYsuBqDXgII02_HFMfqJNNZYkcA_XS-w5ySR09lY{% endblock meta_copydoc %}
 
+{% block extra_meta %}<meta name="robots" content="noindex, nofollow">{% endblock %}
+
 {% block content %}
 <section class="p-strip--accent is-shallow">
   <div class="u-fixed-width">


### PR DESCRIPTION
## Done

Prevent from indexing pages not ready for release day

## QA

- `dotrun`
- Make sure pages http://0.0.0.08045:/tutorials http://0.0.0.08045:/docs and http://0.0.0.08045:/topics/kubernetes have the header `<meta name="robots" content="noindex, nofollow">`


## Issue / Card

Fixes #544 