### PR TITLE
Remove loading state if no filters are selected

### DIFF
--- a/static/js/src/public/store/charms.js
+++ b/static/js/src/public/store/charms.js
@@ -8,11 +8,9 @@ class Charms {
     this._filters = this.getUrlFilters();
 
     if (!this._filters.filter && this._filters.platform[0] === "all") {
-      setTimeout(() => {
-        this.togglePlaceholderContainer();
-        this.toggleFeaturedContainer(true);
-        this.renderResultsCount(true);
-      }, 1000);
+      this.togglePlaceholderContainer();
+      this.toggleFeaturedContainer(true);
+      this.renderResultsCount(true);
     }
 
     this.fetchCharmsList()


### PR DESCRIPTION
## Done
- _Remove loading state if no filters are selected._

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Note that there is no loading state - if you see a loading state, is only for a very brief moment

## Issue / Card
Fixes #782

## Screenshots
[if relevant, include a screenshot]
