### PR TITLE
Update integrate page icons design

### DIFF
--- a/static/sass/_pattern_grid.scss
+++ b/static/sass/_pattern_grid.scss
@@ -5,6 +5,12 @@
     }
   }
 
+  .col-x-large-3 {
+    @media screen and (min-width: $breakpoint-large) {
+      grid-column-end: span 3;
+    }
+  }
+
   .col-large-6 {
     @media (min-width: 1300px) {
       grid-column-end: span 6;

--- a/static/sass/_pattern_p-media-object.scss
+++ b/static/sass/_pattern_p-media-object.scss
@@ -1,4 +1,32 @@
 @mixin p-charmhub-media-object {
+  .p-media-object.has-separator {
+    margin-block-end: 4.75rem;
+
+    @media screen and (max-width: $breakpoint-medium) {
+      margin-block-end: 2.5rem;
+    }
+
+    .p-media-object__image {
+      height: 40px;
+      margin-inline-end: 1rem;
+      width: 40px;
+    }
+
+    .p-media-object__details {
+      border-left: 1px solid $color-mid-light;
+      display: flex;
+      max-width: 10rem;
+      padding-inline-start: 1rem;
+
+      .p-button--base {
+        font-size: 21px;
+        padding-inline-end: 0;
+        padding-inline-start: 0;
+        text-align: left;
+      }
+    }
+  }
+
   .p-media-object--medium {
     .p-bundle-icons {
       $icon-size: 3.75rem;

--- a/templates/details/integrate.html
+++ b/templates/details/integrate.html
@@ -7,74 +7,83 @@
     <p>Charms that integrate with {{ package.name }}:</p>
   </div>
   <div class="row is-wide">
-    <div class="col-3">
-      <div class="p-media-object">
-        <img src="https://api.jujucharms.com/charmstore/v5/prometheus/icon.svg" alt="" class="p-media-object__image is-round" style="height: 32px; width: 32px;">
-        <div class="p-media-object__details u-vertically-center">
-          <button class="p-button--base is-dense u-no-padding--left u-no-padding--right integration-list-icon" aria-controls="modal" data-package="prometheus">prometheus</button>
+    <div class="col-4 col-x-large-3">
+      <div class="p-media-object has-separator">
+        <img src="https://api.jujucharms.com/charmstore/v5/apache2/icon.svg" alt="" class="p-media-object__image is-round">
+        <div class="p-media-object__details">
+          <button class="p-button--base is-dense integration-list-icon" aria-controls="modal" data-package="apache">Apache</button>
         </div>
       </div>
     </div>
 
-    <div class="col-3">
-      <div class="p-media-object">
-        <img src="https://api.jujucharms.com/charmstore/v5/keystone/icon.svg" alt="" class="p-media-object__image is-round" style="height: 32px; width: 32px;">
-        <div class="p-media-object__details u-vertically-center">
-          <button class="p-button--base is-dense u-no-padding--left u-no-padding--right integration-list-icon" aria-controls="modal" data-package="keystone">keystone</button>
+    <div class="col-4 col-x-large-3">
+      <div class="p-media-object has-separator">
+        <img src="https://api.jujucharms.com/charmstore/v5/prometheus/icon.svg" alt="" class="p-media-object__image is-round">
+        <div class="p-media-object__details">
+          <button class="p-button--base is-dense integration-list-icon" aria-controls="modal" data-package="prometheus">Prometheus</button>
         </div>
       </div>
     </div>
 
-    <div class="col-3">
-      <div class="p-media-object">
-        <img src="https://api.jujucharms.com/charmstore/v5/vault/icon.svg" alt="" class="p-media-object__image is-round" style="height: 32px; width: 32px;">
-        <div class="p-media-object__details u-vertically-center">
-          <button class="p-button--base is-dense u-no-padding--left u-no-padding--right integration-list-icon" aria-controls="modal" data-package="vault">vault</button>
+    <div class="col-4 col-x-large-3">
+      <div class="p-media-object has-separator">
+        <img src="https://api.jujucharms.com/charmstore/v5/keystone/icon.svg" alt="" class="p-media-object__image is-round">
+        <div class="p-media-object__details">
+          <button class="p-button--base is-dense integration-list-icon" aria-controls="modal" data-package="keystone">keystone</button>
         </div>
       </div>
     </div>
 
-    <div class="col-3">
-      <div class="p-media-object">
-        <img src="https://api.jujucharms.com/charmstore/v5/mysql/icon.svg" alt="" class="p-media-object__image is-round" style="height: 32px; width: 32px;">
-        <div class="p-media-object__details u-vertically-center">
-          <button class="p-button--base is-dense u-no-padding--left u-no-padding--right integration-list-icon" aria-controls="modal" data-package="mysql">mysql</button>
+    <div class="col-4 col-x-large-3">
+      <div class="p-media-object has-separator">
+        <img src="https://api.jujucharms.com/charmstore/v5/vault/icon.svg" alt="" class="p-media-object__image is-round">
+        <div class="p-media-object__details">
+          <button class="p-button--base is-dense integration-list-icon" aria-controls="modal" data-package="vault">vault</button>
         </div>
       </div>
     </div>
 
-    <div class="col-3">
-      <div class="p-media-object">
-        <img src="https://api.jujucharms.com/charmstore/v5/hacluster/icon.svg" alt="" class="p-media-object__image is-round" style="height: 32px; width: 32px;">
-        <div class="p-media-object__details u-vertically-center">
-          <button class="p-button--base is-dense u-no-padding--left u-no-padding--right integration-list-icon" aria-controls="modal" data-package="hacluster">hacluster</button>
+    <div class="col-4 col-x-large-3">
+      <div class="p-media-object has-separator">
+        <img src="https://api.jujucharms.com/charmstore/v5/mysql/icon.svg" alt="" class="p-media-object__image is-round">
+        <div class="p-media-object__details">
+          <button class="p-button--base is-dense integration-list-icon" aria-controls="modal" data-package="mysql">mysql</button>
         </div>
       </div>
     </div>
 
-    <div class="col-3">
-      <div class="p-media-object">
-        <img src="https://api.jujucharms.com/charmstore/v5/nrpe/icon.svg" alt="" class="p-media-object__image is-round" style="height: 32px; width: 32px;">
-        <div class="p-media-object__details u-vertically-center">
-          <button class="p-button--base is-dense u-no-padding--left u-no-padding--right integration-list-icon" aria-controls="modal" data-package="nrpe">nrpe</button>
+    <div class="col-4 col-x-large-3">
+      <div class="p-media-object has-separator">
+        <img src="https://api.jujucharms.com/charmstore/v5/hacluster/icon.svg" alt="" class="p-media-object__image is-round">
+        <div class="p-media-object__details">
+          <button class="p-button--base is-dense integration-list-icon" aria-controls="modal" data-package="hacluster">hacluster</button>
         </div>
       </div>
     </div>
 
-    <div class="col-3">
-      <div class="p-media-object">
-        <img src="https://api.jujucharms.com/charmstore/v5/octavia-dashboard/icon.svg" alt="" class="p-media-object__image is-round" style="height: 32px; width: 32px;">
-        <div class="p-media-object__details u-vertically-center">
-          <button class="p-button--base is-dense u-no-padding--left u-no-padding--right integration-list-icon" aria-controls="modal" data-package="octavia-dashboard">octavia-dashboard</>
+    <div class="col-4 col-x-large-3">
+      <div class="p-media-object has-separator">
+        <img src="https://api.jujucharms.com/charmstore/v5/nrpe/icon.svg" alt="" class="p-media-object__image is-round">
+        <div class="p-media-object__details">
+          <button class="p-button--base is-dense integration-list-icon" aria-controls="modal" data-package="nrpe">nrpe</button>
         </div>
       </div>
     </div>
 
-    <div class="col-3">
-      <div class="p-media-object">
-        <img src="https://api.jujucharms.com/charmstore/v5/apache2/icon.svg" alt="" class="p-media-object__image is-round" style="height: 32px; width: 32px;">
-        <div class="p-media-object__details u-vertically-center">
-          <button class="p-button--base is-dense u-no-padding--left u-no-padding--right integration-list-icon" aria-controls="modal" data-package="apache2">apache2</button>
+    <div class="col-4 col-x-large-3">
+      <div class="p-media-object has-separator">
+        <img src="https://api.jujucharms.com/charmstore/v5/~openstack-charmers-next/trilio-horizon-plugin-19/icon.svg" alt="" class="p-media-object__image is-round">
+        <div class="p-media-object__details">
+          <button class="p-button--base is-dense integration-list-icon" aria-controls="modal" data-package="trilio-horizon-plugin">Trilio Horizon Plugin</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-4 col-x-large-3">
+      <div class="p-media-object has-separator">
+        <img src="https://api.jujucharms.com/charmstore/v5/octavia-dashboard/icon.svg" alt="" class="p-media-object__image is-round">
+        <div class="p-media-object__details">
+          <button class="p-button--base is-dense integration-list-icon" aria-controls="modal" data-package="octavia-dashboard">Octavia Dashboard</>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Update integrate page icons design

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/prometheus/integrate
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [design](https://app.zeplin.io/project/5f92a9530029eeac84ae9589/screen/5fb260c0e045c169dccdba0c)


## Issue / Card

Fixes #677 

## Screenshots

[if relevant, include a screenshot]
