### PR TITLE
Show bundles in search results

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -66,9 +66,6 @@ def index():
         total_charms = 0
 
         for i, item in enumerate(results):
-            if item["type"] != "charm":
-                continue
-
             total_charms += 1
 
             charm = logic.add_store_front_data(
@@ -98,9 +95,6 @@ def get_charms():
     total_charms = 0
 
     for i, item in enumerate(results):
-        if item["type"] != "charm":
-            continue
-
         total_charms += 1
 
         charm = logic.add_store_front_data(


### PR DESCRIPTION
## Done
- Show bundles in search results (bundles icons are not present on the API)

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure there are more charms in this branch than in production.
- Search for "kubeflow" and a bundle should appear.

## Fix
Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/748