### PR TITLE
Add missing field result.title for details pages

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -111,6 +111,7 @@ FIELDS = [
     "default-release",
     "result.categories",
     "result.publisher.display-name",
+    "result.title",
     "channel-map",
 ]
 


### PR DESCRIPTION
## Done
-  the field title was missing when requesting the info endpoint
- this field is used to display the pretty name of a charm

## How to QA
- http://0.0.0.0:8045/discourse-charmers-discourse-k8s
- The title should be just: Discourse
