### PR TITLE
Fix JS filters when missing categories

### DIFF
--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -270,9 +270,17 @@ class initPackages {
   renderFiltersAndPlatform() {
     if (this.domEl.categoryFilters.el && this.domEl.platformSwitcher.el) {
       this.domEl.categoryFilters.el.forEach((filter) => {
+        let platforms = this.groupedPackages.categories[filter.value];
+
+        if (platforms === undefined) {
+          filter.disabled = true;
+          return;
+        }
+
         if (this._filters.platform[0] === "all") {
           let count = 0;
-          Object.keys(this.groupedPackages.categories[filter.value]).forEach(
+
+          Object.keys(platforms).forEach(
             (platform) => {
               count += platform.length;
             }
@@ -284,9 +292,7 @@ class initPackages {
           }
         } else {
           if (
-            this.groupedPackages.categories[filter.value][
-              this._filters.platform[0]
-            ].length === 0
+            platforms[this._filters.platform[0]].length === 0
           ) {
             filter.disabled = true;
           } else {


### PR DESCRIPTION
## Done

For some reason, some categories are now missing from the API, we'll talk with the store team about this (@tbille )

Our JS code was failing until we rolled back to a previous version of the site. With these changes, the site will continue to work as usual, the category filters will be disabled for the missing categories.

## How to QA
- Check the filters are working as expected.
- Some categories are not available now.

## Issue / Card
Fixes #816

## Screenshots
![image](https://user-images.githubusercontent.com/6353928/107999126-a06f3e80-6fde-11eb-9a86-cc3d9791a749.png)
