### PR TITLE
Add bundle icons to the homepage

### DIFF
--- a/static/js/src/public/store/buildPackageCard.js
+++ b/static/js/src/public/store/buildPackageCard.js
@@ -40,11 +40,16 @@ function buildPackageCard(entity) {
       ".p-bundle-icons__count"
     );
 
-    bundleIconsCount.innerText = `+${Math.floor(Math.random() * 10 + 1)}`;
-
-    bundleThumbnails.forEach((thumbnail) => {
-      thumbnail.src =
-        "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_64,h_64/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg";
+    if (entity.apps && entity.apps.length > 2) {
+      bundleIconsCount.innerText = `+${entity.apps.length - 2}`;
+    }
+    bundleThumbnails.forEach((thumbnail, count) => {
+      if (entity.apps && entity.apps[count]) {
+        thumbnail.src = `/${entity.apps[count]}/icon`;
+      } else {
+        thumbnail.src =
+          "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_64,h_64/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg";
+      }
     });
   }
 

--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -33,6 +33,9 @@ class initPackages {
           return;
         }
 
+        // Temporary hack to get bundle icons, as the API does not have it
+        this.addBundleApps();
+
         this.groupAllPackages();
         this.filterPackages();
         this.handleShowAllPackagesButton();
@@ -56,6 +59,26 @@ class initPackages {
         }
       })
       .catch((e) => console.error(e));
+  }
+
+  addBundleApps() {
+    this.allPackages.forEach((entity, count) => {
+      if (entity.type === "bundle") {
+        fetch(`/${entity.name}/charms.json`)
+          .then((response) => {
+            if (response.ok) {
+              response.json().then((res) => {
+                this.allPackages[count]["apps"] = res.charms;
+              });
+            } else {
+              throw new Error(
+                "There was a problem comunicating with the server."
+              );
+            }
+          })
+          .catch((e) => console.error(e));
+      }
+    });
   }
 
   fetchPackageList() {

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -6,8 +6,8 @@
           {% if package.type == "bundle" %}
           {% set charms = package.store_front.bundle.applications.keys() | list %}
           <div class="p-bundle-icons">
-            <img src="/{{ charms[0] }}/icon.png" alt="" />
-            <img src="/{{ charms[1] }}/icon.png" alt="" />
+            <img src="/{{ charms[0] }}/icon" alt="" />
+            <img src="/{{ charms[1] }}/icon" alt="" />
             {% if charms | length > 2 %}
             <span class="p-bundle-icons__count u-text--muted">
               +{{ charms | length - 2 }}

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -4,7 +4,7 @@ import talisker
 from canonicalwebteam.discourse import DocParser
 from canonicalwebteam.discourse.exceptions import PathNotFoundError
 from canonicalwebteam.store_api.stores.charmstore import CharmPublisher
-from flask import Blueprint, abort, redirect
+from flask import Blueprint, abort, redirect, jsonify
 from flask import current_app as app
 from flask import render_template, request, Response
 
@@ -518,3 +518,23 @@ def entity_icon(entity_name):
         "https://res.cloudinary.com/canonical/image/fetch/f_auto"
         f",q_auto,fl_sanitize,w_64,h_64/{icon_url}"
     )
+
+
+# This method is a temporary hack to show bundle icons on the
+# homepage, and should be removed once the icons are available via the api
+@store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/charms.json')
+def get_charms_from_bundle(entity_name):
+    channel_request = request.args.get("channel", default=None, type=str)
+
+    package = get_package(entity_name, channel_request, FIELDS)
+
+    if package["type"] == "charm":
+        return "Requested object should be a bundle", 400
+
+    charms = []
+
+    if package["store_front"]["bundle"].get("applications"):
+        for charm in package["store_front"]["bundle"]["applications"].keys():
+            charms.append(charm)
+
+    return jsonify({"charms": charms})


### PR DESCRIPTION
## Done
- _Add bundle icons to the homepage_

## How to QA
- Run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
- Change [line 93](https://github.com/canonical-web-and-design/charmhub.io/blob/master/webapp/store/views.py#L93) `if item["type"] != "charm":` to `if item["type"] != "bundle":`
- Click the "See all operators" button
- See all bundles have icons.
- Click on some of the bundles and see the icon info is the same as on the details page

## Issue / Card
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1967
