### PR TITLE
Update styles for manifesto link

### DIFF
--- a/templates/maintenance.html
+++ b/templates/maintenance.html
@@ -9,7 +9,7 @@
   <div class="u-fixed-width is-wide">
     <h1>The Open Operator Collection</h1>
     <h2 class="p-heading--4">Universal operators for Linux, Windows and Kubernetes apps</h2>
-    <h3 class="p-heading--4"><a href="/manifesto" class="p-link--inverted">Read our manifesto</a></h3>
+    <p><a href="/manifesto" class="p-link--inverted">Read our manifesto&nbsp;&rsaquo;</a></p>
   </div>
 </section>
 <div class="p-strip--accent u-no-padding--top u-no-padding--bottom">

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -8,7 +8,7 @@
 <section class="p-strip--overview is-dark is-slanted--right-blue" style="padding-block-end: 3.5rem; padding-block-start: 3rem;">
   <div class="u-fixed-width">
     <h1>Better operators for the whole estate</h1>
-    <p class="p-heading--4"><a href="/manifesto" class="p-link--inverted">Read our manifesto</a></p>
+    <p><a href="/manifesto" class="p-link--inverted">Read our manifesto&nbsp;&rsaquo;</a></p>
   </div>
 </section>
 

--- a/templates/store-search.html
+++ b/templates/store-search.html
@@ -9,7 +9,7 @@
   <div class="u-fixed-width is-wide">
     <h1>The Open Operator Collection</h1>
     <h2 class="p-heading--4">Universal operators for Linux, Windows and Kubernetes apps</h2>
-    <h3 class="p-heading--4"><a href="/manifesto" class="p-link--inverted">Read our manifesto</a></h3>
+    <p><a href="/manifesto" class="p-link--inverted">Read our manifesto&nbsp;&rsaquo;</a></p>
   </div>
 </section>
 <div class="p-strip--accent u-no-padding--top u-no-padding--bottom">

--- a/templates/store.html
+++ b/templates/store.html
@@ -9,7 +9,7 @@
   <div class="u-fixed-width is-wide">
     <h1>The Open Operator Collection</h1>
     <h2 class="p-heading--4">Universal operators for Linux, Windows and Kubernetes apps</h2>
-    <h3 class="p-heading--4"><a href="/manifesto" class="p-link--inverted">Read our manifesto</a></h3>
+    <p><a href="/manifesto" class="p-link--inverted">Read our manifesto&nbsp;&rsaquo;</a></p>
   </div>
 </section>
 <div class="p-strip--accent u-no-padding--top u-no-padding--bottom">


### PR DESCRIPTION
## Done

Update the style of the manifesto link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to http://localhost:8045 and check that the manifesto link is smaller and has an arrow
- Also check /overview and ?q=foo


## Issue / Card

Fixes #646 