### PR TITLE
Remove windows from platforms

### DIFF
--- a/templates/partial/_filters.html
+++ b/templates/partial/_filters.html
@@ -80,7 +80,6 @@
             <option value="all" {% if active_filter('platform', 'all') %}selected{% endif %}>All</option>
             <option value="linux" {% if active_filter('platform', 'linux') %}selected{% endif %}>Linux</option>
             <option value="kubernetes" {% if active_filter('platform', 'kubernetes') %}selected{% endif %}>Kubernetes</option>
-            <option value="windows" {% if active_filter('platform', 'windows') %}selected{% endif %}>Windows</option>
           </select>
         </div>
       </form>


### PR DESCRIPTION
## Done

Remove Windows from platforms dropdown

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Check that Windows is not in the platforms dropdown
