### PR TITLE
Add mobile filters to store page

### DIFF
--- a/static/js/src/public/store/charms.js
+++ b/static/js/src/public/store/charms.js
@@ -15,6 +15,36 @@ function initCharms() {
       enableAllActions();
     })
     .catch((e) => console.error(e));
+
+  initMobileFilters(
+    "[data-js='filter-button-mobile-open']",
+    "[data-js='filter-button-mobile-close']"
+  );
+}
+
+function initMobileFilters(selectorOpen, selectorClose) {
+  const openButton = document.querySelector(selectorOpen);
+  const closeButton = document.querySelector(selectorClose);
+
+  if (openButton && closeButton) {
+    const filtersEl = document.querySelector(".p-layout__sidenav");
+
+    openButton.addEventListener("click", (e) => {
+      e.preventDefault();
+      filtersEl.classList.add("is-expanded");
+    });
+
+    closeButton.addEventListener("click", (e) => {
+      e.preventDefault();
+      filtersEl.classList.remove("is-expanded");
+    });
+  } else {
+    throw new Error(
+      `There are no elements containing ${
+        openButton ? closeButton : openButton
+      } selector.`
+    );
+  }
 }
 
 function getCharmsList() {

--- a/static/sass/_charmhub_p-filter.scss
+++ b/static/sass/_charmhub_p-filter.scss
@@ -1,6 +1,12 @@
 @mixin p-charmhub-filter {
   .p-filter {
     padding-block-start: 0.625rem;
-    padding-left: 0.5rem;
+    padding-inline-start: 0.5rem;
+  }
+
+  .is-expanded {
+    .p-filter {
+      padding-inline-start: 1rem;
+    }
   }
 }

--- a/static/sass/_charmhub_p-layout-store.scss
+++ b/static/sass/_charmhub_p-layout-store.scss
@@ -10,10 +10,86 @@
     }
 
     .p-layout__sidenav {
+      @keyframes vf-p-side-navigation-expand {
+        0% {
+          transform: translate(-100%);
+        }
+
+        100% {
+          transform: translate(0);
+        }
+      }
+
+      @keyframes vf-p-side-navigation-collapse {
+        0% {
+          transform: translate(0);
+        }
+
+        100% {
+          display: none;
+          transform: translate(-100%);
+        }
+      }
+
+      animation:
+        vf-p-side-navigation-collapse
+        map-get($animation-duration, brisk);
+      display: none;
+
+      &.is-expanded {
+        animation:
+          vf-p-side-navigation-expand
+          map-get($animation-duration, brisk);
+        background-color: $color-x-light;
+        display: block;
+        left: 0;
+        max-height: 100%;
+        min-height: 100%;
+        overflow: auto;
+        position: fixed;
+        right: 0;
+        top: 0;
+        z-index: 101;
+      }
+
       @media screen and(min-width: $breakpoint-medium) {
         margin-inline-end: 2rem;
         min-width: 13.5rem;
         width: 13.5rem;
+      }
+
+      @media screen and (min-width: $breakpoint-medium) {
+        display: block;
+      }
+
+      .p-sidenav__drawer-header {
+        border-bottom: 1px solid $color-mid-x-light;
+        display: none;
+        padding: $spv-inner--small 0 $spv-inner--small $spv-inner--small;
+
+        @media screen and (max-width: $breakpoint-medium - 1) {
+          display: block;
+        }
+
+        .p-sidenav__toggle {
+          @extend %vf-button-base;
+
+          border: none;
+          color: $color-dark;
+          margin-block-end: 0;
+          position: relative;
+          width: auto;
+
+          &::before {
+            @extend %icon;
+
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='%23666' d='M8.187 11.748l6.187-6.187-1.06-1.061-5.127 5.127L3.061 4.5 2 5.561z'/%3E%3C/svg%3E");
+            content: "";
+            margin-left: -#{$sph-inner--small};
+            margin-right: $sph-inner--small;
+            transform: rotate(90deg);
+          }
+        }
       }
     }
 
@@ -33,6 +109,20 @@
         display: flex;
         justify-content: flex-end;
         width: 75%;
