### PR TITLE
Fix side navigation to be able to close it on mobile

### DIFF
--- a/static/sass/_pattern_p-navigation.scss
+++ b/static/sass/_pattern_p-navigation.scss
@@ -30,6 +30,12 @@
     margin-right: 0;
   }
 
+  @media screen and (max-width: $breakpoint-navigation-threshold - 1) {
+    .p-side-navigation__drawer {
+      margin-block-start: 5rem;
+    }
+  }
+
   @media screen and (min-width: $breakpoint-navigation-threshold) {
     .p-navigation .p-navigation__item.is-selected {
       background-color: $color-x-light;

--- a/templates/about/about_layout.html
+++ b/templates/about/about_layout.html
@@ -4,7 +4,7 @@
 <section class="p-strip--main">
   <div class="row">
     <div class="col-2">
-      <div class="p-side-navigation is-at-the-top" id="drawer">
+      <div class="p-side-navigation" id="drawer">
         <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation
         </a>

--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -5,7 +5,7 @@
 {% block details_content %}
   <div class="row is-wide p-details-tab__content">
     <div class="col-3 has-space--right">
-      <div class="p-side-navigation is-at-the-top" id="drawer" style="overflow-y: visible;">
+      <div class="p-side-navigation" id="drawer" style="overflow-y: visible;">
         <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation
         </a>


### PR DESCRIPTION
## Done

- Fix side navigation to be able to close it on mobile

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/about
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to mobile view and see the side nav is functional and looks right


## Issue / Card

Fixes #456

## Screenshots

[if relevant, include a screenshot]
