### PR TITLE
Add ellipsis to side navigation on configure tab

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -65,6 +65,7 @@ $theme-default-nav: dark;
 @include vf-u-vertical-spacing;
 @include vf-u-text-muted;
 @include vf-u-no-max-width;
+@include vf-u-truncate;
 
 // Import site specific patterns and overrides
 @import "pattern_p-card";
@@ -293,6 +294,10 @@ body {
 .p-details-tab__content {
   p {
     max-width: unset;
+  }
+
+  .p-side-navigation__link.u-truncate {
+    display: block;
   }
 }
 

--- a/templates/details/configure.html
+++ b/templates/details/configure.html
@@ -11,7 +11,7 @@
         <ul class="p-side-navigation__list">
           {% for config in package.store_front.config.options.keys() %}
           <li class="p-side-navigation__item">
-            <a href="#{{ config }}" class="p-side-navigation__link" role="tab" aria-controls="{{ config }}" {% if loop.index == 1 %}aria-selected="false" {% endif %}>
+            <a href="#{{ config }}" class="p-side-navigation__link u-truncate" role="tab" aria-controls="{{ config }}" {% if loop.index == 1 %}aria-selected="false" {% endif %}>
               {{ config }}
             </a>
           </li>
@@ -28,7 +28,7 @@
           {% if value.default %}
           <p style="overflow-wrap: break-word;"><span class="u-text--muted">Default:</span> {{ value.default }}</p>
           {% endif %}
-          <p style="overflow-wrap: break-word;white-space: pre-wrap;">{{ value.description | escape }}</p>
+          <p style="overflow-wrap: break-word; white-space: pre-wrap;">{{ value.description | escape }}</p>
         </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
## Done
- _A changelist description explaining what the change achieves and why you’re making it._

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/discourse/configure
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that on smaller screens the side navigation content has ellipsis

## Issue / Card
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1744

## Screenshots
[if relevant, include a screenshot]
