### PR TITLE
Remove duplicate search on large screens

### DIFF
--- a/templates/partial/_filters.html
+++ b/templates/partial/_filters.html
@@ -45,7 +45,7 @@
       <div class="p-muted-heading" id="results-count-container" data-js="filtered-items">15 Featured</div>
     </div>
     <div class="p-layout__right">
-      <form action="/" class="p-search-box p-layout__search" data-js="search-handler-mobile">
+      <form action="/" class="p-search-box p-layout__search u-hide--medium u-hide--large" data-js="search-handler-mobile">
         <input type="search" class="p-search-box__input" name="q" aria-label="Search Charmhub" placeholder="Search Charmhub" {% if q %}value="{{ q }}" {% endif %} required />
         <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Clear</i></button>
         <button type="submit" class="p-search-box__button" alt="Search"><i class="p-icon--search">Search</i></button>


### PR DESCRIPTION
## Done

Hide mobile search on large screens

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Check that there is only one search on the screen

