### PR TITLE
Use creation date from API on library page

### DIFF
--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -102,7 +102,7 @@ than the latest.</span>
                 </span>
               </li>
               <li class="p-inline-list__item">
-                <i class="p-icon--update">Last updated</i> 26 June 2019
+                <i class="p-icon--update">Last updated</i> {{ creation_date }}
               </li>
               <li class="p-inline-list__item">
                 <i class="p-icon--revision">Revision</i> Library version {{ library['api'] }}

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -329,6 +329,7 @@ def details_library(entity_name, library_name):
         docstrings=docstrings,
         channel_requested=channel_request,
         library_name=library_name,
+        creation_date=logic.convert_date(library["created-at"]),
     )
 
 


### PR DESCRIPTION
## Done
- Remove hard code date for library tab
- Use `created_at` field from the API to show when the library was created
- This should also work with udpates, since when a library is updated  a new one is created

## How to QA
- On staging api, add this to the `.env.local`:
```
# Staging API for publisher:
CHARMSTORE_PUBLISHER_API_URL=https://api.staging.charmhub.io/
CANDID_API_URL=https://api.staging.jujucharms.com/identity/

# Staging API for consumer:
CHARMSTORE_API_URL=https://api.staging.charmhub.io/
```
- http://0.0.0.0:8045/toto-wordpress/libraries/libwithdocs
- Make sure the date is correct.

## Issue / Card
Fixes #887 