### PR TITLE
Fix spacing for info icon on libraries page

### DIFF
--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -21,6 +21,7 @@
               <a class="p-side-navigation__link" {% if request.path.endswith('libraries') %}aria-current="page"{% endif %} href="/{{ entity_name }}/libraries">Introduction</a>
             </li>
           </ul>
+          {% if libraries %}
           <ul class="p-side-navigation__list">
             <li class="p-side-navigation__item--title">
               <span class="p-side-navigation__text">
@@ -55,6 +56,7 @@ than the latest.</span>
             </li>
             {% endfor %}
           </ul>
+          {% endif %}
         </nav>
       </div>
     </div>

--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -25,7 +25,7 @@
             <li class="p-side-navigation__item--title">
               <span class="p-side-navigation__text">
                 Publisher suggests
-                <div class="p-side-navigation__status u-hide--small">
+                <div class="p-side-navigation__status u-no-margin--left u-hide--small">
                   <span class="p-tooltip--right" aria-describedby="rght">
                     <i class="p-icon--information" class="p-tooltip--right" aria-describedby="publisher-suggests-info"></i>
                     <span class="p-tooltip__message" role="tooltip" id="publisher-suggests-info">These are libraries that the charm author has chosen to share


### PR DESCRIPTION
## Done

Fix spacing for info icon on libraries page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/cassandra/libraries
- Check that the icon next to "Publisher suggests" doesn't have too much space between it and the text

## Issue / Card

Fixes #512 