### PR TITLE
Add icon to the list and listing pages

### DIFF
--- a/static/sass/_pattern_heading-icon.scss
+++ b/static/sass/_pattern_heading-icon.scss
@@ -3,7 +3,9 @@
     @extend .p-heading-icon--small;
 
     .p-heading-icon__img {
+      border-radius: 50%;
       height: 1.5rem;
+      margin-inline-end: 0.5rem;
       width: 1.5rem;
 
       @media screen and (max-width: $breakpoint-medium) {

--- a/templates/publisher/list.html
+++ b/templates/publisher/list.html
@@ -81,7 +81,31 @@
                 <td role="rowheader" class="p-table--mobile-card__header">
                   <div class="p-heading-icon--x-small">
                     <span class="p-heading-icon__header">
-                      <img src="https://dashboard.snapcraft.io/site_media/appmedia/2020/04/products-hero-ubuntu.svg.png" width="24" height="24" class="p-heading-icon__img">
+                      {% if published_charm.media %}
+                        {{
+                          image(
+                            url=published_charm.media[0].url,
+                            alt=published_charm.name,
+                            width="24",
+                            height="24",
+                            hi_def=True,
+                            fill=True,
+                            attrs={"class": "p-heading-icon__img"},
+                          ) | safe
+                        }}
+                      {% else %}
+                        {{
+                          image(
+                            url="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg",
+                            alt=published_charm.name,
+                            width="24",
+                            height="24",
+                            hi_def=True,
+                            fill=True,
+                            attrs={"class": "p-heading-icon__img"},
+                          ) | safe
+                        }}
+                      {% endif %}
                       <p class="u-no-margin--bottom u-no-padding--top">
                         <a href="/{{ published_charm.name }}/listing">{{ published_charm.name }}</a>
                       </p>
@@ -90,9 +114,9 @@
                 </td>
                 <td role="gridcell" aria-label="visibility">
                   {% if published_charm.private %}
-                  Private
+                    Private
                   {% else %}
-                  Public
+                    Public
                   {% endif %}
                 </td>
               </tr>
@@ -142,7 +166,11 @@
                   <a href="/{{ registered_charm['name'] }}/listing">{{ registered_charm['name'] }}</a>
                 </td>
                 <td>
-                  {{ registered_charm['visibility'] }}
+                  {% if registered_charm.private %}
+                    Private
+                  {% else %}
+                    Public
+                  {% endif %}
                 </td>
               </tr>
               {% endfor %}

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -29,6 +29,40 @@
       </h2>
     <div class="row p-form__group p-form-validation">
       <div class="col-2">
+        <p class="is-label">{{ package.type|capitalize }} icon:</p>
+      </div>
+      <div class="col-8 col-x-large-6 u-sv2">
+        <div class="p-form__control">
+          {% if package.media %}
+            {{
+              image(
+                url=package.media[0].url,
+                alt=package.name,
+                width="64",
+                height="64",
+                hi_def=True,
+                fill=True,
+                attrs={"class": "p-media-object__image", "style": "border-radius: 50%;"},
+              ) | safe
+            }}
+          {% else %}
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg",
+                alt=package.name,
+                width="64",
+                height="64",
+                hi_def=True,
+                fill=True,
+                attrs={"class": "p-media-object__image", "style": "border-radius: 50%;"},
+              ) | safe
+            }}
+          {% endif %}
+        </div>
+      </div>
+    </div>
+    <div class="row p-form__group p-form-validation">
+      <div class="col-2">
         <label for="title" class="p-form__label">Title:</label>
       </div>
       <div class="col-8 col-x-large-6">


### PR DESCRIPTION
## Done
- _Add entity icon to the listing page._
- _Add entity icon to the list page._
- _Fix visibility on the list page._

## How to QA
- Run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/charms
- Go to http://localhost:8045/charms and http://localhost:8045/bundles and see there are icons displayed for all your published charms/bundles
- Go to http://localhost:8045/[charm_name]/listing and see it has the icon displayed

## Issue / Card
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1962
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1963

## Screenshots
![image](https://user-images.githubusercontent.com/40214246/114831815-b5413600-9dc5-11eb-84a3-504edb00f6aa.png)

![image](https://user-images.githubusercontent.com/40214246/114831875-c4c07f00-9dc5-11eb-9156-b34147652a89.png)


