### PR TITLE
Integrate API for POST listing page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.discourse==2.1.0
 canonicalwebteam.flask-base==0.6.4
 canonicalwebteam.search==0.2.1
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.store-api==2.3.8
+canonicalwebteam.store-api==2.3.9
 docstring-extractor==0.2.0
 Flask-WTF==0.14.3
 humanize==2.6.0

--- a/templates/publisher/charms.html
+++ b/templates/publisher/charms.html
@@ -29,7 +29,7 @@
                 <span class="p-heading-icon__header">
                   <img src="https://dashboard.snapcraft.io/site_media/appmedia/2020/04/products-hero-ubuntu.svg.png" width="24" height="24" class="p-heading-icon__img">
                   <p class="u-no-margin--bottom u-no-padding--top">
-                    {{ published_charm.name }}
+                    <a href="/{{ published_charm.name }}/listing">{{ published_charm.name }}</a>
                   </p>
                 </span>
               </div>

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -23,7 +23,7 @@
             <span class="p-tooltip__message" role="tooltip" id="preview-tooltip">Previews will only work in the same browser, locally</span>
           </button>
           <a class="p-button--neutral is-disabled" href="javascript:void(0);" style="margin-inline-end: 1rem;">Revert</a>
-          <button type="submit" class="p-button--positive" name="submit_apply" value="Save" disabled="">
+          <button type="submit" class="p-button--positive" name="submit_apply" value="Save">
             Save
           </button>
         </div>
@@ -36,6 +36,20 @@
   </div>
 
   <section class="p-strip is-shallow">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+    <div class="u-fixed-width">
+      {% for category, message in messages %}
+      <div id="market-form-status" class="p-notification--{{ category }}">
+        <p class="p-notification__response">
+          {{ message }}
+        </p>
+      </div>
+      {% endfor %}
+    </div>
+    {% endif %}
+    {% endwith %}
+
     <div class="u-fixed-width">
       <h2 class="p-heading--4">
         Listing details
@@ -401,11 +415,11 @@
 
     <div class="row p-form__group p-form-validation ">
       <div class="col-2">
-        <label for="project-homepage" class="p-form__label">Project homepage:</label>
+        <label for="website" class="p-form__label">Project homepage:</label>
       </div>
       <div class="col-8">
         <div class="p-form__control">
-          <input class="p-form-validation__input" id="project-homepage" type="url" name="project-homepage" value="{{ package.website or '' }}" maxlength="256" placeholder="https://charmhub.io">
+          <input class="p-form-validation__input" id="website" type="url" name="website" value="{{ package.website or '' }}" maxlength="256" placeholder="https://charmhub.io">
         </div>
       </div>
     </div>
@@ -476,6 +490,7 @@
     </div>
   </section>
   <input type="hidden" name="changes" value="">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 </form>
 {% endblock %}
 

--- a/templates/publisher/publisher_layout.html
+++ b/templates/publisher/publisher_layout.html
@@ -5,32 +5,32 @@
   <div class="u-fixed-width">
     <a href="/charms">&lsaquo;&nbsp;My charms & bundles</a>
     <h1 class="p-heading--3">
-      {{package_name}}
+      {{package.name}}
     </h1>
     <nav class="p-tabs">
       <ul class="p-tabs__list u-no-margin--bottom" role="tablist">
         <li class="p-tabs__item" role="presentation">
-          <a href="/{{package_name}}/listing" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "listing" %}aria-selected="true"{% endif %}>
+          <a href="/{{package.name}}/listing" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "listing" %}aria-selected="true"{% endif %}>
             Listing
           </a>
         </li>
         <li class="p-tabs__item" role="presentation">
-          <a href="/{{package_name}}/releases" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "releases" %}aria-selected="true"{% endif %}>
+          <a href="/{{package.name}}/releases" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "releases" %}aria-selected="true"{% endif %}>
             Releases
           </a>
         </li>
         <li class="p-tabs__item" role="presentation">
-          <a href="/{{package_name}}/metrics" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "metrics" %}aria-selected="true"{% endif %}>
+          <a href="/{{package.name}}/metrics" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "metrics" %}aria-selected="true"{% endif %}>
             Metrics
           </a>
         </li>
         <li class="p-tabs__item" role="presentation">
-          <a href="/{{package_name}}/publicise" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "publicise" %}aria-selected="true"{% endif %}>
+          <a href="/{{package.name}}/publicise" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "publicise" %}aria-selected="true"{% endif %}>
             Publicise
           </a>
         </li>
         <li class="p-tabs__item" role="presentation">
-          <a href="/{{package_name}}/settings" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "settings" %}aria-selected="true"{% endif %}>
+          <a href="/{{package.name}}/settings" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "settings" %}aria-selected="true"{% endif %}>
             Settings
           </a>
         </li>


### PR DESCRIPTION
## Done

- Update data for the publisher listing view

## QA

- You have to publish a charm with `charmcraft`
- Login as a publisher and go to:
- `http://localhost:8045/<YOUR_CHARM>/listing` , in my case http://localhost:8045/fran-wordpress/listing
- Modify any of the following available fields:
https://api.staging.charmhub.io/docs/default.html#update_package_metadata:
  - Contact
  - Description
  - Summary
  - Title
  - Website


## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1690
