### PR TITLE
Make charm install snippet selectable

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -66,20 +66,24 @@
         </div>
         {% include "partial/_channel-map.html" %}
         <div class="p-charm-header__code">
-          <code>juju deploy {% if package["cs"] %}cs:{% endif %}{{ package.name }}{% if package["channel_selected"]["channel"]["name"] and package["channel_selected"]["channel"]["name"] != "stable" %} --channel {{ package["channel_selected"]["channel"]["name"] }}{% endif %}</code>
-          <div class="p-tooltip--information u-no-margin--left instruction-tooltip" style="display: inline-block; top: -5px;">
-            <div class="p-tooltip__button" role="button" aria-controls="icon-tooltip-modal" tabindex="0">
-              Show information
+          <div style=" align-items: center; display: flex;">
+            <div>
+              <code>juju deploy {% if package["cs"] %}cs:{% endif %}{{ package.name }}{% if package["channel_selected"]["channel"]["name"] and package["channel_selected"]["channel"]["name"] != "stable" %} --channel {{ package["channel_selected"]["channel"]["name"] }}{% endif %}</code>
             </div>
-            <div class="p-tooltip__modal" aria-controls="icon-tooltip-modal" id="icon-tooltip-modal">
-              <div class="p-tooltip__dialog" role="dialog" aria-labelledby="modal-content" style="position: relative; top: -0.8rem">
-                <span id="modal-content" class="u-no-margin--bottom u-no-padding--top">
-                  {% if "kubernetes" in package.store_front.os %}
-                    <p class="u-no-padding--top">Deploy Kubernetes operators easily with Juju, the <a href="https://juju.is/overview">Universal Operator Lifecycle Manager</a>. Need a Kubernetes cluster? Install <a href="https://microk8s.io/">MicroK8s</a> to create a full <a href="https://www.cncf.io/certification/software-conformance/">CNCF-certified</a> Kubernetes system in under 60 seconds.</p><p class="u-no-margin--bottom"><a href="https://juju.is/docs/microk8s-cloud">Deploy using our Quickstart Guide</a></p>
-                  {% else %}
-                    <p class="u-no-padding--top">Deploy universal operators easily with Juju, the <a href="https://juju.is/overview">Universal Operator Lifecycle Manager</a>.</p><p class="u-no-margin--bottom"><a href="https://juju.is/docs/deploying-applications#heading--deploying-from-the-charm-store">Learn how with our Quickstart Guide</a></p>
-                  {% endif %}
-                </span>
+            <div class="p-tooltip--information instruction-tooltip">
+              <div class="p-tooltip__button" role="button" aria-controls="icon-tooltip-modal" tabindex="0">
+                Show information
+              </div>
+              <div class="p-tooltip__modal" aria-controls="icon-tooltip-modal" id="icon-tooltip-modal">
+                <div class="p-tooltip__dialog" role="dialog" aria-labelledby="modal-content" style="position: relative; top: -0.8rem;">
+                  <span id="modal-content" class="u-no-margin--bottom u-no-padding--top">
+                    {% if "kubernetes" in package.store_front.os %}
+                      <p class="u-no-padding--top">Deploy Kubernetes operators easily with Juju, the <a href="https://juju.is/overview">Universal Operator Lifecycle Manager</a>. Need a Kubernetes cluster? Install <a href="https://microk8s.io/">MicroK8s</a> to create a full <a href="https://www.cncf.io/certification/software-conformance/">CNCF-certified</a> Kubernetes system in under 60 seconds.</p><p class="u-no-margin--bottom"><a href="https://juju.is/docs/microk8s-cloud">Deploy using our Quickstart Guide</a></p>
+                    {% else %}
+                      <p class="u-no-padding--top">Deploy universal operators easily with Juju, the <a href="https://juju.is/overview">Universal Operator Lifecycle Manager</a>.</p><p class="u-no-margin--bottom"><a href="https://juju.is/docs/deploying-applications#heading--deploying-from-the-charm-store">Learn how with our Quickstart Guide</a></p>
+                    {% endif %}
+                  </span>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Done

Make charm install selectable on click

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/cassandra
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click on the `juju deploy cs:cassandra` snippet and see that it is selected


## Issue / Card

Fixes #570 