### PR TITLE
Add libraries tab

### DIFF
--- a/templates/details/_details-tab-navigation.html
+++ b/templates/details/_details-tab-navigation.html
@@ -9,6 +9,9 @@
         <a href="/{{ package.name }}/docs{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'docs' %}aria-selected="true" {% endif %}>Docs</a>
       </li>
       <li class="p-tabs__item" role="presentation">
+        <a href="/{{ package.name }}/libraries{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'libraries' %}aria-selected="true" {% endif %}>Libraries</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
         <a href="/{{ package.name }}/configure{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'configure' %}aria-selected="true" {% endif %}>Configure</a>
       </li>
       <li class="p-tabs__item" role="presentation">


### PR DESCRIPTION
## Done
- add libraries tab to details page

## How to QA
- http://0.0.0.0:8045/prometheus/libraries
- the details page should have a new tab: Libraries
- this tab should be accessible from any details page