### PR TITLE
Hide feature on show all button

### DIFF
--- a/static/js/src/public/store/filters.js
+++ b/static/js/src/public/store/filters.js
@@ -256,6 +256,7 @@ function handleShowAllOperators(charms) {
   showAllOperatorsButton.addEventListener("click", (e) => {
     e.preventDefault();
     // setQueryStringParameter("platform", "all");
+    hideFeatured();
     renderResultsCount(charms.length, charms.length);
     renderCharmCards(charms);
     toggleShowAllOperatorsButton("all");


### PR DESCRIPTION
## Done

On homepage click on `show all operators`
should show all operators

## QA

- `dotrun`
- http://0.0.0.0:8045
- On homepage click on `show all operators`


## Issue / Card

Fixes #625 
