### PR TITLE
Fix summary console error on charm details page

### DIFF
--- a/static/js/src/public/details/index.js
+++ b/static/js/src/public/details/index.js
@@ -1,40 +1,12 @@
 import { HistoryState } from "./historyState";
 import { TableOfContents } from "./tableOfContents";
 import { channelMap } from "./channelMap";
-import { truncateString } from "../../libs/truncate-string";
 
 if (window.location.hash) {
   setTimeout(() => {
     window.scrollTo(0, 0);
   }, 1);
 }
-
-const truncateSummary = (selector) => {
-  const summaryEl = document.querySelector(selector);
-
-  if (summaryEl) {
-    const showMoreEl = summaryEl.querySelector("[data-js='summary-read-more']");
-    const summaryContentEl = summaryEl.querySelector(
-      "[data-js='summary-content']"
-    );
-    const summary = summaryEl.getAttribute("data-summary");
-
-    if (summary.length > 103) {
-      const truncatedSummary = truncateString(summary, 103);
-      summaryContentEl.innerHTML = truncatedSummary;
-
-      showMoreEl.classList.remove("u-hide");
-
-      showMoreEl.addEventListener("click", (e) => {
-        e.preventDefault();
-        showMoreEl.classList.add("u-hide");
-        summaryContentEl.innerHTML = summary;
-      });
-    }
-  } else {
-    throw new Error(`There are no elements containing ${selector} selector.`);
-  }
-};
 
 const init = (packageName) => {
   const historyState = new HistoryState();
@@ -87,8 +59,6 @@ const init = (packageName) => {
   if (channelMapButton) {
     channelMap(packageName, channelMapButton);
   }
-
-  truncateSummary("[data-js='summary']");
 };
 
 export { init };

--- a/static/js/src/public/details/overview/index.js
+++ b/static/js/src/public/details/overview/index.js
@@ -1,0 +1,32 @@
+import { truncateString } from "../../../libs/truncate-string";
+
+const truncateSummary = (selector) => {
+  const summaryEl = document.querySelector(selector);
+
+  if (summaryEl) {
+    const showMoreEl = summaryEl.querySelector("[data-js='summary-read-more']");
+    const summaryContentEl = summaryEl.querySelector(
+      "[data-js='summary-content']"
+    );
+    const summary = summaryEl.getAttribute("data-summary");
+
+    if (summary.length > 103) {
+      const truncatedSummary = truncateString(summary, 103);
+      summaryContentEl.innerHTML = truncatedSummary;
+
+      showMoreEl.classList.remove("u-hide");
+
+      showMoreEl.addEventListener("click", (e) => {
+        e.preventDefault();
+        showMoreEl.classList.add("u-hide");
+        summaryContentEl.innerHTML = summary;
+      });
+    }
+  }
+};
+
+const init = () => {
+  truncateSummary("[data-js='summary']");
+};
+
+export { init };

--- a/templates/details/actions.html
+++ b/templates/details/actions.html
@@ -77,12 +77,6 @@
 </div>
 {% endblock%}
 
-{% block page_scripts %}
-  <script src="{{ versioned_static('js/dist/details.js') }}" defer></script>
+{% block details_scripts %}
   <script src="{{ versioned_static('js/dist/highlight-nav.js') }}" defer></script>
-  <script>
-   window.addEventListener("DOMContentLoaded", function () {
-       charmhub.details.init("{{ package.name }}");
-   });
-  </script>
 {% endblock %}

--- a/templates/details/details_layout.html
+++ b/templates/details/details_layout.html
@@ -41,10 +41,11 @@
 {% endblock %}
 
 {% block page_scripts %}
-<script src="{{ versioned_static('js/dist/details.js') }}" defer></script>
-<script>
-  window.addEventListener("DOMContentLoaded", function () {
-    charmhub.details.init("{{ package.name }}");
-  });
-</script>
+  <script src="{{ versioned_static('js/dist/details.js') }}" defer></script>
+  <script>
+    window.addEventListener("DOMContentLoaded", function () {
+      charmhub.details.init("{{ package.name }}");
+    });
+  </script>
+  {% block details_scripts %}{% endblock details_scripts %}
 {% endblock %}

--- a/templates/details/docs.html
+++ b/templates/details/docs.html
@@ -50,12 +50,10 @@
   </div>
 {% endblock%}
 
-{% block page_scripts %}
-  <script src="{{ versioned_static('js/dist/details.js') }}" defer></script>
+{% block details_scripts %}
   <script src="{{ versioned_static('js/dist/details_docs.js') }}" defer></script>
   <script>
     window.addEventListener("DOMContentLoaded", function () {
-      charmhub.details.init("{{ package.name }}");
       charmhub.details.docs.initSideNav();
     });
   </script>

--- a/templates/details/empty-docs.html
+++ b/templates/details/empty-docs.html
@@ -15,13 +15,3 @@
   </div>
 {% endblock%}
 
-{% block page_scripts %}
-  <script src="{{ versioned_static('js/dist/details.js') }}" defer></script>
-  <script src="{{ versioned_static('js/dist/details_docs.js') }}" defer></script>
-  <script>
-    window.addEventListener("DOMContentLoaded", function () {
-      charmhub.details.init("{{ package.name }}");
-      charmhub.details.docs.initSideNav();
-    });
-  </script>
-{% endblock %}

--- a/templates/details/history.html
+++ b/templates/details/history.html
@@ -42,7 +42,7 @@
   </div>
 {% endblock%}
 
-{% block page_scripts %}
+{% block details_scripts %}
   <script src="{{ versioned_static('js/dist/details_history.js') }}" defer></script>
   <script>
     window.addEventListener("DOMContentLoaded", function () {

--- a/templates/details/integrate.html
+++ b/templates/details/integrate.html
@@ -112,7 +112,7 @@
   </div>
 {% endblock%}
 
-{% block page_scripts %}
+{% block details_scripts %}
   <script src="{{ versioned_static('js/dist/details_integrate.js') }}" defer></script>
   <script>
     /**

--- a/templates/details/overview.html
+++ b/templates/details/overview.html
@@ -50,4 +50,13 @@
       {{ readme | safe }}
     </div>
   </div>
-{% endblock%}
+{% endblock %}
+
+{% block details_scripts %}
+  <script src="{{ versioned_static('js/dist/details_overview.js') }}" defer></script>
+  <script>
+    window.addEventListener("DOMContentLoaded", function () {
+      charmhub.details.overview.init();
+    });
+  </script>
+{% endblock %}

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -4,6 +4,7 @@ module.exports = {
   docs: "./static/js/src/public/docs/index.js",
   base: "./static/js/src/base/base.js",
   details: "./static/js/src/public/details/index.js",
+  details_overview: "./static/js/src/public/details/overview/index.js",
   details_docs: "./static/js/src/public/details/docs/index.js",
   details_history: "./static/js/src/public/details/history/index.js",
   details_integrate: "./static/js/src/public/details/integrate/index.js",

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -36,9 +36,7 @@ module.exports = [
     use: ["expose-loader?exposes=charmhub.base", "babel-loader"],
   },
   {
-    test: require.resolve(
-        __dirname + "/static/js/src/base/highlight.js"
-    ),
+    test: require.resolve(__dirname + "/static/js/src/base/highlight.js"),
     use: ["expose-loader?exposes=charmhub.highlight", "babel-loader"],
   },
   {
@@ -48,6 +46,12 @@ module.exports = [
   {
     test: require.resolve(__dirname + "/static/js/src/public/details/index.js"),
     use: ["expose-loader?exposes=charmhub.details", "babel-loader"],
+  },
+  {
+    test: require.resolve(
+      __dirname + "/static/js/src/public/details/overview/index.js"
+    ),
+    use: ["expose-loader?exposes=charmhub.details.overview", "babel-loader"],
   },
   {
     test: require.resolve(


### PR DESCRIPTION
### ## Done
- _Fix summary console error on charm details page._

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/activemq
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Open the console and see there are no errors

## Issue / Card
Fixes #745

## Screenshots
[if relevant, include a screenshot]