+
+        .p-container--inline {
+          display: flex;
+          justify-content: space-between;
+
+          .p-button {
+            margin-inline-end: 1rem;
+          }
+
+          .p-button,
+          .p-form {
+            width: 50%;
+          }
+        }
 
         @media screen and (max-width: $breakpoint-medium - 1) {
           display: block;

--- a/static/sass/_pattern_p-icon.scss
+++ b/static/sass/_pattern_p-icon.scss
@@ -15,6 +15,13 @@
     width: 10px;
   }
 
+  .p-icon--arrow-right {
+    @extend %icon;
+
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='%23666' d='M8.187 11.748l6.187-6.187-1.06-1.061-5.127 5.127L3.061 4.5 2 5.561z'/%3E%3C/svg%3E");
+    transform: rotate(-90deg);
+  }
+
   .p-icon--revisions {
     @extend %icon;
 

--- a/templates/partial/_filters.html
+++ b/templates/partial/_filters.html
@@ -1,4 +1,7 @@
-<div class="p-layout__sidenav u-hide--small">
+<div class="p-layout__sidenav">
+  <div class="p-sidenav__drawer-header">
+    <a href="/" class="p-sidenav__toggle" data-js="filter-button-mobile-close">Apply filters</a>
+  </div>
   <div class="p-filter" data-js="filter-handler">
     <h3 class="p-muted-heading" data-filters="applied-filters">
       Filters
@@ -52,16 +55,19 @@
         <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Clear</i></button>
         <button type="submit" class="p-search-box__button" alt="Search"><i class="p-icon--search">Search</i></button>
       </form>
-      <form class="p-form p-form--inline">
-        <div class="p-layout__sort-desktop p-form__group">
-          <label for="platform" aria-label="Filter platforms" class="p-form__label">Platforms</label>
-          <select name="platform" id="platform-handler" data-js="platform-handler" class="p-form__control" value="{{ platform }}" id="platform" disabled>
-            <option value="all" {% if active_filter('platform', 'all') %}selected{% endif %}>All</option>
-            <option value="linux" {% if active_filter('platform', 'linux') %}selected{% endif %}>Linux</option>
-            <option value="kubernetes" {% if active_filter('platform', 'kubernetes') %}selected{% endif %}>Kubernetes</option>
-          </select>
-        </div>
-      </form>
+      <div class="p-container--inline">
+        <a href="#filters" class="p-button has-icon u-hide--medium u-hide--large" data-js="filter-button-mobile-open"><i class="p-icon--arrow-right"></i><span>Filters</span></a>
+        <form class="p-form p-form--inline">
+          <div class="p-layout__sort-desktop p-form__group u-no-margin--right">
+            <label for="platform" aria-label="Filter platforms" class="p-form__label u-hide--medium u-hide--small">Platforms</label>
+            <select name="platform" id="platform-handler" data-js="platform-handler" class="p-form__control" value="{{ platform }}" id="platform" disabled>
+              <option value="all" {% if active_filter('platform', 'all') %}selected{% endif %}>All</option>
+              <option value="linux" {% if active_filter('platform', 'linux') %}selected{% endif %}>Linux</option>
+              <option value="kubernetes" {% if active_filter('platform', 'kubernetes') %}selected{% endif %}>Kubernetes</option>
+            </select>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
   <div class="p-layout__card-container" id="features-container">


### PR DESCRIPTION
## Done

- Add mobile filters to store page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to homepage and switch layout to mobile and compare to [design 1](https://app.zeplin.io/project/5f92a9530029eeac84ae9589/screen/5fb29bb8142e4a7592cf1785). Click the `Filters` button and compare to [design 2](https://app.zeplin.io/project/5f92a9530029eeac84ae9589/screen/5fb2a34abede1f64108b20b4)
- See filters work as expected


## Note:
 **The number of filters will implemented as part of this issue https://github.com/canonical-web-and-design/charmhub.io/issues/679**

## Issue / Card

Fixes #707

## Screenshots

[if relevant, include a screenshot]
