### PR TITLE
Connect register name to the API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.discourse==3.0.8
 canonicalwebteam.flask-base==0.7.3
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.search==1.0.0
-canonicalwebteam.store-api==3.1.6
+canonicalwebteam.store-api==3.1.7
 canonicalwebteam.docstring-extractor==0.7.0
 Flask-WTF==0.14.3
 humanize==2.6.0

--- a/static/js/src/libs/notification-close.js
+++ b/static/js/src/libs/notification-close.js
@@ -1,0 +1,25 @@
+export default function initCloseButton() {
+  /**
+  Attaches event listener for hide notification on close button click.
+  @param {HTMLElement} closeButton The notification close button element.
+*/
+  function setupCloseButton(closeButton) {
+    closeButton.addEventListener("click", function (event) {
+      var target = event.target.getAttribute("aria-controls");
+      var notification = document.getElementById(target);
+
+      if (notification) {
+        notification.classList.add("u-hide");
+      }
+    });
+  }
+
+  // Set up all notification close buttons.
+  var closeButtons = document.querySelectorAll(
+    ".p-notification [aria-controls]"
+  );
+
+  for (var i = 0, l = closeButtons.length; i < l; i++) {
+    setupCloseButton(closeButtons[i]);
+  }
+}

--- a/static/js/src/publisher/list-page.js
+++ b/static/js/src/publisher/list-page.js
@@ -1,5 +1,6 @@
 import { WeeklyActiveDevicesTrend } from "./graphs/activeDevices";
 import debounce from "../libs/debounce";
+import initCloseButton from "../libs/notification-close";
 
 const init = () => {
   // To DO - replace dummy data with API data
@@ -101,6 +102,8 @@ const init = () => {
   }, 100);
 
   window.addEventListener("resize", resize);
+
+  initCloseButton();
 };
 
 export { init };

--- a/templates/publisher/list.html
+++ b/templates/publisher/list.html
@@ -26,6 +26,20 @@
   </div>
 </section>
 <section class="p-strip u-extra-space is-shallow">
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+    <div class="u-fixed-width">
+      {% for category, message in messages %}
+      <div id="notification" class="p-notification p-notification--{{ category }}">
+        <p class="p-notification__response">
+          {{ message }}
+        </p>
+        <button class="p-icon--close" aria-label="Close notification" aria-controls="notification">Close</button>
+      </div>
+      {% endfor %}
+    </div>
+    {% endif %}
+  {% endwith %}
   {% if not published and not registered %}
     <div class="row">
       <div class="col-4">
@@ -87,10 +101,10 @@
           <nav class="p-tabs" aria-label="Charms and bundles navigation">
             <ul class="p-tabs__list" role="tablist">
               <li class="p-tabs__item" role="presentation">
-                <a href="/charms" class="p-tabs__link" tabindex="0" role="tab" aria-controls="charms" {% if page_type=='charms' %}aria-selected="true" {% endif %}>Charms</a>
+                <a href="/charms" class="p-tabs__link" tabindex="0" role="tab" aria-controls="charms" {% if page_type=='charm' %}aria-selected="true" {% endif %}>Charms</a>
               </li>
               <li class="p-tabs__item" role="presentation">
-                <a href="/bundles" class="p-tabs__link" role="tab" aria-controls="bundles" {% if page_type=='bundles' %}aria-selected="true" {% endif %}>Bundles</a>
+                <a href="/bundles" class="p-tabs__link" role="tab" aria-controls="bundles" {% if page_type=='bundle' %}aria-selected="true" {% endif %}>Bundles</a>
               </li>
             </ul>
           </nav>
@@ -101,7 +115,7 @@
       </ul>
     </div>
     <div class="u-fixed-width">
-      <h2 class="p-heading--4">Published {{ page_type }}</h2>
+      <h2 class="p-heading--4">Published {{ page_type }}s</h2>
     </div>
     <div class="p-details-tab__content">
       <div class="u-fixed-width">
@@ -141,7 +155,7 @@
       <div class="p-strip is-shallow">
         <div class="u-fixed-width u-flex">
           <div class="p-tooltip--information">
-            <h2 class="p-heading--4" style="padding-inline-end: 0.5rem;">Registered {{ page_type[:-1] }} names</h2>
+            <h2 class="p-heading--4" style="padding-inline-end: 0.5rem;">Registered {{ page_type }} names</h2>
             <div class="instruction-tooltip">
               <div class="p-tooltip__button" style="transform: translateY(0.65rem);" role="button" aria-controls="icon-tooltip-modal" tabindex="0">
                 Show information

