### PR TITLE
Configure tab: Respect new lines

### DIFF
--- a/templates/details/configure.html
+++ b/templates/details/configure.html
@@ -28,7 +28,7 @@
           {% if value.default %}
           <p style="overflow-wrap: break-word;"><span class="u-text--muted">Default:</span> {{ value.default }}</p>
           {% endif %}
-          <p style="overflow-wrap: break-word;">{{ value.description | safe }}</p>
+          <p style="overflow-wrap: break-word;white-space: pre;">{{ value.description | escape }}</p>
         </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
## Done
- Respect new lines in the config.yaml for descriptions.

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare https://charmhub-io-771.demos.haus/nova-compute/configure#openstack-origin with the screenshot in the issue

## Issue / Card
Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/761

