### PR TITLE
Disable category filters until data loads

### DIFF
--- a/static/js/src/public/store/charms.js
+++ b/static/js/src/public/store/charms.js
@@ -235,7 +235,6 @@ function enableAllActions() {
   platformSwitch.disabled = false;
   allOperatorsButton.disabled = false;
   categoryFilters.forEach((categoryFilter) => {
-    categoryFilter.parentElement.classList.remove("is-disabled");
     categoryFilter.disabled = false;
   });
 }

--- a/templates/partial/_filters.html
+++ b/templates/partial/_filters.html
@@ -11,7 +11,7 @@
           {% if category.slug != "featured" and category.slug != "other" %}
           <li class="p-list__item" data-filter-type="category" data-js="filter">
             <label class="p-checkbox">
-              <input class="category-filter" type="checkbox" id="{{ category.slug }}" value="{{ category.slug }}" {% if active_filter('category', category.slug) %}checked{% endif %}>
+              <input class="category-filter" type="checkbox" id="{{ category.slug }}" value="{{ category.slug }}" {% if active_filter('category', category.slug) %}checked{% endif %} disabled>
               <span class="p-checkbox__label" id="{{ category.slug }}">{{ category.name }}</span>
             </label>
           </li>


### PR DESCRIPTION
## Done

Disabled category filters until the data loads

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Load the page with a hard refresh
- Check that the category filters are disabled until the data is loaded
- Tip: Look at the `charms.json` request in the network inspector to see when it changes from pending


## Issue / Card

Fixes #654 