### PR TITLE
Fix fields management

### DIFF
--- a/templates/details/overview.html
+++ b/templates/details/overview.html
@@ -40,7 +40,7 @@
         <p><span class="u-text--muted">License</span><br />{{ package.result.license }}</p>
         <hr class="p-separator--shallow">
       {% endif %}
-      {% if package.result.website or package.result.repository or package.result.contact %}
+      {% if package.result.website or package.result.repository or package.result.contact or package.result["bugs-url"] %}
         <h4 class="p-heading--5 u-no-margin--bottom">Relevant links</h4>
         <ul class="p-list">
         {% if package.result.website %}
@@ -52,9 +52,10 @@
           <li class="p-list__item">
             <a href="{{ package.result.repository }}"><i class="p-icon--repository"></i>&nbsp;&nbsp;Repository</a>
           </li>
+        {% endif %}
+        {% if package.result["bugs-url"] %}
           <li class="p-list__item">
-            <!-- TO DO - what if the bugs are submitted to launchpad? -->
-            <a href="{{ package.result.repository }}/issues/new"><i class="p-icon--bug"></i>&nbsp;&nbsp;Submit a bug</a>
+            <a href="{{ package.result["bugs-url"] }}"><i class="p-icon--bug"></i>&nbsp;&nbsp;Submit a bug</a>
           </li>
         {% endif %}
         {% if package.result.contact %}

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -147,7 +147,7 @@ CS = []
 def get_package(entity_name, channel_request, fields):
     # Get entity info from API
     package = app.store_api.get_item_details(
-        entity_name, channel=channel_request, fields=FIELDS
+        entity_name, channel=channel_request, fields=fields
     )
 
     if COMMANDS_OVERWRITE.get(entity_name):
@@ -174,16 +174,15 @@ def get_package(entity_name, channel_request, fields):
 def details_overview(entity_name):
     channel_request = request.args.get("channel", default=None, type=str)
 
+    extra_fields = [
+        "default-release.revision.readme-md",
+        "result.bugs-url",
+        "result.website",
+        "result.summary",
+    ]
+
     package = get_package(
-        entity_name,
-        channel_request,
-        FIELDS.copy().extend(
-            [
-                "default-release.revision.readme-md",
-                "result.summary",
-                "channel-map.revision.readme-md",
-            ]
-        ),
+        entity_name, channel_request, FIELDS.copy() + extra_fields
     )
 
     readme = package["default-release"]["revision"].get(
@@ -195,7 +194,6 @@ def details_overview(entity_name):
 
     readme = md_parser(readme)
     readme = decrease_headers(readme)
-
     return render_template(
         "details/overview.html",
         package=package,
@@ -213,15 +211,12 @@ def details_overview(entity_name):
 @redirect_uppercase_to_lowercase
 def details_docs(entity_name, path=None):
     channel_request = request.args.get("channel", default=None, type=str)
+    extra_fields = [
+        "default-release.revision.metadata-yaml",
+    ]
+
     package = get_package(
-        entity_name,
-        channel_request,
-        FIELDS.copy().extend(
-            [
-                "channel-map.revision.metadata-yaml",
-                "default-release.revision.metadata-yaml",
-            ]
-        ),
+        entity_name, channel_request, FIELDS.copy() + extra_fields
     )
 
     if not package["store_front"]["docs_topic"]:
@@ -270,17 +265,13 @@ def details_docs(entity_name, path=None):
 @redirect_uppercase_to_lowercase
 def details_configuration(entity_name):
     channel_request = request.args.get("channel", default=None, type=str)
-    package = get_package(
-        entity_name,
-        channel_request,
-        FIELDS.copy().extend(
-            [
-                "channel-map.revision.config-yaml",
-                "default-release.revision.config-yaml",
-            ]
-        ),
-    )
+    extra_fields = [
+        "default-release.revision.config-yaml",
+    ]
 
+    package = get_package(
+        entity_name, channel_request, FIELDS.copy() + extra_fields
+    )
     return render_template(
         "details/configure.html",
         package=package,
@@ -293,17 +284,13 @@ def details_configuration(entity_name):
 @redirect_uppercase_to_lowercase
 def details_actions(entity_name):
     channel_request = request.args.get("channel", default=None, type=str)
-    package = get_package(
-        entity_name,
-        channel_request,
-        FIELDS.copy().extend(
-            [
-                "default-release.revision.actions-yaml",
-                "channel-map.revision.actions-yaml",
-            ]
-        ),
-    )
+    extra_fields = [
+        "default-release.revision.actions-yaml",
+    ]
 
+    package = get_package(
+        entity_name, channel_request, FIELDS.copy() + extra_fields
+    )
     return render_template(
         "details/actions.html",
         package=package,


### PR DESCRIPTION
## Done
There was a typo, we weren't using the specific fields for the different charm details endpoint.
Now we should see charms with bug url

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
- http://localhost:8045/prometheus
- Checkout the bug-url
- try a few charms with their tabs.
- Should all work as usual
- Once [this bug](https://bugs.launchpad.net/bugs/1908069) is merged, website will magically appear!

## Issue / Card
Fixes #709 
