### PR TITLE
Remove wordpress from featured charms

### DIFF
--- a/webapp/feature.py
+++ b/webapp/feature.py
@@ -61,14 +61,6 @@ FEATURED_CHARMS = [
         "platform": "kubernetes",
     },
     {
-        "name": "wordpress",
-        "display_name": "WordPress",
-        "summary": "Wordpress, uses official Docker Wordpress image by default",
-        "publisher": "mruffel",
-        "icon": "https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg",
-        "platform": "kubernetes",
-    },
-    {
         "name": "alertmanager",
         "display_name": "AlertManager",
         "summary": "Alert management for charmed LMA stack",


### PR DESCRIPTION
## Done

- Remove wordpress from featured charms

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
