### PR TITLE
Add query string value to the search input

### DIFF
--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -19,6 +19,12 @@ class initPackages {
       this.toggleShowAllPackagesButton(true);
     }
 
+    if (this._filters.q.length > 0) {
+      const queryString = this._filters.q.join(",");
+      this.domEl.searchInputDesktop.el.value = queryString;
+      this.domEl.searchInputMobile.el.value = queryString;
+    }
+
     this.fetchPackageList()
       .then((data) => {
         this.allPackages = data.packages;
@@ -95,6 +101,14 @@ class initPackages {
     this.domEl.resultsCountContainer = {
       el: document.querySelector("[data-js='results-count-container']"),
       selector: "[data-js='results-count-container']",
+    };
+    this.domEl.searchInputDesktop = {
+      el: document.querySelector("[data-js='search-input-desktop']"),
+      selector: "[data-js='search-input-desktop']",
+    };
+    this.domEl.searchInputMobile = {
+      el: document.querySelector("[data-js='search-input-mobile']"),
+      selector: "[data-js='search-input-mobile']",
     };
     this.domEl.showAllPackagesButton = {
       el: document.querySelector("[data-js='show-all-packages']"),

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -36,7 +36,7 @@
         </li>
       </ul>
       <form action="/" class="p-search-box is-dark u-hide--small-1" data-js="search-handler-desktop">
-        <input type="search" class="p-search-box__input" name="q" aria-label="Search Charmhub" placeholder="Search Charmhub" {% if q %}value="{{ q }}" {% endif %} required />
+        <input type="search" data-js="search-input-desktop" class="p-search-box__input" name="q" aria-label="Search Charmhub" placeholder="Search Charmhub" {% if q %}value="{{ q }}" {% endif %} required />
         <button type="reset" class="p-search-box__reset"><i class="p-icon--close is-light">Clear</i></button>
         <button type="submit" class="p-search-box__button" alt="Search"><i class="p-icon--search is-light">Search</i></button>
       </form>

--- a/templates/store.html
+++ b/templates/store.html
@@ -68,7 +68,7 @@
           </div>
           <div class="l-main__header--right">
             <form action="/" class="p-search-box u-hide--medium u-hide--large" data-js="search-handler-mobile">
-              <input type="search" class="p-search-box__input" name="q" aria-label="Search Charmhub" placeholder="Search Charmhub" {% if q %}value="{{ q }}" {% endif %} required />
+              <input type="search" data-js="search-input-mobile" class="p-search-box__input" name="q" aria-label="Search Charmhub" placeholder="Search Charmhub" {% if q %}value="{{ q }}" {% endif %} required />
               <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Clear</i></button>
               <button type="submit" class="p-search-box__button" alt="Search"><i class="p-icon--search">Search</i></button>
             </form>


### PR DESCRIPTION
## Done
- _Add query string value to the search input._

## How to QA
- Go to https://charmhub-io-840.demos.haus/?q=kube and see the search term `kube` is showed in the search bar, on both desktop and mobile

## Issue / Card
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1871

## Screenshots
[if relevant, include a screenshot]
