### PR TITLE
Prefix charms install instructions

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -65,7 +65,7 @@
           </div>
         </div>
         {% include "partial/_channel-map.html" %}
-        <p class="p-charm-header__code"><code>juju deploy <span data-js="channel-cli">{{ package.name }}</span>{% if package["channel_selected"]["channel"]["name"] and package["channel_selected"]["channel"]["name"] != "stable" %} --channel {{ package["channel_selected"]["channel"]["name"] }}{% endif %}</code></p>
+        <p class="p-charm-header__code"><code>juju deploy {% if package["cs"] %}cs:{% endif %}{{ package.name }}{% if package["channel_selected"]["channel"]["name"] and package["channel_selected"]["channel"]["name"] != "stable" %} --channel {{ package["channel_selected"]["channel"]["name"] }}{% endif %}</code></p>
       </div>
     </div>
     <div class="col-4">

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -123,6 +123,12 @@ FIELDS = [
     "channel-map.revision.readme-md",
 ]
 
+# TODO This is a temporary fix for release
+# Store will release a field to flag if a charm needs the
+# prefix cs:
+# CS is the list of charms that don't need prefix "cs:"
+CS = []
+
 
 def get_package(entity_name, channel_request):
     # Get entity info from API
@@ -137,6 +143,9 @@ def get_package(entity_name, channel_request):
 
     package = logic.add_store_front_data(package, channel_selected)
     package["channel_selected"] = channel_selected
+
+    if package["name"] not in CS:
+        package["cs"] = True
 
     for channel in package["channel-map"]:
         channel["channel"]["released-at"] = logic.convert_date(


### PR DESCRIPTION
## Done

Some charms will have the ability to be installed without `cs:`
All the rest of charms will have `cs:` in their install instructions

## QA

- `dotrun`
- http://0.0.0.0:8045/jenkins
- Make sure every charm has `cs:<charm>` in their install instruction
- Locally if you add a charm in the array `CS = ["jenkins"]` then the charm jenkins shouldn't be prefixed by `cs:` 


## Issue / Card

Fixes #546 
