### PR TITLE
Upgade vanilla to 2.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-dom": "16.13.1",
     "sass": "1.27.0",
     "swiper": "6.3.4",
-    "vanilla-framework": "2.28.0",
+    "vanilla-framework": "2.29.0",
     "watch-cli": "0.2.3",
     "webpack": "4.44.1",
     "webpack-cli": "3.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6894,10 +6894,10 @@ vanilla-framework@2.19.1:
   version "2.19.1"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.19.1.tgz#f071deed5504a5fe2104d6d9b087ce654e190881"
 
-vanilla-framework@2.28.0:
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.28.0.tgz#45f729d0e2d863e0aeceab4589a8e0d310f8c9df"
-  integrity sha512-EjrPn1sBFRZ+e6OyVgDIl8Nvdb3xxihodTD+L/FgQSiJJREGLmLjC+NZhq4xziNgHedzDZbIC8Qlx8B4SIo41g==
+vanilla-framework@2.29.0:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.29.0.tgz#19bcdc9ccfafcb8fed91747e24aab7bbabd0cb90"
+  integrity sha512-lDTInGGNGH29e9Clvi6CBvzGK5BfX3MejtwkDEKOR0ERadwH2AmIytmSsR7YVC9AdkJA9gRDxSGAlzBdxzN20w==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done
- _Upgade vanilla to 2.29._

## How to QA
- Go to https://charmhub-io-950.demos.haus and click around and see everything looks good.

## Issue / Card
Fixes #

## Screenshots
[if relevant, include a screenshot]
