### PR TITLE
Hide published section on list page if no charms/bundles are published

### DIFF
--- a/templates/publisher/list.html
+++ b/templates/publisher/list.html
@@ -40,61 +40,8 @@
     </div>
     {% endif %}
   {% endwith %}
-  {% if not published and not registered %}
-    <div class="row">
-      <div class="col-4">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/4e112235-Understand+the+basics.svg",
-          alt="",
-          width="84",
-          height="66",
-          hi_def=True,
-          attrs={"style": "margin-block-end: 0.75rem;"}
-          ) | safe
-        }}
-        <h3 class="p-heading--5 u-no-margin--bottom">Understand the basics</h3>
-        <p>Learn everything about charms and all the best practices of how to use them and write them.</p>
-        <p class="u-sv3">
-          <a href="/docs">Read the docs&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-      <div class="col-4">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/dcff8529-First+kubernetes+operator.svg",
-          alt="",
-          width="74",
-          height="65",
-          hi_def=True,
-          attrs={"style": "margin-block-end: 0.75rem;"}
-          ) | safe
-        }}
-        <h3 class="p-heading--5 u-no-margin--bottom">Your first Kubernetes operator</h3>
-        <p>Create a minimal charmed operator with the Python Operator Framework.</p>
-        <p class="u-sv3">
-          <a href="/tutorials/build-a-minimal-operator">Complete this tutorial&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-      <div class="col-4">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/2d09f636-Community.svg",
-          alt="",
-          width="76",
-          height="66",
-          hi_def=True,
-          attrs={"style": "margin-block-end: 0.75rem;"}
-          ) | safe
-        }}
-        <h3 class="p-heading--5 u-no-margin--bottom">Join the community</h3>
-        <p>Request features, troubleshoot and generally find all the latest talk about the world of charms.</p>
-        <p class="u-sv3">
-          <a href="https://discourse.charmhub.io/">Join the discussion&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-    </div>
-  {% else %}
+
+  {% if published or registered %}
     <div class="u-fixed-width">
       <ul class="p-inline-list--stretch is-navigation u-no-margin--bottom">
         <li class="p-inline-list__item">
@@ -114,45 +61,50 @@
         </li>
       </ul>
     </div>
-    <div class="u-fixed-width">
-      <h2 class="p-heading--4">Published {{ page_type }}s</h2>
-    </div>
-    <div class="p-details-tab__content">
-      <div class="u-fixed-width">
-        <table class="p-table--mobile-card" role="grid">
-          <thead>
-            <tr role="row">
-              <th style="width: 30%;">Name</th>
-              <th>Visibility</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for published_charm in published %}
-            <tr role="row">
-              <td role="rowheader" class="p-table--mobile-card__header">
-                <div class="p-heading-icon--x-small">
-                  <span class="p-heading-icon__header">
-                    <img src="https://dashboard.snapcraft.io/site_media/appmedia/2020/04/products-hero-ubuntu.svg.png" width="24" height="24" class="p-heading-icon__img">
-                    <p class="u-no-margin--bottom u-no-padding--top">
-                      <a href="/{{ published_charm.name }}/listing">{{ published_charm.name }}</a>
-                    </p>
-                  </span>
-                </div>
-              </td>
-              <td role="gridcell" aria-label="visibility">
-                {% if published_charm.private %}
-                Private
-                {% else %}
-                Public
-                {% endif %}
-              </td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+
+    {% if published %}
+      <div class="p-strip is-shallow u-no-padding--top">
+        <div class="u-fixed-width">
+          <h2 class="p-heading--4">Published {{ page_type }}s</h2>
+        </div>
+        <div class="u-fixed-width">
+          <table class="p-table--mobile-card" role="grid">
+            <thead>
+              <tr role="row">
+                <th style="width: 30%;">Name</th>
+                <th>Visibility</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for published_charm in published %}
+              <tr role="row">
+                <td role="rowheader" class="p-table--mobile-card__header">
+                  <div class="p-heading-icon--x-small">
+                    <span class="p-heading-icon__header">
+                      <img src="https://dashboard.snapcraft.io/site_media/appmedia/2020/04/products-hero-ubuntu.svg.png" width="24" height="24" class="p-heading-icon__img">
+                      <p class="u-no-margin--bottom u-no-padding--top">
+                        <a href="/{{ published_charm.name }}/listing">{{ published_charm.name }}</a>
+                      </p>
+                    </span>
+                  </div>
+                </td>
+                <td role="gridcell" aria-label="visibility">
+                  {% if published_charm.private %}
+                  Private
+                  {% else %}
+                  Public
+                  {% endif %}
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
       </div>
