### PR TITLE
Remove metrics and releases from the publisher pages navigation

### DIFF
--- a/templates/publisher/publisher_layout.html
+++ b/templates/publisher/publisher_layout.html
@@ -19,16 +19,6 @@
           </a>
         </li>
         <li class="p-tabs__item" role="presentation">
-          <a href="/{{package.name}}/releases" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "releases" %}aria-selected="true"{% endif %}>
-            Releases
-          </a>
-        </li>
-        <li class="p-tabs__item" role="presentation">
-          <a href="/{{package.name}}/metrics" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "metrics" %}aria-selected="true"{% endif %}>
-            Metrics
-          </a>
-        </li>
-        <li class="p-tabs__item" role="presentation">
           <a href="/{{package.name}}/publicise" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "publicise" %}aria-selected="true"{% endif %}>
             Publicise
           </a>


### PR DESCRIPTION
## Done
- _Remove metrics and releases from the publisher pages navigation._

## How to QA
- Run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/CHARM_NAME/listing
- See all the tabs in the nav work fine

## Issue / Card
Fixes #861 

## Screenshots
![image](https://user-images.githubusercontent.com/40214246/111993861-046db100-8b0f-11eb-888e-ab57f485296f.png)

