### PR TITLE
Fix icons on top of tooltip on libraries page

### DIFF
--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -6,7 +6,7 @@
 
   <div class="row is-wide p-details-tab__content">
     <div class="col-3 has-space--right">
-      <div class="p-side-navigation" id="drawer" style="overflow-y: visible;">
+      <div class="p-side-navigation" id="drawer" style="overflow-y: visible; position: relative;">
         <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation
         </a>


### PR DESCRIPTION
## Done
- _Fix icons on top of tooltip on libraries page._

## How to QA
- Run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/toto-wordpress/libraries/libwithdocs
- Hover over the tooltip on the left "Publisher suggests" and note the icons of the "Docstrings" and "Source code" buttons are not visible.

## Issue / Card
Fixes #881 

##  Screenshot
![image](https://user-images.githubusercontent.com/40214246/113692038-044fe280-96c5-11eb-9893-66737c07e699.png)
