### PR TITLE
Stop using format_slug in templates

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -52,7 +52,7 @@
           {% endif %}
           <div class="p-media-object__details">
             <h1 class="p-media-object__title">
-              {{ format_slug(package.store_front["display-name"]) }}
+              {{ package.store_front["display-name"] }}
             </h1>
             <div class="p-media-object__content u-no-margin--bottom">
               <ul class="p-inline-list--middot">

--- a/templates/details/details_layout.html
+++ b/templates/details/details_layout.html
@@ -1,19 +1,19 @@
 {% extends 'base_layout.html' %}
 
-{% block title %}Deploy {{ format_slug(package.name) }} using Charmhub - The Open Operator Collection{% endblock %}
-{% block meta_description %}Deploy the latest version of {{ format_slug(package.name) }} as a Kubernetes Operator on any cloud. {{ package.result.summary }}{% endblock %}
+{% block title %}Deploy {{ package.store_front["display-name"] }} using Charmhub - The Open Operator Collection{% endblock %}
+{% block meta_description %}Deploy the latest version of {{ package.store_front["display-name"] }} as a Kubernetes Operator on any cloud. {{ package.result.summary }}{% endblock %}
 {% block meta_image %}{% if package["store_front"]["icons"] %}https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_200,h_200/{{ package.store_front.icons[0] }}{% else %}https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg{% endif %}{% endblock %}
 {% block meta_twitter_card %}summary{% endblock %}
 {% block meta_image_width %}200{% endblock %}
 {% block meta_image_height %}200{% endblock %}
-{% block meta_image_alt %}{{ format_slug(package.name) }} charm logo{% endblock %}
+{% block meta_image_alt %}{{ package.store_front["display-name"] }} charm logo{% endblock %}
 
 {% block structure_data_markup %}
 <script type="application/ld+json">
  {
      "@context": "http://schema.org",
      "@type": "SoftwareApplication",
-     "name": "{{ format_slug(package.name) }}",
+     "name": "{{ package.store_front["display-name"] }}",
      "image": "{{ self.meta_image() }}",
      "url": "https://charmhub.io/{{ package.name }}",
      "publisher": {

--- a/templates/embeddable-card.html
+++ b/templates/embeddable-card.html
@@ -42,7 +42,7 @@
           </div>
           <div class="p-media-object__details">
             <h1 class="p-media-object__title">
-              {{ format_slug(package.name) }}
+              {{ package.store_front["display-name"] }}
             </h1>
             <div class="p-media-object__content u-no-margin--bottom">
               <ul class="p-inline-list--middot u-no-margin--bottom">

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -32,7 +32,6 @@ def set_handlers(app):
             "add_filter": helpers.add_filter,
             "active_filter": helpers.active_filter,
             "remove_filter": helpers.remove_filter,
-            "format_slug": helpers.format_slug,
             "publisher": publisher,
             "image": image_template,
         }

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -97,26 +97,6 @@ def active_filter(filter_type, filter_name):
     return False
 
 
-def format_slug(slug):
-    """Format slug name into a standard title format
-    :param slug: The hypen spaced, lowercase slug to be formatted
-    :return: The formatted string
-    """
-    # TODO Remove once we have category on store side
-    if slug.lower() == "ai/ml":
-        return slug.upper()
-    if slug.lower() == "openstack":
-        return "OpenStack"
-
-    return (
-        slug.title()
-        .replace("-", " ")
-        .replace("_", " ")
-        .replace("And", "and")
-        .replace("Iot", "IoT")
-    )
-
-
 def convert_date(date_to_convert):
     """Convert date to human readable format: Month Day Year
     If date is less than a day return: today or yesterday

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -238,7 +238,7 @@ def add_store_front_data(package, details=False):
     if "title" in package["result"] and package["result"]["title"]:
         extra["display-name"] = package["result"]["title"]
     else:
-        extra["display-name"] = package["name"]
+        extra["display-name"] = format_slug(package["name"])
 
     if details:
         extra["metadata"] = yaml.load(
@@ -365,3 +365,18 @@ def filter_charm(charm, categories=["all"], base="all"):
         return False
 
     return True
+
+
+def format_slug(slug):
+    """Format slug name into a standard title format
+    :param slug: The hypen spaced, lowercase slug to be formatted
+    :return: The formatted string
+    """
+
+    return (
+        slug.title()
+        .replace("-", " ")
+        .replace("_", " ")
+        .replace("And", "and")
+        .replace("Iot", "IoT")
+    )


### PR DESCRIPTION
## Done
- Stop using format_slug in templates
- If there is no result.title on a charm then use the format_slug function

## How to QA
- `dotrun`
- http://0.0.0.0:8045/
- https://0.0.0.0:8045/ceilometer (should be a capital C because it has no title)
- http://0.0.0.0:8045/postgresql-k8s (should be PostgreSQL because it has a title)

## Issue / Card
Fixes #935 