### PR TITLE
Fix channel map to work when drop-down is changed

### DIFF
--- a/templates/partial/_channel-map.html
+++ b/templates/partial/_channel-map.html
@@ -41,7 +41,7 @@
         <div class="p-form__group">
           <label class="p-form__label">Filter by series:</label>
           <div class="p-form__control">
-            <select data-js="channel-map-filter" value="any">
+            <select data-js="channel-map-filter">
               <option value="any">Any</option>
               {% for version in package.store_front.platforms %}
               <option value="{{ version }}">{{ version }}</option>
@@ -63,7 +63,7 @@
         <tbody>
           {% for track, track_data in package.store_front.channel_map.items() %}
           {% for channel, channel_data in track_data.items() %}
-          <tr data-channel-map-track="{{ track }}" data-channel-map-channel="{{ channel }}" data-channel-map-version="{{ channel_data.version }}" data-channel-map-filter="{% for data in channel_data %}{{ data.platform }} {% endfor %}">
+          <tr data-channel-map-track="{{ track }}" data-channel-map-channel="{{ channel }}" data-channel-map-version="{{ channel_data.version }}" data-channel-map-filter="{% for platform in channel_data[0].platforms %}{{ platform }} {% endfor %}">
             <td>{{ track }}/{{ channel }}</td>
             <td>{{ channel_data[0].version }}</td>
             <td>

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -177,7 +177,8 @@ def convert_channel_maps(channel_map):
             "revision": channel["revision"],
         }
 
-        result[track][risk].append(info)
+        if not result[track][risk]:
+            result[track][risk].append(info)
 
     # Order tracks and risks
     result = OrderedDict(


### PR DESCRIPTION
## Done
- _Fix channel map to work when drop-down is changed._
- _Avoid adding duplicate info to the `store_front channel_map`._

## How to QA
- Visit https://charmhub-io-899.demos.haus/postgresql and click on the channel map and select 20.04 LTS
- See that you only see the channel that contains 20.04LTS

## Issue / Card
Fixes #870 

## Screenshots
[if relevant, include a screenshot]
