### PR TITLE
Fix integration chart being cropped on wide screens

### DIFF
--- a/static/js/src/public/details/integrate/index.js
+++ b/static/js/src/public/details/integrate/index.js
@@ -5,7 +5,7 @@ import "swiper/swiper-bundle.css";
 
 function buildChart(data) {
   // set dimensions
-  const chartWidth = window.innerWidth * 0.8;
+  const chartWidth = window.innerWidth > 1024 ? 960 : window.innerWidth * 0.8;
   const chartHeight = 280;
   const iconWidth = 70;
   const iconHeight = 70;

--- a/static/sass/_pattern-p-integration-charts.scss
+++ b/static/sass/_pattern-p-integration-charts.scss
@@ -93,10 +93,4 @@
       text-decoration: underline;
     }
   }
-
-  @media (min-width: $breakpoint-large) {
-    .integration-modal {
-      overflow: hidden;
-    }
-  }
 }


### PR DESCRIPTION
## Done

Fixed integration chart being cropped on wide screens.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8045/postgresql-k8s/integrate
- Click on one of the operators
- View the site on as wide a screen as possible (it's possible to do this in dev tools on the mobile panel)
- Check that you can see the whole integration chart

## Issue / Card

Fixes #668 