### PR TITLE
Update manifesto page copy

### DIFF
--- a/templates/about/manifesto.html
+++ b/templates/about/manifesto.html
@@ -8,116 +8,123 @@
 
 {% block about_content %}
   <h1>The Open Operator Manifesto</h1>
-  <h2 class="p-heading--4 u-sv3" style="max-width: 40rem;">
-    <strong>We lead the Open Operator Collection, on a mission to elevate the art of dev&ndash;sec&ndash;ops with open&ndash;source operators that control enterprise applications.</strong> These values and guidelines ensure high&ndash;quality code, conversations and experiences for our community.
-  </h2>
+  <h2 class="p-heading--4 u-sv3" style="max-width: 40rem;">Better operators through open community standards</h2>
+  <p>Our goal is to improve devsecops with open source operators for widely used software. These shared values ensure high quality code and conversations.</p>
   <ol class="p-list--ordered is-h4">
     <li>
       Source required
-      <p>An operator is software that takes control of an enterprise system, application or service. The operator source code is essential to verify expected behavior. We make operator source available so that everybody can understand exactly what happens on their systems.</p>
+      <p>We make operator source available so that everybody can understand exactly what happens on their systems.</p>
     </li>
     <li>
       Open source preferred
-      <p>We are an open source community to enable everyone to contribute to the shared problem of common workload operations. Our frameworks and tools are open source to enable the widest benefit of our work. We know some vendors cannot use open source, so our framework license allows them to create proprietary operators while preserving interoperability.</p>
+      <p>We are an open source community to enable everyone to contribute to common app operations. Our frameworks and tools are open source, but our framework license does allow vendors to create interoperable operators with their own license.</p>
+    </li>
+    <li>
+      Community-driven
+      <p>An operator distills real-world application experience into shared code. No one person can know all the ways an app will be used. Open community discussions and code are the best way to improve operator performance, usability, quality and completeness.</p>
     </li>
     <li>
       Security
-      <p>Application security is critical to enterprise integrity. The most common cause of vulnerability in enterprise architecture is human error. Software operators ensure best practice for every deployment and every change. A good operator applies defense-in-depth to every aspect of workload operations &ndash; from data encryption and application confinement to password selection and key handling. We review all operators for security. We treat operator code just like application code, with Common Vulnerabilities and Exposures, and we distribute fixes fast and automatically.</p>
+      <p>An operator should apply defense-in-depth to every aspect of operations &mdash; from data encryption and app confinement to password selection and key handling. We review all operators for security, and we publish fixes fast.</p>
     </li>
     <li>
-      Substrate neutral
-      <p>An operator should not assume any particular infrastructure or Kubernetes implementation, but use common, portable primitives. Where specific application capabilities can be unlocked on a particular substrate, they should be optional.</p>
+      Multi-cloud optimisation
+      <p>An operator should work on every cloud or Kubernetes, and should also automatically optimise for its environment and take advantage of local, differentiated capabilities.</p>
     </li>
     <li>
-      Reuse
-      <p>A well&dash;behaved operator is general and not deployment-specific. The operator understands many ways to deploy the application &ndash; large or small scale, resilient or minimal &ndash; and it serves the diverse needs of multiple users equally. Reusability drives correctness and completeness, it grows the community of users and contributors, and it expands the configurations, scenarios and integrations supported by the operator.</p>
+      Reusability
+      <p>Reuse improves quality and grows the community. An operator should offer many ways to deploy the application &mdash; large or small scale, resilient or minimal, persistent or ephemeral, standalone or integrated with as many other apps as possible.</p>
     </li>
     <li>
-      Updates and Upgrades
-      <p>Software evolves, and deployments must update to benefit from those improvements. High&dash;quality updates inspire the confidence to apply them frequently, which is essential for security. Good operator updates are independent of application upgrades, because application upgrades must be deliberate choices. A good operator distribution system has mechanisms to ensure smooth upgrades across application generations.</p>
+      Patches
+      <p>Operators should facilitate security patching, to help administrators maintain a healthy and compliant deployment. High-quality updates are essential for security.</p>
     </li>
     <li>
-      Purposeful config
-      <p>Application software has many configurable capabilities, but most of those exist to support higher&dash;level goals or purposes. A good operator distinguishes between purpose and mechanism, offers high&dash;level purposeful config, and translates that to the many low&dash;level mechanism configs of the workload.</p>
+      Upgradability
+      <p>Operators should manage upgrades. An operator should ensure maximum availability throughout the upgrade and provide a way to roll back to prior state.</p>
     </li>
     <li>
