### PR TITLE
Fix hidden heading when jumping between sections

### DIFF
--- a/templates/details/configure.html
+++ b/templates/details/configure.html
@@ -22,7 +22,8 @@
     <div class="col-9 col-large-6">
       <ul class="p-list--divided has-separator-centered">
         {% for key, value in package.store_front.config.options.items() %}
-        <li class="p-list__item" id="{{ key }}">
+        <li class="p-list__item doc-section">
+          <span class="section-marker" id="{{ key }}"></span>
           <p class="p-heading--4">{{ key }} <span class="u-text--muted">&VerticalLine; {{ value.type }}</span></p>
           {% if value.default %}
           <p style="overflow-wrap: break-word;"><span class="u-text--muted">Default:</span> {{ value.default }}</p>
@@ -41,4 +42,33 @@
     {% endif %}
   </div>
 </div>
+
+<style>
+  .section-marker {
+    display: block;
+    margin-top: -64px;
+    padding-bottom: 64px;
+  }
+</style>
+
+<script>
+  const sideNavigationLinks = Array.prototype.slice.call(
+    document.querySelectorAll(".p-side-navigation__link")
+  );
+
+  sideNavigationLinks.forEach((sideNavigationLink) => {
+    sideNavigationLink.addEventListener("click", (e) => {
+      const activeNavigationLink = e.target;
+      const oldActiveNavigationLink = document.querySelector(
+        ".p-side-navigation__link.is-active"
+      );
+
+      if (oldActiveNavigationLink) {
+        oldActiveNavigationLink.classList.remove("is-active");
+      }
+
+      activeNavigationLink.classList.add("is-active");
+    });
+  });
+</script>
 {% endblock%}


### PR DESCRIPTION
## Done
Stop heading being hidden under the navigation when jumping between sections

## QA
- Go to http://localhost:8045/cassandra/configure
- Click on the links in the side navigation
- Check that the target section heading isn't hidden behind the navigation
- Check that the side navigation link is highlighted

## Issue/card
Fixes #568