### PR TITLE
Use cloudinary with lazy loading for charm icons

### DIFF
--- a/static/js/src/public/store/filters.js
+++ b/static/js/src/public/store/filters.js
@@ -10,12 +10,13 @@ function buildCharmCard(charm) {
 
   const entityCardThumbnail = clone.querySelector(".p-card__thumbnail");
   entityCardThumbnail.alt = charm.name;
+  entityCardThumbnail.setAttribute('loading', "lazy")
 
   if (charm.store_front.icons && charm.store_front.icons[0]) {
-    entityCardThumbnail.src = charm.store_front.icons[0];
+    entityCardThumbnail.src = "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_64,h_64/" + charm.store_front.icons[0];
   } else {
     entityCardThumbnail.src =
-      "https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg";
+      "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_64,h_64/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg";
   }
 
   const entityCardTitle = clone.querySelector(".entity-card-title");

--- a/static/js/src/public/store/filters.js
+++ b/static/js/src/public/store/filters.js
@@ -11,7 +11,7 @@ function buildCharmCard(charm) {
   const entityCardThumbnail = clone.querySelector(".p-card__thumbnail");
   entityCardThumbnail.alt = charm.name;
 
-  if (charm.store_front.icons) {
+  if (charm.store_front.icons && charm.store_front.icons[0]) {
     entityCardThumbnail.src = charm.store_front.icons[0];
   } else {
     entityCardThumbnail.src =

--- a/templates/partial/_featured-charms.html
+++ b/templates/partial/_featured-charms.html
@@ -3,7 +3,7 @@
   <a href="/{{ charm['name'] }}" class="p-card--button">
     <div class="p-card__header">
       <div class="p-card__thumbnail-container">
-        <img src="{{ charm['icon'] }}" alt="{{ charm['name'] }} icon" class="p-card__thumbnail" width="40" height="40">
+        <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_64,h_64/{{ charm['icon'] }}" alt="{{ charm['name'] }} icon" class="p-card__thumbnail" width="40" height="40" loading="lazy">
       </div>
       <h3 class="p-card__title p-heading--4 u-no-margin--bottom entity-card-title">{{ charm['display_name'] }}</h3>
       <p class="u-text--muted u-no-padding--top entity-card-publisher">{{ charm['publisher'] }}</p>

--- a/webapp/feature.py
+++ b/webapp/feature.py
@@ -9,7 +9,7 @@ FEATURED_CHARMS = [
         "display_name": "Prometheus",
         "summary": "Prometheus for Kubernetes clusters",
         "publisher": "charmcraft",
-        "icon": "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_64,h_64/https://api.snapcraft.io/api/v1/media/download/charm_ZhkY5AmM2Gncryt3xMkejF4Wyn8lZMSL_icon__dba76c5b8378a96bb711093e2cf55a2dd098f938e9aff22e13403a8e28b87548.png",
+        "icon": "https://api.snapcraft.io/api/v1/media/download/charm_ZhkY5AmM2Gncryt3xMkejF4Wyn8lZMSL_icon__dba76c5b8378a96bb711093e2cf55a2dd098f938e9aff22e13403a8e28b87548.png",
         "platform": "kubernetes",
     },
     # {
@@ -57,7 +57,7 @@ FEATURED_CHARMS = [
         "display_name": "Wordpress",
         "summary": "WordPress is a full featured web blogging tool, this charm deploys it.",
         "publisher": "charmcraft",
-        "icon": "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_64,h_64/https://api.snapcraft.io/api/v1/media/download/charm_gShnGJOjDv34a5pTsYaJB70YMfkfxLGh_icon__418ffcecc722f138690d719f8ea15f478a0a59a72b9c6425fea762b46c1aef4c.png",
+        "icon": "https://api.snapcraft.io/api/v1/media/download/charm_gShnGJOjDv34a5pTsYaJB70YMfkfxLGh_icon__418ffcecc722f138690d719f8ea15f478a0a59a72b9c6425fea762b46c1aef4c.png",
         "platform": "linux",
     },
     {
@@ -73,7 +73,7 @@ FEATURED_CHARMS = [
         "display_name": "Cassandra",
         "summary": "Distributed storage system for structured data",
         "publisher": "narindergupta",
-        "icon": "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_64,h_64/https://api.snapcraft.io/api/v1/media/download/charm_tWJQBVwAkpEVNJQaqV01zljMjnTk3Wpl_icon__c54853d543881d105dde58c94baf1b36cb4054b836c3246a6b02bb056867a23e.png",
+        "icon": "https://api.snapcraft.io/api/v1/media/download/charm_tWJQBVwAkpEVNJQaqV01zljMjnTk3Wpl_icon__c54853d543881d105dde58c94baf1b36cb4054b836c3246a6b02bb056867a23e.png",
         "platform": "linux",
     },
     {


### PR DESCRIPTION
## Done

Use cloudinary with lazy loading for charm icons

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
