### PR TITLE
Display empty string if charm title is not set

### DIFF
--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -33,7 +33,7 @@
       </div>
       <div class="col-8 col-x-large-6">
         <div class="p-form__control">
-          <input class="p-form-validation__input" id="title" type="text" name="title" value="{{ package.title or package.name }}" required="" maxlength="40">
+          <input class="p-form-validation__input" id="title" type="text" name="title" value="{{ package.title or '' }}" required="" maxlength="40">
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done
- _Display empty string if charm title is not set._

## How to QA
- Run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/CHARMNAME/listing
- Make sure your charm does not have a title set (you can hack the form by removing the `required` field on "title" input, then delete the name and save).
- Reload the page and see the "title" input is empty

## Issue / Card
Fixes #868

## Screenshots
[if relevant, include a screenshot]
