### PR TITLE
Add empty state

### DIFF
--- a/templates/details/details_layout.html
+++ b/templates/details/details_layout.html
@@ -22,6 +22,8 @@
      },
      {% if package.store_front.categories %}
        "applicationCategory": "{{ package.store_front.categories[0].name }}",
+     {% else %}
+       "applicationCategory": "other",
      {% endif %}
      "operatingSystem": "{{ package["channel_selected"]["channel"]["platform"]["os"] }}",
      "softwareVersion": "{{ package["channel_selected"]["channel"]["name"] }}"


### PR DESCRIPTION
## Done

Add empty state for charms with no category

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/mattermost 
- Make sure that `applicationCategory` is empty
- You can test : https://search.google.com/test/rich-results
- Make sure it's green :)
