### PR TITLE
Add summary and description to the charm overview page

### DIFF
--- a/static/js/src/libs/truncate-string.js
+++ b/static/js/src/libs/truncate-string.js
@@ -1,0 +1,28 @@
+/**
+ * Truncates a string to a word break.
+ * @param {string} str The string to be truncaed.
+ * @param {number} len The length that the string will be truncated to.
+ * @param {string} append This is optional.
+ * @returns {string} The truncated string.
+ */
+function truncateString(str, len, append = "...") {
+  let newLength;
+
+  if (str.indexOf(" ") + append.length > len) {
+    return str; //if the first word + the appended text is too long, the function returns the original String
+  }
+
+  str.length + append.length > len
+    ? (newLength = len - append.length)
+    : (newLength = str.length); // if the length of original string and the appended string is greater than the max length, we need to truncate, otherwise, use the original string
+
+  let tempString = str.substring(0, newLength); //cut the string at the new length
+  tempString = tempString.replace(/\s+\S*$/, ""); //find the last space that appears before the substringed text
+
+  if (append.length > 0) {
+    tempString = tempString + append;
+  }
+  return tempString;
+}
+
+export { truncateString };

--- a/static/js/src/public/details/index.js
+++ b/static/js/src/public/details/index.js
@@ -1,12 +1,40 @@
 import { HistoryState } from "./historyState";
 import { TableOfContents } from "./tableOfContents";
 import { channelMap } from "./channelMap";
+import { truncateString } from "../../libs/truncate-string";
 
 if (window.location.hash) {
   setTimeout(() => {
     window.scrollTo(0, 0);
   }, 1);
 }
+
+const truncateSummary = (selector) => {
+  const summaryEl = document.querySelector(selector);
+
+  if (summaryEl) {
+    const showMoreEl = summaryEl.querySelector("[data-js='summary-read-more']");
+    const summaryContentEl = summaryEl.querySelector(
+      "[data-js='summary-content']"
+    );
+    const summary = summaryEl.getAttribute("data-summary");
+
+    if (summary.length > 103) {
+      const truncatedSummary = truncateString(summary, 103);
+      summaryContentEl.innerHTML = truncatedSummary;
+
+      showMoreEl.classList.remove("u-hide");
+
+      showMoreEl.addEventListener("click", (e) => {
+        e.preventDefault();
+        showMoreEl.classList.add("u-hide");
+        summaryContentEl.innerHTML = summary;
+      });
+    }
+  } else {
+    throw new Error(`There are no elements containing ${selector} selector.`);
+  }
+};
 
 const init = (packageName) => {
   const historyState = new HistoryState();
@@ -59,6 +87,8 @@ const init = (packageName) => {
   if (channelMapButton) {
     channelMap(packageName, channelMapButton);
   }
+
+  truncateSummary("[data-js='summary']");
 };
 
 export { init };

--- a/static/js/src/public/details/libraries/index.js
+++ b/static/js/src/public/details/libraries/index.js
@@ -8,7 +8,7 @@ const init = (tabSelector, tabContentSelector) => {
     new TabSwitch(tabButtonsList, tabContentList);
   } else {
     throw new Error(
-      `There are no elements containing or ${
+      `There are no elements containing ${
         tabButtonsList ? tabContentSelector : tabSelector
       } selector.`
     );

--- a/templates/details/overview.html
+++ b/templates/details/overview.html
@@ -5,11 +5,19 @@
 {% block details_content %}
   <div class="row is-wide p-details-tab__content">
     <div class="col-3 has-space--right">
+      {% if package.result.summary %}
+        <h4 class="p-heading--5 u-no-margin--bottom">About</h4>
+        <p data-js="summary" data-summary="{{ package.result.summary }}">
+          <span data-js="summary-content" style="overflow-wrap: break-word;">{{ package.result.summary }}</span>
+          <a href="/{{ package.name }}" class="is-always-color-link u-hide" data-js="summary-read-more">Read more</a>
+        </p>
+        <hr class="p-separator--shallow">
+      {% endif %}
       {% if package.result.license %}
         <p><span class="u-text--muted">License</span><br />{{ package.result.license }}</p>
+        <hr class="p-separator--shallow">
       {% endif %}
       {% if package.result.website or package.result.repository or package.result.contact %}
-        <hr class="p-separator--shallow">
         <h4 class="p-heading--5 u-no-margin--bottom">Relevant links</h4>
         <ul class="p-list">
         {% if package.result.website %}
@@ -32,6 +40,7 @@
           </li>
         {% endif %}
         </ul>
+        <hr class="p-separator--shallow">
       {% endif %}
       <h4 class="p-heading--5 u-no-margin--bottom">Discuss this {{ package.type }}</h4>
       <p>Share your thoughts on this charm with the community on discourse.</p>

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -175,7 +175,7 @@ def get_licenses():
     return licenses
 
 
-def increase_headers(html_content, step=2):
+def decrease_headers(html_content, step=2):
     soup = BeautifulSoup(html_content, features="html.parser")
 
     # Change all the headers (if step=2: eg h1 => h3)

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 import humanize
 from dateutil import parser
 from docstring_extractor import get_docstrings
-from webapp.helpers import increase_headers
+from webapp.helpers import decrease_headers
 from webapp.helpers import (
     discourse_api,
     format_slug,
@@ -444,16 +444,16 @@ def process_python_docs(library, module_name):
     # Obtain Python docstrings
     docstrings = get_docstrings(library["content"], module_name)
 
-    docstrings["html"] = increase_headers(
+    docstrings["html"] = decrease_headers(
         md_parser(docstrings["docstring"]), 3
     )
 
     # We support markdown inside docstrings (2 levels)
     for py_part in docstrings["content"]:
-        py_part["html"] = increase_headers(md_parser(py_part["docstring"]), 3)
+        py_part["html"] = decrease_headers(md_parser(py_part["docstring"]), 3)
 
         for py_part_2 in py_part["content"]:
-            py_part_2["html"] = increase_headers(
+            py_part_2["html"] = decrease_headers(
                 md_parser(py_part_2["docstring"]), 3
             )
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -13,7 +13,7 @@ from webapp.decorators import (
     redirect_uppercase_to_lowercase,
 )
 from webapp.feature import FEATURED_CHARMS
-from webapp.helpers import discourse_api, increase_headers, md_parser
+from webapp.helpers import discourse_api, decrease_headers, md_parser
 from webapp.store import logic
 
 store = Blueprint(
@@ -124,6 +124,7 @@ FIELDS = [
     "result.categories",
     "result.publisher.display-name",
     "result.summary",
+    "result.description",
     "channel-map",
     "channel-map.revision.readme-md",
     "channel-map.revision.actions-yaml",
@@ -176,7 +177,7 @@ def details_overview(entity_name):
     readme = re.sub("(<!--.*-->)", "", readme, flags=re.DOTALL)
 
     readme = md_parser(readme)
-    readme = increase_headers(readme)
+    readme = decrease_headers(readme)
 
     return render_template(
         "details/overview.html",


### PR DESCRIPTION
## Done

- Add summary and description to the charm overview page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/discourse
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See there is a summary and a description at the top of the page


## Issue / Card

Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/688

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/100734277-50adad80-33c7-11eb-8805-9cdcbd941ccf.png)


