### PR TITLE
Return 404 when requesting publicise pages and charm is not published

### DIFF
--- a/templates/publisher/publicise/publicise_empty.html
+++ b/templates/publisher/publicise/publicise_empty.html
@@ -1,0 +1,30 @@
+{% extends 'publisher/publisher_layout.html' %}
+
+{% block title %}Publicise {{ package.name }}{% endblock %}
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+{% block meta_description %}{% endblock %}
+
+{% set selected_tab='publicise' %}
+
+{% block publisher_content %}
+<div class="p-strip is-shallow u-extra-space">
+  <div class="u-fixed-width u-equal-height">
+    <div class="charm-empty-docs-icon u-vertically-center">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/52579016-JAAS+diagram-update.svg",
+        alt="",
+        width="140",
+        height="130",
+        hi_def=True,
+        ) | safe
+      }}
+    </div>
+    <div class="col-9 charm-empty-docs-content">
+      <h4>Here you will find ways of sharing your {{ package.type }}</h4>
+      <p>This section will only be available once you have published your {{ package.type }}</p>
+      <p class="u-no-margin--bottom"><a class="p-button--positive u-no-margin--bottom" href="https://discourse.charmhub.io/t/creating-and-using-charm-libraries/4058">Learn how to publish an operator</a></p>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -266,6 +266,11 @@ def get_publicise(entity_name):
         session["publisher-auth"], "charm", entity_name
     )
 
+    if not package["status"] == "published":
+        return render_template(
+            "publisher/publicise/publicise_empty.html", package=package
+        )
+
     context = {
         "package": package,
         "languages": SUPPORTED_LANGUAGES,
@@ -282,6 +287,11 @@ def get_publicise_badges(entity_name):
         session["publisher-auth"], "charm", entity_name
     )
 
+    if not package["status"] == "published":
+        return render_template(
+            "publisher/publicise/publicise_empty.html", package=package
+        )
+
     context = {
         "package": package,
     }
@@ -296,6 +306,11 @@ def get_publicise_cards(entity_name):
     package = publisher_api.get_package_metadata(
         session["publisher-auth"], "charm", entity_name
     )
+
+    if not package["status"] == "published":
+        return render_template(
+            "publisher/publicise/publicise_empty.html", package=package
+        )
 
     context = {
         "package": package,

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -128,6 +128,10 @@ def get_package(entity_name, channel_request, fields):
         entity_name, channel=channel_request, fields=fields
     )
 
+    # If the package is not published, return a 404
+    if not package["default-release"]:
+        abort(404)
+
     if COMMANDS_OVERWRITE.get(entity_name):
         package["command"] = COMMANDS_OVERWRITE[entity_name]
     else:
@@ -419,6 +423,9 @@ def details_integrate(entity_name):
 @store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/badge.svg')
 def entity_badge(entity_name):
     package = app.store_api.get_item_details(entity_name, fields=FIELDS)
+
+    if not package["default-release"]:
+        abort(404)
 
     entity_link = request.url_root + entity_name
     right_text = "".join(


### PR DESCRIPTION
## Done
- _Return 404 when requesting publicise pages and charm is not published._

## How to QA
- Visit https://charmhub-io-900.demos.haus/CHARM_NAME/publicise and https://charmhub-io-900.demos.haus/CHARM_NAME/publicise/badges and https://charmhub-io-900.demos.haus/CHARM_NAME/publicise/cards
- The charm/bundle `CHARM_NAME` should not be published
- See the page is showing an empty state like in the screenshot below
- Also check that `/CHARM_NAME/badge.svg` & `/CHARM_NAME/embedded`  are 404ing

## Issue / Card
Fixes #864 

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/114200453-222f7880-994d-11eb-98eb-5fec99c32185.png)


