### PR TITLE
Fix publisher settings page

### DIFF
--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -1,7 +1,6 @@
 {% extends 'publisher/publisher_layout.html' %}
 
 {% block title %}Listing details for {{ package.name }}{% endblock %}
-<!-- To DO - add copy and description -->
 {% block meta_copydoc %}{% endblock meta_copydoc %}
 {% block meta_description %}{% endblock %}
 

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -1,6 +1,8 @@
 {% extends 'publisher/publisher_layout.html' %}
 
-{% block title %}Settings for {{ package_name }}{% endblock %}
+{% block title %}Settings for {{ package.name }}{% endblock %}
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+{% block meta_description %}{% endblock %}
 
 {% set selected_tab='settings' %}
 

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -99,9 +99,12 @@ def post_listing(entity_name):
 @publisher.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/settings')
 @login_required
 def settings(entity_name):
+    package = publisher_api.get_package_metadata(
+        session["publisher-auth"], "charm", entity_name
+    )
+
     context = {
-        "package_name": entity_name,
-        "package_type": "charm",
+        "package": package,
     }
 
     return render_template("publisher/settings.html", **context)


### PR DESCRIPTION
## Done

- Fix publisher settings page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/<charm_name>/settings
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the settings page loads ok

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
