### PR TITLE
Kubernetes tooltips

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -344,8 +344,8 @@ h3 {
   display: block;
   height: 40px;
   left: 100%;
+  margin-top: -20px;
   position: absolute;
   top: -50%;
   width: 40px;
-  margin-top: -20px;
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -339,12 +339,13 @@ h3 {
   display: block;
 }
 
-.instruction-tooltip::after {
+.instruction-tooltip:hover::after {
   content: "";
   display: block;
-  height: 200px;
+  height: 40px;
   left: 100%;
   position: absolute;
   top: -50%;
-  width: 200px;
+  width: 40px;
+  margin-top: -20px;
 }

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -72,8 +72,14 @@
               Show information
             </div>
             <div class="p-tooltip__modal" aria-controls="icon-tooltip-modal" id="icon-tooltip-modal">
-              <div class="p-tooltip__dialog" role="dialog" aria-labelledby="modal-content">
-                <p id="modal-content" class="u-no-margin--bottom u-no-padding--top">The deployment of charms is done using Juju, our Universal Operator Lifecycle Manager. <a href="https://juju.is/docs/microk8s-cloud">Learn how to deploy a charm using MicroK8s</a>.</p>
+              <div class="p-tooltip__dialog" role="dialog" aria-labelledby="modal-content" style="position: relative; top: -0.9rem">
+                <span id="modal-content" class="u-no-margin--bottom u-no-padding--top">
+                  {% if "kubernetes" in package.store_front.os %}
+                    <p class="u-no-padding--top">Deploy Kubernetes operators easily with Juju, the <a href="https://juju.is/overview">Universal Operator Lifecycle Manager</a>. Need a Kubernetes cluster? Install <a href="https://microk8s.io/">MicroK8s</a> to create a full <a href="https://www.cncf.io/certification/software-conformance/">CNCF-certified</a> Kubernetes system in under 60 seconds.</p><p class="u-no-margin--bottom"><a href="https://juju.is/docs/microk8s-cloud">Deploy using our Quickstart Guide</a></p>
+                  {% else %}
+                    <p class="u-no-padding--top">Deploy universal operators easily with Juju, the <a href="https://juju.is/overview">Universal Operator Lifecycle Manager</a>.</p><p class="u-no-margin--bottom"><a href="https://juju.is/docs/deploying-applications#heading--deploying-from-the-charm-store">Learn how with our Quickstart Guide</a></p>
+                  {% endif %}
+                </span>
               </div>
             </div>
           </div>

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -72,7 +72,7 @@
               Show information
             </div>
             <div class="p-tooltip__modal" aria-controls="icon-tooltip-modal" id="icon-tooltip-modal">
-              <div class="p-tooltip__dialog" role="dialog" aria-labelledby="modal-content" style="position: relative; top: -0.9rem">
+              <div class="p-tooltip__dialog" role="dialog" aria-labelledby="modal-content" style="position: relative; top: -0.8rem">
                 <span id="modal-content" class="u-no-margin--bottom u-no-padding--top">
                   {% if "kubernetes" in package.store_front.os %}
                     <p class="u-no-padding--top">Deploy Kubernetes operators easily with Juju, the <a href="https://juju.is/overview">Universal Operator Lifecycle Manager</a>. Need a Kubernetes cluster? Install <a href="https://microk8s.io/">MicroK8s</a> to create a full <a href="https://www.cncf.io/certification/software-conformance/">CNCF-certified</a> Kubernetes system in under 60 seconds.</p><p class="u-no-margin--bottom"><a href="https://juju.is/docs/microk8s-cloud">Deploy using our Quickstart Guide</a></p>


### PR DESCRIPTION
## Done

Make the tooltip smart

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check a k8s tooltip: https://charmhub-io-599.demos.haus/ambassador
- Check a regular tooltip: https://charmhub-io-599.demos.haus/jenkins


## Issue / Card

Fixes #587
