### PR TITLE
Fix car width when only 1,2 or 3 on the page

### DIFF
--- a/static/js/src/base/navigation.js
+++ b/static/js/src/base/navigation.js
@@ -100,6 +100,20 @@ document.addEventListener("click", function (event) {
   }
 });
 
+const enableResetSearchClick = (selector) => {
+  const resetIconList = document.querySelectorAll(selector);
+
+  if (resetIconList) {
+    resetIconList.forEach((resetIcon) => {
+      resetIcon.addEventListener("click", () => {
+        window.location.href = "/";
+      });
+    });
+  } else {
+    console.error(`${selector} is not a valida element!`);
+  }
+};
+
 // Enable sticky navigation
 function enableStickyNav() {
   document.addEventListener("DOMContentLoaded", function () {
@@ -126,14 +140,15 @@ function enableStickyNav() {
       observer.observe(observerEl);
     } else {
       if (selector) {
-        throw new Error(selector + " is not a valid element!");
-      } else {
-        throw new Error("#navigation is not a valid element!");
+        console.error(
+          `${selector ? selector : "#navigation"} is not a valid element!`
+        );
       }
     }
   });
 }
 
 enableStickyNav();
+enableResetSearchClick("[data-js='reset-search']");
 
 export { toggleSubnav };

--- a/static/sass/_pattern_p-navigation.scss
+++ b/static/sass/_pattern_p-navigation.scss
@@ -28,9 +28,7 @@
 
     .p-navigation__item {
       .p-navigation__link,
-      .p-navigation__link > a,
-      .p-navigation__toggle--open,
-      .p-navigation__toggle--close {
+      .p-navigation__link > a {
         padding-block-end: 1rem;
         padding-block-start: 1rem;
       }
@@ -85,14 +83,24 @@
     }
 
     .p-search-box {
+      display: none;
       margin: 0 0 0 0.5rem;
       min-width: 16.625rem;
+
+      @media (min-width: $breakpoint-large) {
+        display: flex;
+      }
     }
   }
 
   .p-navigation__banner {
     @media (max-width: $breakpoint-medium - 1px) {
       padding-inline-start: 0;
+    }
+
+    .p-navigation__toggle--open,
+    .p-navigation__toggle--close {
+      margin: auto 0;
     }
 
     .p-navigation__logo {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -367,8 +367,10 @@ h3 {
   }
 }
 
-// XXX Ant 17.11.2020 - This can be removed once this issue is closed
-// https://github.com/canonical-web-and-design/vanilla-framework/issues/3411
-.p-checkbox {
-  position: relative;
+// XXX Ovi 28.04.2021 - This can be removed once this issue is closed
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/3723
+.l-fluid-breakout__item {
+  @media (min-width: $breakpoint-small) {
+    max-width: 30rem;
+  }
 }

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -93,7 +93,7 @@
         <li class="p-navigation__item u-vertically-center">
           <form action="/" class="p-search-box" data-js="search-handler-desktop">
             <input type="search" data-js="search-input-desktop" class="p-search-box__input" name="q" aria-label="Search Charmhub" placeholder="Search Charmhub" required="">
-            <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Clear</i></button>
+            <button type="reset" class="p-search-box__reset"><i class="p-icon--close" data-js="reset-search">Clear</i></button>
             <button type="submit" class="p-search-box__button" alt="Search"><i class="p-icon--search">Search</i></button>
           </form>
         </li>

--- a/templates/store.html
+++ b/templates/store.html
@@ -18,7 +18,7 @@
           <div class="l-fluid-breakout__toolbar-item">
             <form action="/" class="p-search-box u-hide--large" data-js="search-handler-mobile">
               <input type="search" data-js="search-input-mobile" class="p-search-box__input" name="q" aria-label="Search Charmhub" placeholder="Search Charmhub" {% if q %}value="{{ q }}" {% endif %} required />
-              <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Clear</i></button>
+              <button type="reset" class="p-search-box__reset"><i class="p-icon--close" data-js="reset-search">Clear</i></button>
               <button type="submit" class="p-search-box__button" alt="Search"><i class="p-icon--search">Search</i></button>
             </form>
             <div class="p-container--inline">


### PR DESCRIPTION
## Done
- _Fix car width when only 1,2 or 3 on the page._
- _Make `X` click in the search bar to reset the search._

## How to QA
- Go to and see the card is narrower.
- Click on the `X` in the search bar and see that the pages refreshes and shows the featured charms and bundles.

## Issue / Card
Fixes #961 
Fixes #924 

## Screenshots
[if relevant, include a screenshot]
