### PR TITLE
Remove suru on details page

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -1,4 +1,4 @@
-<div class="p-strip has-suru is-shallow">
+<div class="p-strip--light is-shallow">
   <div class="row is-wide">
     <div class="col-8">
       <div class="p-charm-header">


### PR DESCRIPTION
## Done
- Remove suru pattern on details pages

## How to QA
- `dotrun`
- http://0.0.0.0:8045/prometheus
- The header should be a light gray instead of suru

## Issue / Card
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1946