--- a/templates/publisher/register-name.html
+++ b/templates/publisher/register-name.html
@@ -12,11 +12,56 @@
       Register a new charm or bundle
     </h1>
     <p>You must register a name before you publish a new charm or bundle to the store.</p>
-    <form class="p-form" action="">
-      <div>
+  </div>
+
+  {% if invalid_name %}
+    <div class="row is-wide">
+      <div class="col-8">
+        <div class="p-notification--negative">
+          <p class="p-notification__response" role="status">
+            <span class="p-notification__status">The name '{{ entity_name }}' is not valid.</span> It should only have ASCII lowercase letters, numbers, and hyphens, and must have at least one letter.
+          </p>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
+  {% if already_registered %}
+    <div class="row is-wide">
+      <div class="col-8">
+        <div class="p-notification--negative">
+          <p class="p-notification__response" role="status">
+            <span class="p-notification__status">Another publisher already registered {{ entity_name }}.</span> You can email <a href="mailto:concierge@canonical.com">concierge@canonical.com</a> to file a dispute.
+          </p>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
+  {% if already_owned %}
+    <div class="row is-wide">
+      <div class="col-8">
+        <div class="p-notification--negative">
+          <p class="p-notification__response" role="status">
+            You already own '<a href="/{{ entity_name }}/listing"><strong>{{ entity_name }}</strong></a>'.
+          </p>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
+  <div class="u-fixed-width is-wide">
+    <form class="p-form" method="POST">
+      <div class="p-form-validation{% if entity_name %} is-error{% endif %}">
         <label for="name">Name:</label>
-        <input class="is-input--narrow" id="name" name="name" type="text" autocomplete="name">
-        <p class="p-form-help-text u-no-max-width">It should only have ASCII lowercase letters, numbers, and hyphens, and must have at least one letter</p>
+        <input class="p-form-validation__input is-input--narrow" id="name" name="name" type="text" autocomplete="name" {% if entity_name %}value="{{ entity_name }}"{% endif %}>
+        <p class="p-form-help-text u-no-max-width{% if entity_name %} u-hide{% endif %}">It should only have ASCII lowercase letters, numbers, and hyphens, and must have at least one letter</p>
+        <p class="p-form-validation__message u-no-max-width" role="alert">
+          <strong>Error:</strong>
+          {% if invalid_name %}The name should only have ASCII lowercase letters, numbers, and hyphens, and must have at least one letter.{% endif %}
+          {% if already_registered %}This name is already taken.{% endif %}
+          {% if already_owned %}You already own this name.{% endif %}
+        </p>
       </div>
       <div>
         <label class="p-radio">
@@ -34,13 +79,13 @@
         <label class="p-radio">
           <p class="is-label">Visibility:</p>
           <p class="p-form-help-text">This can be changed at any time after the initial upload</p>
-          <input type="radio" class="p-radio__input" name="visibility" checked="" aria-labelledby="public" value="pubic">
-          <span class="p-radio__label" id="public">Public</span>
+          <input type="radio" class="p-radio__input" name="private" checked="" aria-labelledby="is-public" value="public">
+          <span class="p-radio__label" id="is-public">Public</span>
         </label>
         <p class="p-form-help-text" style="padding-inline-start: 2rem;">Anyone can find your charm in the Charmhub</p>
         <label class="p-radio">
-          <input type="radio" class="p-radio__input" name="visibility" aria-labelledby="private" value="private">
-          <span class="p-radio__label" id="private">Private</span>
+          <input type="radio" class="p-radio__input" name="private" aria-labelledby="is-private" value="private">
+          <span class="p-radio__label" id="is-private">Private</span>
         </label>
         <p class="p-form-help-text" style="padding-inline-start: 2rem;">Charm is hidden in the store and only accessible by the publisher and collaborators</p>
       </div>
@@ -51,6 +96,7 @@
           Register
         </button>
       </div>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     </form>
   </div>
 </section>


### PR DESCRIPTION
## Done
- _Connect register name to the API_
- _Fix `/charms` and `/bundles` page to show only the appropriate registered names_

## How to QA
- Run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/register-name
- Register a bundle name and then a charm name. Go back to http://localhost:8045/charms and http://localhost:8045/bundles and see your names are displayed

## Issue / Card
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1917


## Screenshots

![image](https://user-images.githubusercontent.com/40214246/111981310-68887900-8aff-11eb-99fa-19b2877b7e0f.png)

![image](https://user-images.githubusercontent.com/40214246/111981350-7938ef00-8aff-11eb-8493-4b6b2d63b896.png)

![image](https://user-images.githubusercontent.com/40214246/111981441-98d01780-8aff-11eb-925b-864ef8c18e77.png)
