### PR TITLE
Update library page display on mobile

### DIFF
--- a/static/sass/_pattern_p-image.scss
+++ b/static/sass/_pattern_p-image.scss
@@ -8,7 +8,7 @@
   }
 
   .p-image--platform {
-    @media screen and (max-width: $breakpoint-medium) {
+    @media screen and (max-width: $breakpoint-medium - 1px) {
       transform: scale(0.75) translateX(-16.5%);
     }
   }

--- a/static/sass/_pattern_p-list.scss
+++ b/static/sass/_pattern_p-list.scss
@@ -90,6 +90,14 @@
   }
 
   .p-inline-list.has-vertical-separator {
+    @media screen and (min-width: $breakpoint-medium) and (max-width: 1055px) {
+      margin-inline-start: -$spv-inner--large;
+    }
+
+    @media screen and (max-width: $breakpoint-medium) {
+      margin-block-end: $spv-inner--x-small;
+    }
+
     .p-inline-list__item:not(:last-child) {
       position: relative;
 

--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -80,7 +80,7 @@ than the latest.</span>
           </li>
           <li class="p-inline-list__item">
             <ul class="p-inline-list has-vertical-separator">
-              <li class="p-inline-list__item">
+              <li class="p-inline-list__item u-hide--small">
                 <span class="p-contextual-menu--left">
                   <button class="p-button--base p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">
                     <i class="p-icon--download"></i> Download


### PR DESCRIPTION
## Done

- Update library page look on mobile

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8045/fran-wordpress/libraries/test#source-code
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the page looks good on both large and small screens


## Issue / Card

Fixes #664

## Screenshots
