### PR TITLE
Use title of an operator instead of id when defined

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -45,7 +45,7 @@
           {% endif %}
           <div class="p-media-object__details">
             <h1 class="p-media-object__title">
-              {{ format_slug(package.name) }}
+              {{ format_slug(package.store_front["display-name"]) }}
             </h1>
             <div class="p-media-object__content u-no-margin--bottom">
               <ul class="p-inline-list--middot">

--- a/templates/partial/_featured-charms.html
+++ b/templates/partial/_featured-charms.html
@@ -9,7 +9,7 @@
           <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_64,h_64/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" width="64" height="64" class="p-card__thumbnail" alt="{{ charm['name'] }}">
         {% endif %}
       </div>
-      <h3 class="p-card__title p-heading--4 u-no-margin--bottom package-card-title">{{ charm['name'] | replace("-", " ") }}</h3>
+      <h3 class="p-card__title p-heading--4 u-no-margin--bottom package-card-title">{{ charm['store_front']['display-name'] | replace("-", " ") }}</h3>
       <p class="u-text--muted u-no-padding--top package-card-publisher">{{ charm.result.publisher["display-name"] }}</p>
     </div>
 

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -258,6 +258,10 @@ def add_store_front_data(package, details=False):
         package["default-release"]["revision"]["platforms"]
     )
     extra["categories"] = package["result"]["categories"]
+    if "title" in package["result"] and package["result"]["title"]:
+        extra["display-name"] = package["result"]["title"]
+    else:
+        extra["display-name"] = package["name"]
 
     if details:
         extra["metadata"] = yaml.load(

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -31,6 +31,7 @@ SEARCH_FIELDS = [
     "result.categories",
     "result.summary",
     "result.media",
+    "result.title",
     "result.publisher.display-name",
     "default-release.revision.revision",
     "default-release.revision.platforms",


### PR DESCRIPTION
## Done
- use title of a charm if it is defined

## How to QA
-  `dotrun`
- There no charms currently with title set. Check for now if the homepage and the details page are still showing the charm names
- http://0.0.0.0:8045/charmcraft-prometheus
- http://0.0.0.0:8045/