### PR TITLE
Refactor search view

### DIFF
--- a/templates/partial/_filters.html
+++ b/templates/partial/_filters.html
@@ -60,7 +60,7 @@
   <div class="p-layout__filter-container">
     <div class="p-layout__left">
       <div class="p-muted-heading" data-js="filtered-items">
-        Showing {{ show_elements }} of {{ results|length }} items
+        Showing {{ results|length }} of {{ total_charms }} items
       </div>
       <div class="p-layout__sort-mobile">
         <a href="/" data-js="mobile-platform-reveal-button" class="has-icon p-store__button is-always-color-link"><i class="p-icon--filter"></i>Platforms</a>
@@ -96,7 +96,7 @@
     {% else %}
       <div class="p-notification--information">
           <p class="p-notification__response">
-            We couldn't find anything for your search "<strong>{{ q }}</strong>".
+            We couldn't find anything for your search{% if q %} "<strong>{{ q }}</strong>"{% endif %}.
           </p>
       </div>
     {% endif %}


### PR DESCRIPTION
## Done

Refactor search view

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Try filters directly in the URL the results should be always correct:
- http://0.0.0.0:8045/?platform=kubernetes
- http://0.0.0.0:8045/?platform=windows
- http://0.0.0.0:8045/?platform=all
- http://0.0.0.0:8045/?platform=all&category=featured,Kubernetes
- http://0.0.0.0:8045/?q=charm&platform=all&category=featured,Kubernetes

The frontend is not fixed in this PR