### PR TITLE
Change login URL

### DIFF
--- a/templates/publisher/bundles.html
+++ b/templates/publisher/bundles.html
@@ -3,6 +3,7 @@
 {% set package_type = "bundle"%}
 
 <!-- To DO - add copy -->
+{% block meta_description %}{% endblock meta_description %}
 {% block meta_copydoc %}{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/publisher/charms.html
+++ b/templates/publisher/charms.html
@@ -3,6 +3,7 @@
 {% set package_type = "charm"%}
 
 <!-- To DO - add copy -->
+{% block meta_description %}{% endblock meta_description %}
 {% block meta_copydoc %}{% endblock meta_copydoc %}
 
 {% block content %}

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -30,7 +30,7 @@ def logout():
     return flask.redirect("/")
 
 
-@login.route("/publisher/login/")
+@login.route("/login/")
 def publisher_login():
     # Get a bakery v2 macaroon from the publisher API to be discharged
     # and save it in the session


### PR DESCRIPTION
## Done

We used to have two different logins:

1. As a publisher
2. To visit the entire website since it was private

Now we can rename `/publisher/login/` to `/login/`, this will make the site match with snapcraft.io.

## QA

**Login will not work on the demo service**
- Go to http://localhost:8045/login/
- Finish the login process, you will get redirected to `/charms`
