### PR TITLE
Remove underline hero link

### DIFF
--- a/static/sass/_pattern_p-link.scss
+++ b/static/sass/_pattern_p-link.scss
@@ -1,5 +1,0 @@
-@mixin p-charmhub-link {
-  .has-icon [class*="p-icon"]:first-child {
-    margin-right: $spv-inner--small;
-  }
-}

--- a/static/sass/_pattern_p-link.scss
+++ b/static/sass/_pattern_p-link.scss
@@ -1,18 +1,4 @@
 @mixin p-charmhub-link {
-  .p-link--inverted {
-    color: $color-light;
-    font-weight: $font-weight-bold;
-    text-decoration: underline;
-
-    &:hover {
-      color: $color-light;
-    }
-
-    &:visited {
-      color: darken($color-light, 10%);
-    }
-  }
-
   .has-icon [class*="p-icon"]:first-child {
     margin-right: $spv-inner--small;
   }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -68,10 +68,6 @@ $theme-default-nav: dark;
 
 @include p-charmhub-card;
 
-@import "pattern_p-link";
-
-@include p-charmhub-link;
-
 @import "pattern_grid";
 
 @include p-charmhub-grid;

--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -81,13 +81,13 @@ than the latest.</span>
           <li class="p-inline-list__item">
             <ul class="p-inline-list has-vertical-separator">
               <li class="p-inline-list__item">
-                <a href="#" class="is-always-color-link has-icon"><i class="p-icon--download">Download</i><span>Download</span></a>
+                <a href="#" class="is-always-color-link"><i class="p-icon--download">Download</i> <span>Download</span></a>
               </li>
-              <li class="p-inline-list__item has-icon">
-                <i class="p-icon--update">Last updated</i>26 June 2019
+              <li class="p-inline-list__item">
+                <i class="p-icon--update">Last updated</i> 26 June 2019
               </li>
-              <li class="p-inline-list__item has-icon">
-                <i class="p-icon--revision">Revision</i>Library version {{ library['api'] }}
+              <li class="p-inline-list__item">
+                <i class="p-icon--revision">Revision</i> Library version {{ library['api'] }}
               </li>
             </ul>
           </li>


### PR DESCRIPTION
## Done
- Remove the bespoke underline hero links
- Replaced styling on icons in links with Vanilla's recommendation
- Remove bespoke links styling file

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Check the "Read our manifesto ›" link the hero strip is not underlined until hovered

## Screenshot
Icons next the links:
![image](https://user-images.githubusercontent.com/1413534/99376497-ed972380-28bc-11eb-9cac-57861261646b.png)

Hero link:
![image](https://user-images.githubusercontent.com/1413534/99376536-f8ea4f00-28bc-11eb-8792-c20922e24d38.png)

