### PR TITLE
Add CTA for more operators

### DIFF
--- a/static/js/src/public/store/filters.js
+++ b/static/js/src/public/store/filters.js
@@ -33,6 +33,19 @@ class Filters {
     });
   }
 
+  toggleMoreOperatorsButton() {
+    const moreOperatorsButton = document.getElementById("more-operators");
+    if (
+      this._filters.category &&
+      this._filters.category.length &&
+      !this._filters.category.includes("all")
+    ) {
+      moreOperatorsButton.classList.remove("u-hide");
+    } else {
+      moreOperatorsButton.classList.add("u-hide");
+    }
+  }
+
   /**
    * Return the number of active filters
    * without including 'sort' and `q`
@@ -117,6 +130,8 @@ class Filters {
         this.submitButtonMobile.innerHTML = `Show results (${filteredItemsNumber})`;
       }
     }
+
+    this.toggleMoreOperatorsButton();
   }
 
   updateUI() {

--- a/static/js/src/public/store/filters.test.js
+++ b/static/js/src/public/store/filters.test.js
@@ -47,6 +47,8 @@ describe("Filters", () => {
           <a href="/store" data-js="mobile-sort-reveal-button" class="has-icon p-store__button"><i class="p-icon--sort"></i>Sort by</a>
           <a href="/store" data-js="mobile-filter-reveal-button" class="has-icon p-store__button"><i class="p-icon--filter"></i>Filters</a>
         </div>
+
+        <a href="?category=all" class="p-button--positive u-hide" id="more-operators">See more operators</a>
         `;
 
       document.body.appendChild(filterElements);

--- a/templates/partial/_filters.html
+++ b/templates/partial/_filters.html
@@ -101,4 +101,8 @@
       </div>
     {% endif %}
   </div>
+
+  <div class="u-align--center" style="margin-top: 1rem;">
+    <a href="?category=all" class="p-button--positive u-hide" id="more-operators">See more operators</a>
+  </div>
 </div>


### PR DESCRIPTION
## Done

Add CTA which only appears if a filter is applied to show all operators

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- If there is a filter there should be a button at the bottom of the list
- Clicking the button should reload the page with the "all" filter and the button should not be there

## Issue / Card

Fixes #543