### PR TITLE
Fix missing use of variable

### DIFF
--- a/templates/details/libraries/docstring.html
+++ b/templates/details/libraries/docstring.html
@@ -47,10 +47,7 @@
           <h4 id="{{ group['name'].lower() }}" class="p-docstring-block__heading">
             {% if group["type"].lower() == "function" %}
               <span class="token keyword">def</span>
-              <span class="token function">{{ group["name"] }}(</span>
-              {% for arg in group["arguments"] %}
-                <span class="token string">arg</span>
-              {% endfor %}
+              <span class="token function">{{ group["name"] }}(</span>{% for arg in group["arguments"] %}<span class="token string">{{ arg }}</span>{% endfor %}
               <span class="token function u-no-horizontal-space">)</span>
               {% elif group["type"].lower() == "class" %}
               <span class="token keyword">{{ group["type"].lower() }}</span>


### PR DESCRIPTION
## Done
- The variable in the loop wasn't use for the parameters of a function in the libraries tab
- Remove extra space before the first argument name  

## How to QA
- On staging api, add this to the `.env.local`:
```
# Staging API for publisher:
CHARMSTORE_PUBLISHER_API_URL=https://api.staging.charmhub.io/
CANDID_API_URL=https://api.staging.jujucharms.com/identity/

# Staging API for consumer:
CHARMSTORE_API_URL=https://api.staging.charmhub.io/
```
- http://0.0.0.0:8045/toto-wordpress/libraries/libwithdocs
- Check that the functions have the correct name of arguments (not just `arg`)

## Issue / Card
Fixes #889 

