### PR TITLE
Add download dropdown to library page

### DIFF
--- a/static/sass/_charmhub_p-contextual-menu.scss
+++ b/static/sass/_charmhub_p-contextual-menu.scss
@@ -1,0 +1,20 @@
+@mixin p-charmhub-contextual-menu {
+  .p-contextual-menu__dropdown--wide {
+    @extend .p-contextual-menu__dropdown;
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      max-width: 26rem;
+    }
+  }
+
+  .p-contextual-menu__body {
+    padding: 1rem;
+  }
+
+  .p-contextual-menu__link--deep {
+    @extend .p-contextual-menu__link;
+
+    padding-bottom: 1rem;
+    padding-top: 1rem;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -49,6 +49,7 @@ $theme-default-nav: dark;
 @include vf-p-table-mobile-card;
 @include vf-p-tabs;
 @include vf-p-tooltips;
+@include vf-p-contextual-menu;
 
 // Vanilla utilities
 @include vf-u-align;
@@ -160,6 +161,10 @@ $theme-default-nav: dark;
 @import "charmhub_metrics";
 
 @include charmhub-metrics;
+
+@import "charmhub_p-contextual-menu";
+
+@include p-charmhub-contextual-menu;
 
 @import "pattern_form-multiselect";
 

--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -81,7 +81,24 @@ than the latest.</span>
           <li class="p-inline-list__item">
             <ul class="p-inline-list has-vertical-separator">
               <li class="p-inline-list__item">
-                <a href="#" class="is-always-color-link"><i class="p-icon--download">Download</i> <span>Download</span></a>
+                <span class="p-contextual-menu--left">
+                  <button class="p-button--base p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">
+                    <i class="p-icon--download"></i> Download
+                  </button>
+                  <span class="p-contextual-menu__dropdown--wide" id="menu-3" aria-hidden="true">
+                    <span class="p-contextual-menu__group">
+                      <div class="p-contextual-menu__body">
+                        <p class="u-no-padding--top"><i class="p-icon--code"></i> Fetch library</p>
+                        <pre class="u-no-margin--bottom">charmcraft fetch-libs {{docstrings["name"]}}</pre>
+                      </div>
+                    </span>
+                    <span class="p-contextual-menu__group">
+                      <a class="p-contextual-menu__link--deep" href="/{{ library['charm-name'] }}/libraries/{{ docstrings['name'] }}/download" download>
+                        <i class="p-icon--download"></i> Download {{ docstrings['name'] }}.py
+                      </a>
+                    </span>
+                  </span>
+                </span>
               </li>
               <li class="p-inline-list__item">
                 <i class="p-icon--update">Last updated</i> 26 June 2019
@@ -101,4 +118,68 @@ than the latest.</span>
       </div>
     </div>
   </div>
+{% endblock %}
+
+{% block page_scripts %}
+  <script>
+    function toggleMenu(element, show, top) {
+      var target = document.getElementById(element.getAttribute('aria-controls'));
+
+      if (target) {
+        element.setAttribute('aria-expanded', show);
+        target.setAttribute('aria-hidden', !show);
+
+        if (typeof top !== 'undefined') {
+          target.style.top = top + 'px';
+        }
+      }
+    }
+
+    function setupContextualMenu(menuToggle) {
+      menuToggle.addEventListener('click', function (event) {
+        event.preventDefault();
+        var menuAlreadyOpen = menuToggle.getAttribute('aria-expanded') === 'true';
+
+        var top = menuToggle.offsetHeight;
+
+        if (window.getComputedStyle(menuToggle).display === 'inline') {
+          top += 5;
+        }
+
+        toggleMenu(menuToggle, !menuAlreadyOpen, top);
+      });
+    }
+
+    function setupAllContextualMenus(contextualMenuToggleSelector) {
+      var toggles = document.querySelectorAll(contextualMenuToggleSelector);
+
+      for (var i = 0, l = toggles.length; i < l; i++) {
+        setupContextualMenu(toggles[i]);
+      }
+
+      document.addEventListener('click', function (event) {
+        for (var i = 0, l = toggles.length; i < l; i++) {
+          var toggle = toggles[i];
+          var contextualMenu = document.getElementById(toggle.getAttribute('aria-controls'));
+          var clickOutside = !(toggle.contains(event.target) || contextualMenu.contains(event.target));
+
+          if (clickOutside) {
+            toggleMenu(toggle, false);
+          }
+        }
+      });
+
+      document.addEventListener('keydown', function (e) {
+        e = e || window.event;
+
+        if (e.keyCode === 27) {
+          for (var i = 0, l = toggles.length; i < l; i++) {
+            toggleMenu(toggles[i], false);
+          }
+        }
+      });
+    }
+
+    setupAllContextualMenus('.p-contextual-menu__toggle');
+  </script>
 {% endblock%}


### PR DESCRIPTION
## Done

Add a download popup to the library page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045/fran-wordpress/libraries/test
- Hover over the download link
- Check that there is a popup with the command line instructions to download

## Issue / Card

Fixes #508 