### PR TITLE
Change missing var name

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -310,7 +310,7 @@ def details_library(entity_name, library_name):
     if not library:
         abort(404)
 
-    library = publisher_api.get_charm_library("my-super-charm", library["id"])
+    library = publisher_api.get_charm_library(entity_name, library["id"])
     docstrings = logic.process_python_docs(library, module_name=library_name)
 
     return render_template(


### PR DESCRIPTION
## Done

- I created a library for the fran-wordpress charm and this will fix the actual view.

## QA

- Modify you `.env.local` file and include:
```bash
# Staging API
CHARMSTORE_API_URL=https://api.staging.snapcraft.io/
```
- `dotrun`
- http://0.0.0.0:8045/fran-wordpress/libraries/
