### PR TITLE
Wrap text properly on configure tab

### DIFF
--- a/templates/details/configure.html
+++ b/templates/details/configure.html
@@ -28,7 +28,7 @@
           {% if value.default %}
           <p style="overflow-wrap: break-word;"><span class="u-text--muted">Default:</span> {{ value.default }}</p>
           {% endif %}
-          <p style="overflow-wrap: break-word;white-space: pre;">{{ value.description | escape }}</p>
+          <p style="overflow-wrap: break-word;white-space: pre-wrap;">{{ value.description | escape }}</p>
         </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
## Done
- Change `white-space` property from `pre` to `pre-wrap`

## How to QA
- Check  https://charmhub-io-785.demos.haus/nova-compute/configure#openstack-origin is working as expected on **mobile** and **desktop**

## Issue / Card
Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/779

See also  https://github.com/canonical-web-and-design/charmhub.io/issues/761
