### PR TITLE
Fix hidden content under the sticky nav bar on actions page

### DIFF
--- a/templates/details/actions.html
+++ b/templates/details/actions.html
@@ -79,4 +79,8 @@
 
 {% block details_scripts %}
   <script src="{{ versioned_static('js/dist/highlight-nav.js') }}" defer></script>
+  <script>
+      // Fix to see the content under the sticky nav when you navigate using #id
+      window.addEventListener("hashchange", () => { scrollBy(0, -65) })
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Done
- _Fix hidden content under the sticky nav bar on actions page._

## How to QA
- Go to https://charmhub-io-858.demos.haus/ceph/action and click some items in the side navigation
- See it takes you to the right section and you can see the title of that section

## Issue / Card
Fixes #857 

## Screenshots
[if relevant, include a screenshot]
