### PR TITLE
Remove hover effect on disabled filters

### DIFF
--- a/static/js/src/public/store/filters.js
+++ b/static/js/src/public/store/filters.js
@@ -258,6 +258,7 @@ function enableAllActions() {
   platformSwitch.disabled = false;
   allOperatorsButton.disabled = false;
   categoryFilters.forEach((categoryFilter) => {
+    categoryFilter.parentElement.classList.remove("is-disabled");
     categoryFilter.disabled = false;
   });
 }

--- a/static/sass/_charmhub_p-filter.scss
+++ b/static/sass/_charmhub_p-filter.scss
@@ -55,6 +55,10 @@
 
       padding-left: $spv-inner--small;
 
+      &.is-disabled:hover {
+        background-color: transparent;
+      }
+
       &:hover {
         cursor: pointer;
       }

--- a/templates/partial/_filters.html
+++ b/templates/partial/_filters.html
@@ -12,7 +12,7 @@
           </li>
           {% for category in categories %}
           {% if not category["slug"] in ["other", "featured"] %}
-          <li class="p-filter__item" data-filter-type="category" data-js="filter" data-filter-value="{{ category.slug }}" tabindex="0" style="position: relative;">
+          <li class="p-filter__item is-disabled" data-filter-type="category" data-js="filter" data-filter-value="{{ category.slug }}" tabindex="0" style="position: relative;">
             <input class="category-filter" type="checkbox" id="{{ category.slug }}" value="{{ category.slug }}" {% if active_filter('category', category.slug) %}checked{% endif %} tabindex="-1" disabled>
             <label for="{{ category.slug }}" tabindex="-1">{{ category.name }}</label>
           </li>


### PR DESCRIPTION
## Done

Disabled filter hover effect when disabled

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- When the filters are disabled on page load, hover and check there is no background colour


## Issue / Card

Fixes #634