### PR TITLE
Improve the filter checkboxes

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -24,6 +24,7 @@ $theme-default-nav: dark;
 @include vf-p-card;
 @include vf-p-forms;
 @include vf-p-form-help-text;
+@include vf-p-form-tick-elements;
 @include vf-p-grid;
 @include vf-p-grid-modifications;
 @include vf-p-headings;
@@ -348,4 +349,10 @@ h3 {
   position: absolute;
   top: -50%;
   width: 40px;
+}
+
+// XXX Ant 17.11.2020 - This can be removed once this issue is closed
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/3411
+.p-checkbox {
+  position: relative;
 }

--- a/templates/partial/_filters.html
+++ b/templates/partial/_filters.html
@@ -11,8 +11,8 @@
           {% if category.slug != "featured" and category.slug != "other" %}
           <li class="p-list__item" data-filter-type="category" data-js="filter">
             <label class="p-checkbox">
-              <input class="category-filter" type="checkbox" id="{{ category.slug }}" value="{{ category.slug }}" {% if active_filter('category', category.slug) %}checked{% endif %} disabled>
-              <span class="p-checkbox__label" id="{{ category.slug }}">{{ category.name }}</span>
+              <input class="p-checkbox__input category-filter" aria-labelledby="{{ category.slug }}-filter" type="checkbox" value="{{ category.slug }}" {% if active_filter('category', category.slug) %}checked{% endif %} disabled>
+              <span class="p-checkbox__label" id="{{ category.slug }}-filter">{{ category.name }}</span>
             </label>
           </li>
           {% endif %}


### PR DESCRIPTION
## Done
Improve the filter checkboxes

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- See that when the filtered checkboxes are disabled the labels look it too
