### PR TITLE
Use deployable-on field

### DIFF
--- a/static/js/src/public/store/buildPackageCard.js
+++ b/static/js/src/public/store/buildPackageCard.js
@@ -96,7 +96,7 @@ function buildPackageCard(entity) {
   }
 
   const entityCardIcons = clone.querySelector(".package-card-icons");
-  if (entity.store_front.base === "kubernetes") {
+  if (entity.store_front['deployable-on'].includes("kubernetes")) {
     buildPlatformIcons(
       entityCardIcons,
       "Kubernetes",
@@ -105,7 +105,7 @@ function buildPackageCard(entity) {
     );
   }
 
-  if (entity.store_front.base === "windows") {
+  if (entity.store_front['deployable-on'].includes("windows")) {
     buildPlatformIcons(
       entityCardIcons,
       "Windows",
@@ -114,7 +114,7 @@ function buildPackageCard(entity) {
     );
   }
 
-  if (entity.store_front.base === "linux") {
+  if (entity.store_front['deployable-on'].includes("linux")) {
     buildPlatformIcons(
       entityCardIcons,
       "Linux",
@@ -123,7 +123,7 @@ function buildPackageCard(entity) {
     );
   }
 
-  if (entity.store_front.base === "all") {
+  if (entity.store_front['deployable-on'].includes("all")) {
     buildPlatformIcons(
       entityCardIcons,
       "Linux",

--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -321,7 +321,7 @@ class initPackages {
               kubernetes: [],
             };
           }
-          if (entity.store_front.base === "kubernetes") {
+          if (entity.store_front['deployable-on'].includes("kubernetes")) {
             this.groupedPackages.categories[cat.name].kubernetes.push(entity);
           } else {
             this.groupedPackages.categories[cat.name].linux.push(entity);
@@ -440,11 +440,11 @@ class initPackages {
       this._filters.filter.length === 0
     ) {
       this.packages = this.allPackages.filter((entity) =>
-        entity.store_front.base === this._filters.base[0]
+        entity.store_front['deployable-on'].includes(this._filters.base[0])
       );
     } else {
       let pakagesFilteredByPlatform = this.allPackages.filter((entity) =>
-        entity.store_front.base === this._filters.base[0]
+        entity.store_front['deployable-on'].includes(this._filters.base[0])
       );
 
       this.packages = pakagesFilteredByPlatform.filter((entity) =>

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -78,14 +78,13 @@
       </div>
     </div>
     <div class="col-4">
-      <p style="margin-bottom: 0.5rem;"><small class="u-no-padding--top u-text--muted">Base:</small></p>
-      {% if package.store_front.series|length == 1 and package.store_front.series[0] == "kubernetes" %}
+      <p style="margin-bottom: 0.5rem;"><small class="u-no-padding--top u-text--muted">Platform:</small></p>
+      {% if package.store_front["deployable-on"]|length == 1 and package.store_front["deployable-on"][0] == "kubernetes" %}
       <img src="https://assets.ubuntu.com/v1/9f8a8273-2018-logo-kubernetes+%282%29.svg" alt="" width="160" height="27" class="p-image--base">
       {% else %}
       <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="" width="89" height="20" class="p-image--base">
-      {% endif %}
       <div class="series-tags">
-        {% for version in package.store_front.platforms %}
+        {% for version in package.store_front.series %}
         {% if version != "Kubernetes" %}
         <span class="series-tag">
           {{ version }}
@@ -93,6 +92,7 @@
         {% endif %}
         {% endfor %}
       </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/templates/partial/_featured-charms.html
+++ b/templates/partial/_featured-charms.html
@@ -18,14 +18,14 @@
 
       <div class="p-card__footer">
         <div class="package-card-icons">
-          {% if charm.store_front.base == "linux" %}
+          {% if "linux" in charm.store_front["deployable-on"] %}
             <span class="p-tooltip" aria-describedby="linux-tooltip">
               <img alt="Linux" src="https://assets.ubuntu.com/v1/dc11bd39-Linux.svg" width="24" height="24">
               <span class="p-tooltip__message" role="tooltip" id="linux-tooltip">This operator drives the application on Linux servers</span>
             </span>
           {% endif %}
 
-          {% if charm.store_front.base == "kubernetes" %}
+          {% if "kubernetes" in charm.store_front["deployable-on"] %}
             <span class="p-tooltip" aria-describedby="k8s-tooltip">
               <img alt="Kubernetes" src="https://assets.ubuntu.com/v1/f1852c07-Kubernetes.svg" width="24" height="24">
               <span class="p-tooltip__message" role="tooltip" id="k8s-tooltip">This operator drives the application on Kubernetes</span>

--- a/templates/store.html
+++ b/templates/store.html
@@ -25,7 +25,7 @@
               <a href="#drawer" class="p-button has-icon u-hide--large js-drawer-toggle" data-js="filter-button-mobile-open"><i class="p-icon--arrow-right"></i><span>Filters</span></a>
               <form class="p-form p-form--inline">
                 <div class="p-form__group u-no-margin--right">
-                  <label for="base" aria-label="Filter platforms" class="p-form__label u-no-margin--bottom u-hide--small">Bases</label>
+                  <label for="base" aria-label="Filter platforms" class="p-form__label u-no-margin--bottom u-hide--small">Platform</label>
                   <select name="base" data-js="base-handler" class="p-form__control u-no-margin--bottom" value="{{ base }}" id="base" disabled>
                     <option value="all" {% if active_filter('base', 'all' ) %}selected{% endif %}>All</option>
                     <option value="linux" {% if active_filter('base', 'linux' ) %}selected{% endif %}>Linux</option>

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -235,13 +235,10 @@ def add_store_front_data(package, details=False):
 
     extra["icons"] = get_icons(package)
 
-    if package["default-release"]["channel"]["base"]:
-        extra["base"] = PLATFORMS.get(
-            package["default-release"]["channel"]["base"]["name"],
-            package["default-release"]["channel"]["base"]["name"],
-        )
+    if package["result"]["deployable-on"]:
+        extra["deployable-on"] = package["result"]["deployable-on"]
     else:
-        extra["base"] = "all"
+        extra["deployable-on"] = ["linux"]
 
     extra["categories"] = package["result"]["categories"]
     if "title" in package["result"] and package["result"]["title"]:

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -34,7 +34,7 @@ SEARCH_FIELDS = [
     "result.publisher.display-name",
     "default-release.revision.revision",
     "default-release.channel",
-    "default-release.channel.base",
+    "result.deployable-on",
 ]
 
 CATEGORIES = [
@@ -107,6 +107,7 @@ FIELDS = [
     "result.publisher.display-name",
     "result.title",
     "channel-map",
+    "result.deployable-on",
 ]
 
 


### PR DESCRIPTION
## Done
- Use new API field `result.deployable-on`

## How to QA
- Check https://charmhub-io-960.demos.haus/mattermost-charmers-mattermost the Kubernetes icon should appear
- Check https://charmhub-io-960.demos.haus/postgresql the Ubuntu icon should appear
- Check filters are working in the main view.

## Issue / Card
Fixes #954 
