### PR TITLE
Remove featured and others from filters

### DIFF
--- a/templates/partial/_filters.html
+++ b/templates/partial/_filters.html
@@ -8,12 +8,14 @@
         {% if categories %}
         <ul class="p-list">
           {% for category in categories %}
+          {% if category.slug != "featured" and category.slug != "other" %}
           <li class="p-list__item" data-filter-type="category" data-js="filter">
             <label class="p-checkbox">
               <input class="category-filter" type="checkbox" id="{{ category.slug }}" value="{{ category.slug }}" {% if active_filter('category', category.slug) %}checked{% endif %}>
               <span class="p-checkbox__label" id="{{ category.slug }}">{{ category.name }}</span>
             </label>
           </li>
+          {% endif %}
           {% endfor %}
         </ul>
         {% endif %}


### PR DESCRIPTION
## Done

Removed "featured" and "other" filters from homepage

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the homepage filters do not include "featured" or "other"


## Issue / Card

Fixes #647