-      Scale
-      <p>Applications are often clustered for resilience or performance. A good operator will handle scale, guided by purposeful config and the workload nature, and respond to dynamic changes. A great operator will scale up and down equally well.</p>
+      High-level config
+      <p>Operators should abstract complex application configuration. An operator should offer only high-level config to capture admin intent and reduce the burden of application specific domain expertise required to run the app.</p>
     </li>
     <li>
-      Actionable
-      <p>Every application has a set of actions that can be performed by administrators. A good operator declares them and facilitates reliable execution. Daily actions like backup, restore, reset, and restart should never require direct admin access to underlying systems, configuration files, tools or containers. Actions should be remote procedures driven by API or CLI, subject to permissions, and logged for audit and accountability.</p>
+      Scalability
+      <p>Applications are often clustered for resilience or performance. An operator should handle dynamic changes, optimise for admin intent, and scale up or down equally well.</p>
     </li>
     <li>
-      Awareness
-      <p>A good operator evaluates and presents the state of its workload in human&dash;friendly terms. The operator understands the health, availability, and dependencies of the application, assesses those and presents them to the admin. Admins should never access the underlying systems or containers to assess the state of a workload, because the operator reports it continuously and automatically.</p>
+      Everyday actions included
+      <p>Daily actions like backup, restore, reset, and restart should never require direct admin access to underlying systems or containers. Actions should be driven by API or CLI, subject to permissions, and logged for audit and accountability.</p>
+    </li>
+    <li>
+      Status
+      <p>Admins should never require direct access to underlying systems or containers to know the status of a workload. An operator should assess and represent the health, availability, and dependencies of the app.</p>
     </li>
     <li>
       Leadership
-      <p>In distributed systems, some decisions must be taken for a whole cluster. Problems occur if different units make independent conflicting decisions. An operator should always know whether to make a decision or defer to another unit. Leader decisions should be available to all units in a reliable way. Leadership in distributed systems is a hard problem, and a well&dash;formed operator will follow proven algorithms for leader election to ensure cluster consistency.</p>
+      <p>In distributed systems, problems occur if different units of the same app make conflicting decisions. An operator should provide leadership and communicate leader decisions to all units in a reliable way with proven consistency.</p>
     </li>
     <li>
-      Composition
-      <p>It is common to integrate multiple pieces of software on the same system. For example, an intrusion detection system may need direct access to the processes on a database server. The operator framework must provide clear mechanisms to enable diverse functions to coexist in a single execution environment such as a Kubernetes pod or a machine.</p>
+      Subordinate software
+      <p>An operator should provide for related functions to coexist in its execution environment, whether that is a Kubernetes pod or a machine.</p>
     </li>
     <li>
-      Topology
-      <p>Most of the work of enterprise software is integration. A good operator goes beyond the application lifecycle to the application graph, understanding integration with other applications, and controlling its workload appropriately.</p>
+      Application graph
+      <p>Most of the work in enterprise software operations is integration. An operator should go beyond the application lifecycle to the application graph, and enable integration with as many other applications as possible to support as many scenarios as possible.</p>
     </li>
     <li>
-      Interoperable
-      <p>Enterprises require multi&dash;vendor deployments to work well. Operators should work with operators from other vendors and publishers. Collaboration and coordination are best done in a public forum to ensure the widest perspective.</p>
+      Interoperability
+      <p>Enterprises require multi-vendor deployments to work well. Operators should work well with operators from other vendors and publishers. Collaboration is best done in a public forum to ensure the widest participation.</p>
     </li>
     <li>
-      Consistent
-      <p>Admins work with many operators in large systems of many components. A well&dash;designed operator will reuse common patterns of naming and behavior to simplify the learning curve and increase administrator effectiveness.</p>
+      Consistency
+      <p>It is easier to use new applications if they follow common patterns. An operator should use common conventions to simplify the learning and adoption curve.</p>
     </li>
     <li>
       Substitution
-      <p>Many applications provide services that are standard or similar. Enterprises expect to choose the actual implementation in a particular deployment, or swap implementations later. Operators should not assume specific integration counterparts, allowing their substitution.</p>
+      <p>Enterprises expect to choose the actual implementation of services in a deployment. Operators should not assume specific integration counterparts, to allow substitution with compatible alternatives.</p>
     </li>
     <li>
