### PR TITLE
Link to discourse documentation about libraries

### DIFF
--- a/templates/details/libraries/introduction.html
+++ b/templates/details/libraries/introduction.html
@@ -42,5 +42,5 @@ Library charms.foobar.v2.plugin updated to version 2.7.
 Library charms.mysql.v3.metris was already up to date in version 3.2.</code></pre>
     <hr class="p-separator">
     <h4>Learn how to create publish your charm&rsquo;s libraries</h4>
-    <p>Libraries facilitate other charms effectively integrating with your charm. Visit our <a href="#">documentation</a> if you&rsquo;d like to learn how to create and publish libraries.</p>
+    <p>Libraries facilitate other charms effectively integrating with your charm. Visit our <a href="https://discourse.charmhub.io/t/creating-and-using-charm-libraries/4058">documentation</a> if you&rsquo;d like to learn how to create and publish libraries.</p>
 {% endblock%}


### PR DESCRIPTION
## Done
- Link to library documentation
- The documentation is not live, so for now we are linking to a set of documentation that is currently hosted on discourse

## How to QA
- http://localhost:8045/jenkins/libraries
- Make sure the link goes to the correct discourse documentation (link is at the bottom of the page :) )

## Issue / Card
Fixes #884 

