### PR TITLE
Align text baseline on homepage

### DIFF
--- a/templates/store.html
+++ b/templates/store.html
@@ -74,7 +74,7 @@
               <a href="#drawer" class="p-button has-icon u-hide--medium u-hide--large js-drawer-toggle" data-js="filter-button-mobile-open"><i class="p-icon--arrow-right"></i><span>Filters</span></a>
               <form class="p-form p-form--inline">
                 <div class="p-form__group u-no-margin--right">
-                  <label for="platform" aria-label="Filter platforms" class="p-form__label u-hide--small">Platforms</label>
+                  <label for="platform" aria-label="Filter platforms" class="p-form__label u-no-margin--bottom u-hide--small">Platforms</label>
                   <select name="platform" data-js="platform-handler" class="p-form__control u-no-margin--bottom" value="{{ platform }}" id="platform" disabled>
                     <option value="all" {% if active_filter('platform', 'all' ) %}selected{% endif %}>All</option>
                     <option value="linux" {% if active_filter('platform', 'linux' ) %}selected{% endif %}>Linux</option>


### PR DESCRIPTION
## Done
- _Align text baseline on homepage._

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that `Filters`, `Featured 14` & `Platforms` are all vertically aligned

## Issue / Card
Fixes #762

## Screenshots
[if relevant, include a screenshot]
