### PR TITLE
Publisher charm listing view

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.discourse==2.0.3
 canonicalwebteam.flask-base==0.6.4
 canonicalwebteam.search==0.2.1
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.store-api==2.3.7
+canonicalwebteam.store-api==2.3.8
 docstring-extractor==0.2.0
 Flask-WTF==0.14.3
 humanize==2.6.0

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -1,6 +1,6 @@
 {% extends 'publisher/publisher_layout.html' %}
 
-{% block title %}Listing details for {{ package_name }}{% endblock %}
+{% block title %}Listing details for {{ package.name }}{% endblock %}
 <!-- To DO - add copy and description -->
 {% block meta_copydoc %}{% endblock meta_copydoc %}
 {% block meta_description %}{% endblock %}
@@ -13,7 +13,7 @@
     <div class="row" style="padding-block-start: 1rem;">
       <div class="col-7">
         <p>
-          Updates to this information will appear immediately on the <a href="/{{ package_name }}">{{ package.type }} listing page</a>.
+          Updates to this information will appear immediately on the <a href="/{{ package.name }}">{{ package.type }} listing page</a>.
         </p>
       </div>
       <div class="col-5">
@@ -88,7 +88,7 @@
             <div class="u-flex u-vertically-center">
               <div class="p-editable-icon">
                 <div class="p-editable-icon__icon" tabindex="0">
-                  <img class="p-editable-icon__image" src="https://dashboard.snapcraft.io/site_media/appmedia/2020/04/products-hero-ubuntu.svg.png" alt="{{ package_name }} {{ package.type }}">
+                  <img class="p-editable-icon__image" src="https://dashboard.snapcraft.io/site_media/appmedia/2020/04/products-hero-ubuntu.svg.png" alt="{{ package.name }} {{ package.type }}">
                   <span class="p-editable-icon__change">Edit</span>
                   <input type="file" name="icon" id="{{ package.type }}-icon" accept="image/png,image/jpeg,image/svg+xml" hidden="">
                 </div>
@@ -118,7 +118,7 @@
       </div>
       <div class="col-8">
         <div class="p-form__control">
-          <input class="p-form-validation__input" id="{{ package.type }}-title" type="text" name="title" value="{{ package_name }}" required="" maxlength="40">
+          <input class="p-form-validation__input" id="{{ package.type }}-title" type="text" name="title" value="{{ package.title or package.name }}" required="" maxlength="40">
         </div>
       </div>
     </div>
@@ -182,7 +182,7 @@
       </div>
       <div class="col-8">
         <div class="p-form__control">
-          <input class="p-form-validation__input" type="text" id="summary" name="summary" required="" maxlength="128">
+          <input class="p-form-validation__input" type="text" id="summary" name="summary" required="" maxlength="128" value="{{ package.summary or ''}}">
         </div>
       </div>
     </div>
@@ -225,7 +225,7 @@
       </div>
       <div class="col-8">
         <div class="p-form__control">
-          <textarea class="p-form-validation__input" id="description" name="description" rows="10" required=""></textarea>
+          <textarea class="p-form-validation__input" id="description" name="description" rows="10" required="">{{ package.description }}</textarea>
         </div>
       </div>
     </div>
@@ -405,7 +405,7 @@
       </div>
       <div class="col-8">
         <div class="p-form__control">
-          <input class="p-form-validation__input" id="project-homepage" type="url" name="project-homepage" value="" maxlength="256" placeholder="https://charmhub.io">
+          <input class="p-form-validation__input" id="project-homepage" type="url" name="project-homepage" value="{{ package.website or '' }}" maxlength="256" placeholder="https://charmhub.io">
         </div>
       </div>
     </div>
@@ -438,7 +438,7 @@
       </div>
       <div class="col-8">
         <div class="p-form__control">
-          <input id="contact" class="p-form-validation__input" type="url" name="contact" value="" maxlength="256" placeholder="mailto:example@example.com">
+          <input id="contact" class="p-form-validation__input" type="text" name="contact" value="{{ package.contact or '' }}" maxlength="256" placeholder="mailto:example@example.com">
         </div>
       </div>
     </div>

--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -17,9 +17,7 @@ def login_required(func):
     @functools.wraps(func)
     def is_user_logged_in(*args, **kwargs):
         if not authentication.is_authenticated(flask.session):
-            return flask.redirect(
-                "/publisher/login?next=" + flask.request.path
-            )
+            return flask.redirect("/login?next=" + flask.request.path)
 
         return func(*args, **kwargs)
 

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -50,25 +50,18 @@ def bundles():
 @publisher.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/listing')
 @login_required
 def listing(entity_name):
-    package_type = "charm"
-    if entity_name == "bundle":
-        package_type = "bundle"
+    package = publisher_api.get_package_metadata(
+        session["publisher-auth"], "charm", entity_name
+    )
 
     licenses = []
     for license in get_licenses():
         licenses.append({"key": license["licenseId"], "name": license["name"]})
 
-    license_type = "simple"
-    license = "AFL-1.1"
-
     context = {
-        "package_name": entity_name,
-        "package_type": package_type,
-        "license": license,
+        "package": package,
         "licenses": licenses,
-        "license_type": license_type,
     }
-
     return render_template("publisher/listing.html", **context)
 
 


### PR DESCRIPTION
## Done

- Get API data for the publisher listing view

## QA

- You have to publish a charm with `charmcraft`
- Login as a publisher and go to:
- `http://localhost:8045/<YOUR_CHARM>/listing` , in my case http://localhost:8045/fran-wordpress/listing


## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1689

## Screenshots

![image](https://user-images.githubusercontent.com/6353928/99509193-5c3bb600-297d-11eb-9e67-4aa80aeddf25.png)

