### PR TITLE
Fix scroll on libraries page

### DIFF
--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -122,7 +122,7 @@ than the latest.</span>
   <script>
     {% if not is_source_code %}
       // Fix to see the content under the sticky nav when you navigate using # on the docstring page
-        window.addEventListener("hashchange", () => { scrollBy(0, -40) })
+        window.addEventListener("hashchange", () => { scrollBy(0, -55) })
     {% endif %}
 
     function toggleMenu(element, show, top) {


### PR DESCRIPTION
## Done
- _Fix scroll on libraries page._

## How to QA
- Go to https://charmhub-io-883.demos.haus/toto-wordpress/libraries/superlib and click on "class Person" from the index navigation.
- See that there is some space between the "class Person" title and the underside of the main navigation.

## Issue / Card
Fixes #882

## Screenshots
![image](https://user-images.githubusercontent.com/40214246/111652089-b0a55400-87fe-11eb-9e8c-6e2e087f492c.png)

