### PR TITLE
Add suru pattern to details pages

### DIFF
--- a/static/sass/_pattern_p-strip.scss
+++ b/static/sass/_pattern_p-strip.scss
@@ -4,6 +4,33 @@
   @include jaas-p-strip-half-and-half;
   @include jaas-p-strip-muted-suru;
   @include charmhub-p-strip;
+  @include p-suru-light;
+}
+
+@mixin p-suru-light {
+  [class*="p-strip"].has-suru {
+    @media screen and (min-width: $breakpoint-medium) {
+      background-color: $color-light;
+      background-image:
+        linear-gradient(
+          -48deg,
+          rgba(205, 205, 205, 0.2),
+          rgba(205, 205, 205, 0.2) 35%,
+          rgba(247, 247, 247, 0) 35%,
+          rgba(247, 247, 247, 0) 100%
+        ),
+        linear-gradient(
+          16deg,
+          rgba(247, 247, 247, 0),
+          rgba(247, 247, 247, 0) 80%,
+          rgba(229, 229, 229, 0.5) 80%,
+          rgba(229, 229, 229, 0.5) 100%
+        );
+      background-position: top right, top right;
+      background-repeat: no-repeat;
+      background-size: 25% 100%, 125% 250%;
+    }
+  }
 }
 
 @mixin jaas-p-strip-suru {

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -1,4 +1,4 @@
-<div class="p-strip--light is-shallow">
+<div class="p-strip has-suru is-shallow">
   <div class="row is-wide">
     <div class="col-8">
       <div class="p-charm-header">


### PR DESCRIPTION
## Done

Added light suru pattern to detail pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/postgresql-k8s
- Check that there is a light grey suru on the header strip

## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1688