### PR TITLE
Add endpoints for publicise pages

### DIFF
--- a/templates/publisher/publicise/embedded_cards.html
+++ b/templates/publisher/publicise/embedded_cards.html
@@ -1,0 +1,5 @@
+{% extends 'publisher/publicise/publicise_layout.html' %}
+
+{% block publicise_content %}
+  <h4>Promote your charm using embeddable responsive card</h4>
+{% endblock %}

--- a/templates/publisher/publicise/github_badges.html
+++ b/templates/publisher/publicise/github_badges.html
@@ -1,0 +1,5 @@
+{% extends 'publisher/publicise/publicise_layout.html' %}
+
+{% block publicise_content %}
+  <h4>Github badges page</h4>
+{% endblock %}

--- a/templates/publisher/publicise/publicise_layout.html
+++ b/templates/publisher/publicise/publicise_layout.html
@@ -1,0 +1,44 @@
+{% extends 'publisher/publisher_layout.html' %}
+
+{% block title %}Publicise {{ package.name }}{% endblock %}
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+{% block meta_description %}{% endblock %}
+
+{% set selected_tab='punlicise' %}
+
+{% block publisher_content %}
+<div class="p-strip is-shallow">
+  <div class="row is-wide">
+    <div class="col-3 has-space--right">
+      <div class="p-side-navigation " id="drawer">
+        <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
+          Toggle side navigation
+        </a>
+        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
+        <nav class="p-side-navigation__drawer" aria-label="Example side navigation">
+          <div class="p-side-navigation__drawer-header">
+            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+              Toggle side navigation
+            </a>
+          </div>
+          <ul class="p-side-navigation__list">
+            <li class="p-side-navigation__item">
+              <a class="p-side-navigation__link" {% if request.path.endswith('/publicise') %}aria-current="page"{% endif %} href="/{{ package.name }}/publicise">Charmhub buttons</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="p-side-navigation__link" {% if request.path.endswith('/publicise/badges') %}aria-current="page"{% endif %} href="/{{ package.name }}/publicise/badges">Github badges</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="p-side-navigation__link" {% if request.path.endswith('/publicise/cards' )%}aria-current="page"{% endif %} href="/{{ package.name }}/publicise/cards">Embeddable cards</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+    <div class="col-8">
+      {% block publicise_content %}{% endblock publicise_content %}
+    </div>
+  </div>
+</div>
+{% endblock %}
+

--- a/templates/publisher/publicise/store_buttons.html
+++ b/templates/publisher/publicise/store_buttons.html
@@ -1,0 +1,5 @@
+{% extends 'publisher/publicise/publicise_layout.html' %}
+
+{% block publicise_content %}
+  <h4>Promote your charm using Charmhub buttons</h4>
+{% endblock %}

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -141,3 +141,50 @@ def register_name_dispute_thank_you():
         "publisher/register-name-dispute/thank-you.html",
         entity_name=entity_name,
     )
+
+
+@publisher.route(
+    '/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/publicise'
+)
+@login_required
+def get_publicise(entity_name):
+    package = publisher_api.get_package_metadata(
+        session["publisher-auth"], "charm", entity_name
+    )
+
+    context = {
+        "package": package,
+    }
+    return render_template("publisher/publicise/store_buttons.html", **context)
+
+
+@publisher.route(
+    '/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/publicise/badges'
+)
+@login_required
+def get_publicise_badges(entity_name):
+    package = publisher_api.get_package_metadata(
+        session["publisher-auth"], "charm", entity_name
+    )
+
+    context = {
+        "package": package,
+    }
+    return render_template("publisher/publicise/github_badges.html", **context)
+
+
+@publisher.route(
+    '/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/publicise/cards'
+)
+@login_required
+def get_publicise_cards(entity_name):
+    package = publisher_api.get_package_metadata(
+        session["publisher-auth"], "charm", entity_name
+    )
+
+    context = {
+        "package": package,
+    }
+    return render_template(
+        "publisher/publicise/embedded_cards.html", **context
+    )


### PR DESCRIPTION
## Done
- _Add endpoints for publicise pages_
-_Add templates for publicise pages_

## How to QA
- run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/<charm_name>/publicise

## Issue / Card
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1859

## Screenshots
[if relevant, include a screenshot]
