### PR TITLE
Update featured charm publisher

### DIFF
--- a/webapp/feature.py
+++ b/webapp/feature.py
@@ -16,7 +16,7 @@ FEATURED_CHARMS = [
         "name": "postgresql-k8s",
         "display_name": "PostgreSQL",
         "summary": "PostgreSQL charm for Kubernetes deployments.",
-        "publisher": "team-ion",
+        "publisher": "postgresql-charmers",
         "icon": "https://api.snapcraft.io/api/v1/media/download/charm_zDdv4KnGGAGTYSKyvZtmBleis8tLcKii_icon__58a751522b5f0849e40c39418ea99526f731997ae7720636a5881adce75742d7.png",
         "platform": "kubernetes",
     },

--- a/webapp/feature.py
+++ b/webapp/feature.py
@@ -14,7 +14,7 @@ FEATURED_CHARMS = [
     },
     {
         "name": "postgresql-k8s",
-        "display_name": "PostgreSQL",
+        "display_name": "Postgresql K8S",
         "summary": "PostgreSQL charm for Kubernetes deployments.",
         "publisher": "postgresql-charmers",
         "icon": "https://api.snapcraft.io/api/v1/media/download/charm_zDdv4KnGGAGTYSKyvZtmBleis8tLcKii_icon__58a751522b5f0849e40c39418ea99526f731997ae7720636a5881adce75742d7.png",

--- a/webapp/feature.py
+++ b/webapp/feature.py
@@ -14,7 +14,7 @@ FEATURED_CHARMS = [
     },
     {
         "name": "postgresql-k8s",
-        "display_name": "Postgresql K8S",
+        "display_name": "PostgreSQL K8s",
         "summary": "PostgreSQL charm for Kubernetes deployments.",
         "publisher": "postgresql-charmers",
         "icon": "https://api.snapcraft.io/api/v1/media/download/charm_zDdv4KnGGAGTYSKyvZtmBleis8tLcKii_icon__58a751522b5f0849e40c39418ea99526f731997ae7720636a5881adce75742d7.png",


### PR DESCRIPTION
## Done
Featured charms are still hardccoded.
Update charm publisher name for postgresql charm

## QA

- `dotrun`
- on the homepage make sure the charm publsiher name matches the name of the user on the charm details page for teh postgresql charm


## Issue / Card

Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/705