### PR TITLE
Add bottom spacing on docs and actions empty pages

### DIFF
--- a/templates/details/actions.html
+++ b/templates/details/actions.html
@@ -63,14 +63,16 @@
       </div>
     </div>
   {% else %}
-    <div class="u-fixed-width u-equal-height is-wide">
-      <div class="charm-empty-docs-icon u-vertically-center">
-        <img src="https://assets.ubuntu.com/v1/3234f995-Generic_chamhub_NoDocs.svg" alt="" width="121" height="121">
-      </div>
-      <div class="col-9 charm-empty-docs-content">
-        <h4>No actions have been added yet</h4>
-        <p>Actions are executables associated with a charm that may be invoked by the user.</p>
-        <p class="u-no-margin--bottom"><a class="p-button--positive u-no-margin--bottom" href="https://juju.is/docs/charm-writing/actions">Learn more about working with actions</a></p>
+    <div class="p-strip u-no-padding--top">
+      <div class="u-fixed-width u-equal-height is-wide">
+        <div class="charm-empty-docs-icon u-vertically-center">
+          <img src="https://assets.ubuntu.com/v1/3234f995-Generic_chamhub_NoDocs.svg" alt="" width="121" height="121">
+        </div>
+        <div class="col-9 charm-empty-docs-content">
+          <h4>No actions have been added yet</h4>
+          <p>Actions are executables associated with a charm that may be invoked by the user.</p>
+          <p class="u-no-margin--bottom"><a class="p-button--positive u-no-margin--bottom" href="https://juju.is/docs/charm-writing/actions">Learn more about working with actions</a></p>
+        </div>
       </div>
     </div>
   {% endif %}

--- a/templates/details/empty-docs.html
+++ b/templates/details/empty-docs.html
@@ -3,14 +3,16 @@
 {% extends '/details/details_layout.html' %}
 
 {% block details_content %}
-  <div class="u-fixed-width u-equal-height is-wide">
-    <div class="charm-empty-docs-icon u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/3234f995-Generic_chamhub_NoDocs.svg" alt="" width="121" height="121">
-    </div>
-    <div class="col-9 charm-empty-docs-content">
-      <h4>Docs help you learn how to use a charm</h4>
-      <p>Looks like {{ package.store_front.publisher_name }} hasn’t added any docs to this charm yet.</p>
-      <p class="u-no-margin--bottom"><a class="p-button--positive u-no-margin--bottom" href="https://charmhub.io/tutorials/add-docs-to-your-charmhub-page">Learn how to add docs to a charm</a></p>
+  <div class="p-strip u-no-padding--top">
+    <div class="u-fixed-width u-equal-height is-wide">
+      <div class="charm-empty-docs-icon u-vertically-center">
+        <img src="https://assets.ubuntu.com/v1/3234f995-Generic_chamhub_NoDocs.svg" alt="" width="121" height="121">
+      </div>
+      <div class="col-9 charm-empty-docs-content">
+        <h4>Docs help you learn how to use a charm</h4>
+        <p>Looks like {{ package.store_front.publisher_name }} hasn’t added any docs to this charm yet.</p>
+        <p class="u-no-margin--bottom"><a class="p-button--positive u-no-margin--bottom" href="https://charmhub.io/tutorials/add-docs-to-your-charmhub-page">Learn how to add docs to a charm</a></p>
+      </div>
     </div>
   </div>
 {% endblock%}


### PR DESCRIPTION
## Done
- _Add bottom spacing on docs and actions empty pages._

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: https://charmhub-io-895.demos.haus/prometheus/actions & https://charmhub-io-895.demos.haus/prometheus/docs
- See there is some space under the green button

## Issue / Card
Fixes #894 

## Screenshots
![image](https://user-images.githubusercontent.com/40214246/112006886-0d18b400-8b1c-11eb-8df2-0c794f1ca250.png)

