### PR TITLE
Fix moving filters when loading homepage

### DIFF
--- a/static/sass/_charmhub_p-layout-store.scss
+++ b/static/sass/_charmhub_p-layout-store.scss
@@ -31,9 +31,12 @@
         }
       }
 
-      animation:
-        vf-p-side-navigation-collapse
-        map-get($animation-duration, brisk);
+      @media screen and (max-width: $breakpoint-medium - 1) {
+        animation:
+          vf-p-side-navigation-collapse
+          map-get($animation-duration, brisk);
+      }
+
       display: none;
 
       &.is-expanded {


### PR DESCRIPTION
## Done
- Fixed filters navigation sliding in and out of page load on desktop

## How to QA
- Go to https://charmhub-io-737.demos.haus/ on desktop
- Check that the filters side navigation doesn't slide in and out on page load (compare to live)

## Issue / Card
Fixes #735