-      Model driven
-      <p>All applications must all work together for a successful deployment. A change in one application is often relevant for all the applications integrated with it. Operators should observe and respond to changes in a model that describes the whole deployment application topology and configuration.</p>
+      Model-driven
+      <p>Applications must work together to be successful. Operators should respond to changes in a shared model that describes the whole application graph and config.</p>
     </li>
     <li>
-      Resourceful
-      <p>An operator should not assume a given resource allocation or scale. A user may deploy the application on a few small machines in one scenario, and many large machines in another. The model determines resources, not the operator.</p>
+      Capacity agnostic
+      <p>Admins may deploy the application on a few small machines, or many large machines. An operator should not assume capacity or scale, but learn it from the model.</p>
     <li>
       Network Agnostic
-      <p>Different enterprises take different approaches to networking. An operator should learn what&rsquo;s intended from the model, and not hard-code specific network details. There are good reasons to separate services on different networks, and operators should support segregated network architectures.</p>
+      <p>Different scenarios require different networking for the same application. An operator should support segregated network architecture as described in the model.</p>
     </li>
     <li>
       Cross platform
-      <p>Enterprises have applications on a wide range of operating systems like Windows and Linux, and many deployments integrate systems on diverse platforms. The operator framework should enable multi&dash;platform scenarios.</p>
+      <p>Enterprises have applications on both Windows and Linux, and many deployments integrate platforms. The operator framework should enable multi-platform scenarios.</p>
     </li>
     <li>
-      Architecture neutral
-      <p>Where the underlying application provider cares to be multi&dash;arch, the operator community should care too.</p>
+      Multi-arch
+      <p>An operator should work on all supported architectures of the application.</p>
     </li>
     <li>
       Tested
-      <p>Operators are privileged software dealing with critical functionality in sensitive environments. A good operator will have both unit and integration tests, which can be run by users to verify behaviour in their intended scenarios.</p>
+      <p>Operators are privileged software dealing with critical apps in sensitive environments. An operator should have both unit and integration tests that gate all changes.</p>
     </li>
     <li>
       Trusted builds
-      <p>Operators are software, which is often compiled. The integrity of the build system, and the integrity of the revision control system that drives them, is central to the provenance of the operator. A trustworthy operator system must enable trusted builds of operators as much as workloads.</p>
+      <p>An operator should be built in a trusted environment, just like the app it drives, to guarantee provenance and integrity.</p>
     </li>
     <li>
       Signed
-      <p>The trust placed in an operator means that it is important to know who produced it, and that it has not been modified. A trustworthy operator distribution system must enable verification of the provenance of any given revision at any time.</p>
+      <p>Operators are privileged software in which users place great trust. An operator should be signed to know who produced it, and prove that it has not been modified.</p>
     </li>
     <li>
-      Staged
-      <p>Software changes are inevitable. The more widely they can be inspected and tested, and the sooner issues can be uncovered, the better. A good operator will publish not only stable changes, but upcoming releases in beta or release candidate form, and possibly a development tip, for each major version. This enables widespread testing of changes and increases the quality of stable releases.</p>
+      Beta testing
+      <p>An operator should publish beta and release candidate versions to enable widespread testing and increase the quality of stable releases.</p>
     </li>
     <li>
       Managed
-      <p>An enterprise environment must plan changes at particular times. Operator distribution mechanisms should enable fine&dash;grained control of update propagation as well as enterprise control of versions.</p>
+      <p>An enterprise environment must plan changes. Operators should enable fine-grained control of updates and enterprise control of application versions.</p>
     </li>
   </ol>
   <p>
-    As a community, these principles guide our work and make it relevant to a wider audience. The more we can improve our operators in line with these values, the more our community benefits from the entire collection of operators.
+    Operators that embrace these principles, practices and values are better for a wider audience. We elevate the art of application management with universal, open operators that reflect the deepest insights from the broadest community in the widest contexts.
   </p>
 {% endblock %}
 


### PR DESCRIPTION
## Done

Updated the copy on the manifesto page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/manifesto
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare the page to [the copy doc](https://docs.google.com/document/d/1bPFekWN4xrUue2l8F2_2w3ygnh06VHMA3VUVoTzuAFk/edit#)
- Resolve Mark's comment in [the copy doc](https://docs.google.com/document/d/1bPFekWN4xrUue2l8F2_2w3ygnh06VHMA3VUVoTzuAFk/edit#)


## Issue / Card

Fixes #638 