### PR TITLE
Fix tooltip on charms page

### DIFF
--- a/templates/publisher/list.html
+++ b/templates/publisher/list.html
@@ -106,13 +106,13 @@
     {% if registered %}
       <div class="p-strip is-shallow u-no-padding--top">
         <div class="u-fixed-width u-flex">
-          <div class="p-tooltip--information">
-            <h2 class="p-heading--4" style="padding-inline-end: 0.5rem;">Registered {{ page_type }} names</h2>
+          <div class="p-tooltip--information" style="margin-block-end: 0.95rem;">
+            <h2 class="p-heading--4 u-no-margin--bottom" style="padding-inline-end: 0.5rem;">Registered {{ page_type }} names</h2>
             <div class="instruction-tooltip">
               <div class="p-tooltip__button" style="transform: translateY(0.65rem);" role="button" aria-controls="icon-tooltip-modal" tabindex="0">
                 Show information
               </div>
-              <div class="p-tooltip__modal" id="icon-tooltip-modal" style="top: 0.25rem; transform: translateX(1rem) translateY(-0.5rem);">
+              <div class="p-tooltip__modal" id="icon-tooltip-modal">
                 <div class="p-tooltip__dialog" role="dialog" aria-labelledby="modal-content">
                   <button class="p-tooltip__close" aria-controls="icon-tooltip-modal" aria-label="Close tooltip modal">Close</button>
                   <span id="modal-content" class="u-no-margin--bottom u-no-padding--top">


### PR DESCRIPTION
## Done
- _Fix tooltip on charms page._

## How to QA
- Visit https://charmhub-io-902.demos.haus/charms
- See the tooltip works fine both on small and large screens.

## Issue / Card
Fixes #865 

## Screenshots
[if relevant, include a screenshot]
