### PR TITLE
Add register charm name and dispute pages

### DIFF
--- a/static/sass/_charmhub_publisher.scss
+++ b/static/sass/_charmhub_publisher.scss
@@ -2,7 +2,6 @@
   @include charmhub-market;
   @include charmhub-market-screenshots;
   @include charmhub-form;
-  @include charmhub-p-dispute-list;
 }
 
 @mixin charmhub-form {
@@ -388,20 +387,6 @@
       max-width: 100%;
       pointer-events: none;
       user-select: none;
-    }
-  }
-}
-
-@mixin charmhub-p-dispute-list {
-  .p-charmhub-dispute-list__item {
-    .p-charmhub-dispute-list__link {
-      display: none;
-    }
-
-    &:hover {
-      .p-charmhub-dispute-list__link {
-        display: block;
-      }
     }
   }
 }

--- a/static/sass/_pattern_p-button-group.scss
+++ b/static/sass/_pattern_p-button-group.scss
@@ -3,7 +3,6 @@
     align-content: center;
     column-gap: 1rem;
     display: flex;
-    padding: 0.25rem 0;
 
     button:hover {
       border-color: $color-mid-light;
@@ -29,16 +28,11 @@
     }
 
     &__buttons {
-      border: 1px solid $color-mid-light;
-      border-radius: 0.25rem;
+      border: 1px solid $color-mid-dark;
+      border-radius: 0.125rem;
       display: flex;
-      margin-bottom: 0.5rem;
-      width: 100%;
-
-      @media (min-width: 1055px) {
-        margin-bottom: 0;
-        width: auto;
-      }
+      margin-bottom: 1rem;
+      width: auto;
     }
 
     &__inner {
@@ -49,16 +43,20 @@
     &__button {
       align-items: center;
       border: none;
-      border-right: 1px solid $color-mid-light;
+      border-right: 1px solid $color-mid-dark;
       color: $color-dark;
       display: flex;
       flex: 1;
       height: 100%;
       line-height: 1.5;
       margin: 0 !important; // Required to override Vanilla button:not(:last-of-type):not(:only-of-type)
-      padding: 0.25rem 0.5rem;
+      padding: calc(0.4rem - 1px) 1rem;
       text-align: center;
       white-space: nowrap;
+
+      &.is-smaller {
+        padding: 0.25rem 0.5rem;
+      }
 
       &.is-selected {
         background: $color-mid-x-light;

--- a/static/sass/charmhub_utils.scss
+++ b/static/sass/charmhub_utils.scss
@@ -23,6 +23,12 @@
     }
   }
 
+  .is-input--narrow {
+    @media screen and (min-width: $breakpoint-medium) {
+      max-width: 18.25rem;
+    }
+  }
+
   .is-wide {
     max-width: $grid-max-width !important;
   }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -63,6 +63,7 @@ $theme-default-nav: dark;
 @include vf-u-vertically-center;
 @include vf-u-vertical-spacing;
 @include vf-u-text-muted;
+@include vf-u-no-max-width;
 
 // Import site specific patterns and overrides
 @import "pattern_p-card";

--- a/templates/details/actions.html
+++ b/templates/details/actions.html
@@ -9,6 +9,16 @@
       <div class="col-3 has-space--right">
         <div class="p-side-navigation">
           <ul class="p-side-navigation__list">
+            <li class="p-side-navigation__item">
+              <a href="#one" class="p-side-navigation__link" role="tab" aria-controls="one">
+                some
+              </a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a href="#one" class="p-side-navigation__link" role="tab" aria-controls="one">
+                some
+              </a>
+            </li>
             {% for action in package.store_front.actions %}
               <li class="p-side-navigation__item">
                 <a href="#{{ action }}" class="p-side-navigation__link" role="tab" aria-controls="{{ action }}" {% if loop.index == 1 %}aria-current="page"{% endif %}>

--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -70,10 +70,10 @@ than the latest.</span>
             <div class="p-button-group">
               <div class="p-button-group__inner">
                 <div class="p-button-group__buttons">
-                  <a href="#docstrings" class="p-button-group__button" data-js="tab-button" data-href="#docstrings">
+                  <a href="#docstrings" class="p-button-group__button is-smaller" data-js="tab-button" data-href="#docstrings">
                     <i class="p-icon--docstrings">Docstrings</i><span>Docstrings</span>
                   </a>
-                  <a href="#source-code" class="p-button-group__button" data-js="tab-button" data-href="#source-code"><i class="p-icon--code">Code</i><span>Source code</span></a>
+                  <a href="#source-code" class="p-button-group__button is-smaller" data-js="tab-button" data-href="#source-code"><i class="p-icon--code">Code</i><span>Source code</span></a>
                 </div>
               </div>
             </div>

--- a/templates/partial/_header-publisher-packages.html
+++ b/templates/partial/_header-publisher-packages.html
@@ -1,7 +1,7 @@
-<div class="u-fixed-width">
+<div class="u-fixed-width is-wide">
   <ul class="p-inline-list u-no-margin--bottom">
     <li class="p-inline-list__item">
-      <h2 class="p-heading--4" style="display: inline-block;">My published {{ package_type }}s</h2>
+      <h2 style="display: inline-block;">Published {{ package_type }}s</h2>
     </li>
   </ul>
 </div>

--- a/templates/partial/_tabs-publisher-packages.html
+++ b/templates/partial/_tabs-publisher-packages.html
@@ -1,10 +1,16 @@
-<nav class="p-tabs has-no-arrow-mobile" data-js="tabs">
-  <ul class="p-tabs__list" role="tablist">
-    <li class="p-tabs__item" role="presentation">
-      <a href="/charms" class="p-tabs__link" tabindex="0" {% if package_type == "charm" %}aria-selected="true"{% endif %}>Charms</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a href="/bundles" class="p-tabs__link" tabindex="-1" {% if package_type == "bundle" %}aria-selected="true"{% endif %}>Bundles</a>
-    </li>
-  </ul>
-</nav>
+<ul class="p-inline-list--stretch">
+  <li class="p-inline-list__item u-no-margin--right">
+    <div class="p-button-group">
+      <div class="p-button-group__inner">
+        <div class="p-button-group__buttons">
+          <a href="/charms" class="p-button-group__button{% if request.path.endswith('charms') %} is-selected{% endif %}">Charms</a>
+          <a href="/bundles" class="p-button-group__button{% if request.path.endswith('bundles') %} is-selected{% endif %}">Bundles</a>
+        </div>
+      </div>
+    </div>
+  </li>
+  <li class="p-inline-list__item u-align--right">
+    <a href="/register-name" class="p-button--neutral">Register a new charm or bundle</a>
+  </li>
+</ul>
+

--- a/templates/publisher/bundles.html
+++ b/templates/publisher/bundles.html
@@ -2,23 +2,16 @@
 
 {% set package_type = "bundle"%}
 
-<!-- To DO - add copy -->
 {% block meta_description %}{% endblock meta_description %}
 {% block meta_copydoc %}{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip u-extra-space is-shallow">
-  <div class="u-fixed-width">
+  <div class="u-fixed-width is-wide">
     {% include "partial/_tabs-publisher-packages.html" %}
   </div>
   <div class="p-details-tab__content" id="bundles">
-    <div class="u-fixed-width">
-      <ul class="p-inline-list u-no-margin--bottom">
-        <li class="p-inline-list__item">
-          <h2 class="p-heading--4" style="display: inline-block;">My published bundles</h2>
-        </li>
-      </ul>
-    </div>
+    {% include "partial/_header-publisher-packages.html" %}
   </div>
 </section>
 {% endblock %}

--- a/templates/publisher/charms.html
+++ b/templates/publisher/charms.html
@@ -2,18 +2,17 @@
 
 {% set package_type = "charm"%}
 
-<!-- To DO - add copy -->
 {% block meta_description %}{% endblock meta_description %}
 {% block meta_copydoc %}{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip u-extra-space is-shallow">
-  <div class="u-fixed-width">
+  <div class="u-fixed-width is-wide">
     {% include "partial/_tabs-publisher-packages.html" %}
   </div>
   <div class="p-details-tab__content">
     {% include "partial/_header-publisher-packages.html" %}
-    <div class="u-fixed-width">
+    <div class="u-fixed-width is-wide">
       <table class="p-table--mobile-card" role="grid">
         <thead>
           <tr role="row">
@@ -36,9 +35,9 @@
             </td>
             <td role="gridcell" aria-label="visibility">
               {% if published_charm.private %}
-                Private
+              Private
               {% else %}
-                Public
+              Public
               {% endif %}
             </td>
           </tr>
@@ -46,22 +45,41 @@
         </tbody>
       </table>
     </div>
+    {% set registered=[{"name": "My name is DD", "visibility": "Public"}]%}
     {% if registered %}
     <div class="p-strip is-shallow">
-      <div class="u-fixed-width">
-        <h4 class="p-heading--5">Registered charm names ({{ registered|length }})</h4>
+      <div class="u-fixed-width is-wide u-flex" style="align-items: center;">
+        <h4 class="p-heading--2">Registered charm names</h4>
+        <div class="p-tooltip--information instruction-tooltip">
+          <div class="p-tooltip__button" role="button" aria-controls="icon-tooltip-modal" tabindex="0">
+            Show information
+          </div>
+          <div class="p-tooltip__modal" aria-controls="icon-tooltip-modal" id="icon-tooltip-modal">
+            <div class="p-tooltip__dialog" role="dialog" aria-labelledby="modal-content" style="position: relative; top: -0.8rem; width: 14.5rem;">
+              <span id="modal-content" class="u-no-margin--bottom u-no-padding--top">
+                <a href="/tutorials/publish-on-charmhub">Learn how to publish your operator in Charmhub.</a>
+              </span>
+            </div>
+          </div>
+        </div>
       </div>
-      <div class="row">
+      <div class="row is-wide">
         <div class="col-6">
-          <table>
+          <table aria-label="Registered charm names">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Visibility</th>
+              </tr>
+            </thead>
             <tbody>
               {% for registered_charm in registered %}
-              <tr class="p-charmhub-dispute-list__item">
+              <tr>
                 <td style="width: 50%;">
-                  {{ registered_charm['name'] }}
+                  <a href="/{{ registered_charm['name'] }}/listing">{{ registered_charm['name'] }}</a>
                 </td>
                 <td>
-                  <a href="/docs/releasing-your-app" target="_blank" class="p-charmhub-dispute-list__link u-float-right">Publish to this name</a>
+                  {{ registered_charm['visibility'] }}
                 </td>
               </tr>
               {% endfor %}

--- a/templates/publisher/publisher_layout.html
+++ b/templates/publisher/publisher_layout.html
@@ -3,7 +3,7 @@
 {% block content %}
 <section class="p-strip is-shallow u-no-padding--bottom">
   <div class="u-fixed-width">
-    <a href="/charms">&lsaquo;&nbsp;My charms & bundles</a>
+    <a href="/charms">&lsaquo;&nbsp;My charms &amp; bundles</a>
     <h1 class="p-heading--3">
       {{package.name}}
     </h1>

--- a/templates/publisher/register-name-dispute/index.html
+++ b/templates/publisher/register-name-dispute/index.html
@@ -1,0 +1,48 @@
+{% extends 'publisher/publisher_layout.html' %}
+
+{% block title %}Claim a name that is already registered{% endblock %}
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+{% block meta_description %}{% endblock %}
+
+{% block content %}
+<section class="p-strip is-shallow">
+  <div class="u-fixed-width is-wide">
+    <a href="/charms">&lsaquo;&nbsp;My charms &amp; bundles</a>
+    <h1 class="p-heading--2">
+      Claim the name <strong>{{ entity_name }}</strong>
+    </h1>
+    <p class="u-no-max-width">By completing this form you are requesting for this name to be transferred to you from its owner.</p>
+    <form class="p-form p-form--stacked" action="" method="POST">
+      <div class="p-form__group row is-wide u-no-padding">
+        <div class="col-2">
+          <p class="is-label">Charm/bundle name:</p>
+        </div>
+        <div class="col-6">
+          <div class="p-form__control u-clearfix">
+            <span>{{ entity_name }}</span>
+            <input hidden="text" id="entity-name" name="entity-name" value="{{ entity_name }}">
+          </div>
+        </div>
+      </div>
+      <div class="p-form__group row is-wide u-no-padding">
+        <div class="col-2">
+          <label for="claim-comment" class="p-form__label">Comment:</label>
+        </div>
+        <div class="col-6">
+          <div class="p-form__control u-clearfix">
+            <textarea id="claim-comment" name="claim-comment"></textarea>
+            <p class="p-form-help-text">Explain why you would like this name to be transferred from its current owner</p>
+          </div>
+        </div>
+      </div>
+      <hr class="p-separator--shallow">
+      <div class="u-align--right">
+        <a class="p-button--neutral" href="/charms" style="margin-inline-end: 1rem;">Cancel</a>
+        <button type="submit" class="p-button--positive">
+          Submit claim
+        </button>
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/templates/publisher/register-name-dispute/thank-you.html
+++ b/templates/publisher/register-name-dispute/thank-you.html
@@ -1,0 +1,21 @@
+{% extends 'publisher/publisher_layout.html' %}
+
+{% block title %}Thank you forrequesting the name {{ entity_name}}{% endblock %}
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+{% block meta_description %}{% endblock %}
+
+{% block content %}
+<section class="p-strip is-shallow">
+  <div class="u-fixed-width is-wide">
+    <a href="/charms">&lsaquo;&nbsp;My charms &amp; bundles</a>
+    <h1 class="p-heading--2">
+      Thank you for requesting the name <strong>{{ entity_name }}</strong>
+    </h1>
+    <p>We will process the details provided with the name dispute.</p>
+    <p>Each case is reviewed individually and we can’t provide an estimate on how long it will take for us to process this information. We will contact you once we confirm the information provided.</p>
+    <p>
+      <a href="/charms" class="p-button--positive">Return to my charms</a>
+    </p>
+  </div>
+</section>
+{% endblock %}

--- a/templates/publisher/register-name.html
+++ b/templates/publisher/register-name.html
@@ -1,0 +1,57 @@
+{% extends 'publisher/publisher_layout.html' %}
+
+{% block title %}Register a new charm or bundle{% endblock %}
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+{% block meta_description %}{% endblock %}
+
+{% block content %}
+<section class="p-strip is-shallow">
+  <div class="u-fixed-width is-wide">
+    <a href="/charms">&lsaquo;&nbsp;My charms &amp; bundles</a>
+    <h1 class="p-heading--2">
+      Register a new charm or bundle
+    </h1>
+    <p>You must register a name before you publish a new charm or bundle to the store.</p>
+    <form class="p-form" action="">
+      <div>
+        <label for="name">Name:</label>
+        <input class="is-input--narrow" id="name" name="name" type="text" autocomplete="name">
+        <p class="p-form-help-text u-no-max-width">It should only have ASCII lowercase letters, numbers, and hyphens, and must have at least one letter</p>
+      </div>
+      <div>
+        <label class="p-radio">
+          <p class="is-label">Type:</p>
+          <p class="p-form-help-text">This can NOT be changed after the initial upload</p>
+          <input type="radio" class="p-radio__input" name="type" checked="" aria-labelledby="charm" value="charm">
+          <span class="p-radio__label" id="charm">Charm</span>
+        </label>
+        <label class="p-radio">
+          <input type="radio" class="p-radio__input" name="type" aria-labelledby="bundle" value="bundle">
+          <span class="p-radio__label" id="bundle">Bundle</span>
+        </label>
+      </div>
+      <div style="margin-block-end: 2.5rem;">
+        <label class="p-radio">
+          <p class="is-label">Visibility:</p>
+          <p class="p-form-help-text">This can be changed at any time after the initial upload</p>
+          <input type="radio" class="p-radio__input" name="visibility" checked="" aria-labelledby="public" value="pubic">
+          <span class="p-radio__label" id="public">Public</span>
+        </label>
+        <p class="p-form-help-text" style="padding-inline-start: 2rem;">Anyone can find your charm in the Charmhub</p>
+        <label class="p-radio">
+          <input type="radio" class="p-radio__input" name="visibility" aria-labelledby="private" value="private">
+          <span class="p-radio__label" id="private">Private</span>
+        </label>
+        <p class="p-form-help-text" style="padding-inline-start: 2rem;">Charm is hidden in the store and only accessible by the publisher and collaborators</p>
+      </div>
+      <hr class="p-separator--shallow">
+      <div class="u-align--right">
+        <a class="p-button--neutral" href="/charms" style="margin-inline-end: 1rem;">Cancel</a>
+        <button type="submit" class="p-button--positive">
+          Register
+        </button>
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -36,12 +36,6 @@
           </label>
         </div>
         <div class="p-form__control">
-          <input type="radio" name="private" id="is-unlisted" {% if not private and unlisted %}checked="checked" {% endif %} value="unlisted">
-          <label for="is-unlisted">Unlisted
-            <span class="p-form-help-text">Does not appear in search results. Anyone can deploy using the charm name.</span>
-          </label>
-        </div>
-        <div class="p-form__control">
           <input type="radio" name="private" id="is-private" {% if private %}checked="checked" {% endif %} value="private">
           <label for="is-private">Private
             <span class="p-form-help-text">Hidden in the Charmhub. Only accessible by the publisher and collaborators.</span>

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -108,3 +108,37 @@ def settings(entity_name):
     }
 
     return render_template("publisher/settings.html", **context)
+
+
+@publisher.route("/register-name")
+@login_required
+def register_name():
+
+    return render_template("publisher/register-name.html")
+
+
+@publisher.route("/register-name-dispute")
+@login_required
+def register_name_dispute():
+    entity_name = request.args.get("entity-name", type=str)
+
+    if not entity_name:
+        return redirect(url_for(".register_name", entity_name=entity_name))
+
+    return render_template(
+        "publisher/register-name-dispute/index.html", entity_name=entity_name
+    )
+
+
+@publisher.route("/register-name-dispute/thank-you")
+@login_required
+def register_name_dispute_thank_you():
+    entity_name = request.args.get("entity-name", type=str)
+
+    if not entity_name:
+        return redirect(url_for(".register_name", entity_name=entity_name))
+
+    return render_template(
+        "publisher/register-name-dispute/thank-you.html",
+        entity_name=entity_name,
+    )


### PR DESCRIPTION
## Done

- Add register charm page
- Add register name dispute page
- Add register name dispute thank you page
- Update charms page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to http://localhost:8045/charms and compare to [design](https://app.zeplin.io/project/5fb68befd7ea8e4d263f3c26/screen/5fb68cefbe4d689491830eef)
- Go to http://localhost:8045/register-name and compare to [design](https://app.zeplin.io/project/5fb68befd7ea8e4d263f3c26/screen/5fb68cf099a00179b9f91b63)
- Go to http://localhost:8045/register-name-dispute?entity-name=firefox and compare to [design](https://app.zeplin.io/project/5fb68befd7ea8e4d263f3c26/screen/5fbbccbec33feb5a1fa27f97)
- Go to http://localhost:8045/register-name-dispute/thank-you?entity-name=firefox and compare to [design](https://app.zeplin.io/project/5fb68befd7ea8e4d263f3c26/screen/5fbbecfd9205735c3ad43a00)


## Issue / Card

Fixes #160 
Fixes #161

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/100203896-1772ca80-2efb-11eb-80ca-69998d2a6e63.png)

