### PR TITLE
Fix index issue when no icons

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -504,9 +504,9 @@ def entity_icon(entity_name):
         ],
     )
 
-    icon_url = package["result"]["media"][0]["url"]
-
-    if not icon_url:
+    if package["result"]["media"]:
+        icon_url = package["result"]["media"][0]["url"]
+    else:
         icon_url = (
             "https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg"
         )


### PR DESCRIPTION
## Done
- When no icon is set there is an index issue
- When a charm has no icon it should return the default icon

## How to QA
- `dotrun` 
- http://0.0.0.0:8045/containers-metallb-speaker/icon
- should return default icon
- http://0.0.0.0:8045/prometheus/icon
- should return prometheus icon 
