### PR TITLE
Update search label for search results

### DIFF
--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -157,6 +157,14 @@ class initPackages {
     if (this.domEl.resultsCountContainer.el) {
       if (featured) {
         this.domEl.resultsCountContainer.el.innerHTML = `${this.domEl.featuredContainer.el.children.length} Featured`;
+      } else if (this._filters.q.length > 0) {
+        this.domEl.resultsCountContainer.el.innerHTML = `${
+          this.packages.length
+        } of ${
+          this.allPackages.length
+        } search results for <span style='font-weight: 500;'>'${this._filters.q.join(
+          ","
+        )}'</span>`;
       } else {
         this.domEl.resultsCountContainer.el.innerHTML = `${this.packages.length} of ${this.allPackages.length}`;
       }

--- a/templates/store.html
+++ b/templates/store.html
@@ -64,7 +64,7 @@
       <div class="l-main">
         <div class="l-main__header">
           <div class="l-main__header--left">
-            <div class="u-text--muted" data-js="results-count-container"></div>
+            <div data-js="results-count-container"></div>
           </div>
           <div class="l-main__header--right">
             <form action="/" class="p-search-box u-hide--medium u-hide--large" data-js="search-handler-mobile">


### PR DESCRIPTION
## Done
- _Update search label for search results._

## How to QA
- Go to https://charmhub-io-838.demos.haus/?q=kube and see the label at the top says: `69 of 69 search results for 'kube'`
- Go to https://charmhub-io-838.demos.haus/?q=kube&platform=all&filter=containers and see the label at the top says: `1 of 69 search results for 'kube'`
- Compare to [design](https://app.zeplin.io/project/5f92a9530029eeac84ae9589/screen/5fdc754d37a601a886dcfdee)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1870

## Screenshots
[if relevant, include a screenshot]
