### PR TITLE
Hide loading cards if no JS

### DIFF
--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -4,6 +4,7 @@ import buildPackageCard from "./buildPackageCard";
 class initPackages {
   constructor() {
     this.selectElements();
+    this.togglePlaceholderContainer(true);
     this.searchCache = window.location.search;
     this._filters = this.getUrlFilters();
     if (
@@ -13,6 +14,7 @@ class initPackages {
       this.togglePlaceholderContainer();
       this.toggleFeaturedContainer(true);
       this.renderResultsCount(true);
+      this.toggleShowAllPackagesButton(true);
     }
 
     this.fetchPackageList()
@@ -430,9 +432,13 @@ class initPackages {
     }
   }
 
-  toggleShowAllPackagesButton() {
+  toggleShowAllPackagesButton(visibility) {
     if (this.domEl.showAllPackagesButton.el) {
-      this.domEl.showAllPackagesButton.el.classList.add("u-hide");
+      if (visibility) {
+        this.domEl.showAllPackagesButton.el.classList.remove("u-hide");
+      } else {
+        this.domEl.showAllPackagesButton.el.classList.add("u-hide");
+      }
     } else {
       throw new Error(
         `There is no element containing ${this.domEl.showAllPackagesButton.selector} selector.`

--- a/templates/store.html
+++ b/templates/store.html
@@ -86,7 +86,7 @@
           </div>
         </div>
 
-        <div class="l-flex__card-container" data-js="placeholder-container">
+        <div class="l-flex__card-container u-hide" data-js="placeholder-container">
           {% for _ in range(0, 10) %}
           <div class="l-flex__card u-equal-height" id="alertmanager">
             <a href="/alertmanager" class="p-card--button is-placeholder">
@@ -125,7 +125,7 @@
         </div>
 
         <div class="u-align--center" style="margin-top: 1rem;">
-          <button type="button" class="p-button--positive" data-js="show-all-packages" disabled>See all operators</button>
+          <button type="button" class="p-button--positive u-hide" data-js="show-all-packages" disabled>See all operators</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done
- _A changelist description explaining what the change achieves and why you’re making it._

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Reload the page, add filters, reload the page. See all works the same as charmhub.io
- Go to http://localhost:8045/  
- Open your console and disable JS (press "Ctrl+Shift+P" and search for javascript in Chrome"). Do a hard refresh and see there is no loading cards showing, only the featured ones.
-  

## Issue / Card
Fixes #796 

## Screenshots
[if relevant, include a screenshot]