-      {% if registered %}
-      <div class="p-strip is-shallow">
+    {% endif %}
+
+    {% if registered %}
+      <div class="p-strip is-shallow u-no-padding--top">
         <div class="u-fixed-width u-flex">
           <div class="p-tooltip--information">
             <h2 class="p-heading--4" style="padding-inline-end: 0.5rem;">Registered {{ page_type }} names</h2>
@@ -198,9 +150,72 @@
           </table>
         </div>
       </div>
-      {% endif %}
+    {% endif %}
+  {% endif %}
+
+  {% if not published %}
+    {% if registered %}
+      <div class="u-fixed-width">
+        <hr class="p-separator">
+        <h3 class="p-heading--4 u-sv1">Getting started</h3>
+      </div>
+    {% endif %}
+
+    <div class="row">
+      <div class="col-4">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/4e112235-Understand+the+basics.svg",
+          alt="",
+          width="84",
+          height="66",
+          hi_def=True,
+          attrs={"style": "margin-block-end: 0.75rem;"}
+          ) | safe
+        }}
+        <h4 class="p-heading--5 u-no-margin--bottom">Understand the basics</h4>
+        <p>Learn everything about charms and all the best practices of how to use them and write them.</p>
+        <p class="u-sv3">
+          <a href="/docs">Read the docs&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+      <div class="col-4">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/dcff8529-First+kubernetes+operator.svg",
+          alt="",
+          width="74",
+          height="65",
+          hi_def=True,
+          attrs={"style": "margin-block-end: 0.75rem;"}
+          ) | safe
+        }}
+        <h4 class="p-heading--5 u-no-margin--bottom">Your first Kubernetes operator</h4>
+        <p>Create a minimal charmed operator with the Python Operator Framework.</p>
+        <p class="u-sv3">
+          <a href="/tutorials/build-a-minimal-operator">Complete this tutorial&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+      <div class="col-4">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/2d09f636-Community.svg",
+          alt="",
+          width="76",
+          height="66",
+          hi_def=True,
+          attrs={"style": "margin-block-end: 0.75rem;"}
+          ) | safe
+        }}
+        <h4 class="p-heading--5 u-no-margin--bottom">Join the community</h4>
+        <p>Request features, troubleshoot and generally find all the latest talk about the world of charms.</p>
+        <p class="u-sv3">
+          <a href="https://discourse.charmhub.io/">Join the discussion&nbsp;&rsaquo;</a>
+        </p>
+      </div>
     </div>
   {% endif %}
+
 </section>
 {% endblock %}
 

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -41,7 +41,9 @@ def list_page():
 
     context = {
         "published": [
-            c for c in publisher_charms if c["status"] == "published"
+            c
+            for c in publisher_charms
+            if c["status"] == "published" and c["type"] == page_type
         ],
         "registered": [
             c


### PR DESCRIPTION
## Done
- _Change page layout when user has registered names, but not published._

## How to QA
- Visit https://charmhub-io-898.demos.haus/charms and https://charmhub-io-898.demos.haus/bundles and you should see one of the 3 states below depending if you have any names registered and/or any charms/bundles published

## Issue / Card
Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/863

## Screenshots
![image](https://user-images.githubusercontent.com/40214246/112185274-f9db1680-8bf7-11eb-8d41-3da3d755b88a.png)

![image](https://user-images.githubusercontent.com/40214246/112185169-e334bf80-8bf7-11eb-950e-eef949001cf0.png)

![image](https://user-images.githubusercontent.com/40214246/112185341-0b242300-8bf8-11eb-98bf-0295ac77ff51.png)


