### PR TITLE
Update history tab

### DIFF
--- a/static/js/src/public/details/channelMap.js
+++ b/static/js/src/public/details/channelMap.js
@@ -2,7 +2,6 @@ const init = (packageName, channelMapButton) => {
   const currentChannel = channelMapButton.querySelector(
     "[data-js='channel-map-selected']"
   );
-  const channelCli = document.querySelector("[data-js='channel-cli']");
   const channelMapState = {
     channel: currentChannel.innerText.split(" ")[0],
     version: currentChannel.innerText.split(" ")[1],

--- a/templates/details/_details-tab-navigation.html
+++ b/templates/details/_details-tab-navigation.html
@@ -13,6 +13,9 @@
       <li class="p-tabs__item" role="presentation">
         <a href="/{{ package.name }}/actions{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'actions' %}aria-selected="true" {% endif %}>Actions</a>
       </li>
+      <li class="p-tabs__item" role="presentation">
+        <a href="/{{ package.name }}/history{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'history' %}aria-selected="true" {% endif %}>History</a>
+      </li>
     </ul>
   </nav>
 </div>

--- a/templates/details/history.html
+++ b/templates/details/history.html
@@ -11,7 +11,7 @@
           <th>Date</th>
           <th class="u-align--right">Charm version</th>
           {% for resource in package.store_front.resources %}
-          <th class="u-align--right">{{ resource }}</th>
+          <th class="u-align--right">{{ resource.name }}</th>
           {% endfor %}
         </tr>
       </thead>
@@ -21,7 +21,7 @@
           <td role="rowheader" aria-label="Date">{{ release.released_at }}</td>
           <td role="gridcell" aria-label="Charm version" class="u-align--right">{{ release.version }}</td>
           {% for resource in package.store_front.resources %}
-          <td role="gridcell" aria-label="Charm version" class="u-align--right">{{ release.resources[resource]["revision"] }}</td>
+          <td role="gridcell" aria-label="{{ resource.name }}" class="u-align--right">{{ resource.revision }}</td>
           {% endfor %}
         </tr>
         {% endfor %}

--- a/templates/details/libraries/library.html
+++ b/templates/details/libraries/library.html
@@ -52,7 +52,7 @@
   </div>
 {% endblock%}
 
-{% block page_scripts %}
+{% block details_scripts %}
 
 {{ super() }}
 


### PR DESCRIPTION
## Done
- _Fix `channel_map` drop-down to work on the History tab_
- _Add `History` tab to the navigation._

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/postgresql/history
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See there is a resource in the table (`wal-e`)

## Issue / Card
Fixes #754 

## Screenshots
[if relevant, include a screenshot]
