### PR TITLE
Consume real charm libraries

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -267,7 +267,7 @@ def details_libraries(entity_name):
     package = get_package(entity_name, channel_request)
 
     libraries = logic.process_libraries(
-        publisher_api.get_charm_libraries("my-super-charm")
+        publisher_api.get_charm_libraries(entity_name)
     )
 
     return render_template(
@@ -299,7 +299,7 @@ def details_library(entity_name, library_name):
         lib_name = library_name
 
     libraries = logic.process_libraries(
-        publisher_api.get_charm_libraries("my-super-charm")
+        publisher_api.get_charm_libraries(entity_name)
     )
 
     library = next(


### PR DESCRIPTION
## Done

We used to have a charm called "my-super-charm" on the staging API to get some libraries from there, this charm is not there anymore and now we can use the real charm to obtain the libraries.

## QA

- ¯\_(ツ)_/¯ I think we don't have Charms with libraries for now.
