### PR TITLE
Add tutorials to the site

### DIFF
--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -127,4 +127,15 @@
       }
     }
   }
+
+  .p-card.has-footer {
+    padding-bottom: 3rem;
+    position: relative;
+    width: 100%;
+
+    .p-card__footer {
+      bottom: 1rem;
+      position: absolute;
+    }
+  }
 }

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -1,7 +1,11 @@
 <footer>
   <hr>
   <div class="u-fixed-width is-wide">
+    {% if request.path == '/tutorials' %}
+    <p class="u-no-padding--top" style="margin-block-end: 1rem;"><strong>List your own tutorial on Charmhub.</strong><a href="/tutorials/how-to-write-a-tutorial"> Submit your tutorial&nbsp;&rsaquo;</a></p>
+    {% else %}
     <p class="u-no-padding--top" style="margin-block-end: 1rem;"><strong>List your own operator on Charmhub.</strong><a href="https://github.com/canonical/operator" class="p-link--external"> Submit your operator</a></p>
+    {% endif %}
   </div>
   <div class="p-footer">
     <div class="row is-wide">

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -24,6 +24,11 @@
             About
           </a>
         </li>
+        <li class="p-navigation__item {% if request.path == '/tutorials' %}is-selected{% endif %}" role="menuitem">
+          <a href="/tutorials" class="p-navigation__link">
+            Tutorials
+          </a>
+        </li>
         <li class="p-navigation__item" role="menuitem">
           <a href="https://discourse.charmhub.io" class="p-navigation__link">
             Community

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -6,26 +6,19 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1CfwkYsuBqDXgII02_HFMfqJNNZYkcA_XS-w5ySR09lY{% endblock meta_copydoc %}
 
-{% block extra_meta %}<meta name="robots" content="noindex, nofollow">{% endblock %}
-
 {% block content %}
-<section class="p-strip--accent is-shallow">
-  <div class="u-fixed-width">
-    <h1 class="p-heading--two u-no-margin--bottom">Tutorials</h1>
-  </div>
-</section>
-
-<section class="p-strip is-shallow" style="margin-block-end: 6rem;">
+<section class="p-strip">
   <div class="row">
     {% for item in metadata %}
     {% if loop.index <= posts_per_page * page and loop.index >= posts_per_page * page - posts_per_page + 1 %}
     <div class="col-medium-3 col-4 u-equal-height">
-      <div class="p-card">
+      <div class="p-card has-footer">
         <h2 class="p-card__title p-heading--4">{{ item.topic | safe }}</h2>
+        <hr />
         <p class="p-card__content">
           {{ item.summary | safe }}
         </p>
-        <p>Difficulty: <span class="p-tutorials-meter p-tutorials-meter--{{ item.difficulty }}">{{ item.difficulty }} out of 5</span></p>
+        <p class="p-card__footer">Difficulty: <span class="p-tutorials-meter p-tutorials-meter--{{ item.difficulty }}">{{ item.difficulty }} out of 5</span></p>
       </div>
     </div>
     {% endif %}


### PR DESCRIPTION
## Done
- Add tutorials to the navigation
- Created a tutorial for creating tutorials
- Updated the link in the footer of tutorials to link to the tutorial
- Update the look of the cards slightly

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/tutorials
- See they render and the link in the footer opens the right tutorial