### PR TITLE
Add redirect from manifesto to juju.is/model-driven-operations-manifesto

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,7 +1,7 @@
 tutorials(?P<page>.*)/?: https://juju.is/tutorials{page}
 mattermost: mattermost-charmers-mattermost
 about: https://juju.is/about
-manifesto: https://juju.is/about
+manifesto: https://juju.is/model-driven-operations-manifesto
 publishing: https://juju.is/docs/sdk
 governance: https://juju.is/about
 glossary: https://juju.is/about

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -89,7 +89,7 @@
           <a class="p-link--soft" href="#"><small>Best Practices for creating charms</small></a>
         </li>
         <li class="p-list__item">
-          <a class="p-link--soft" href="#"><small>Model Driven Operations Manifesto</small></a>
+          <a class="p-link--soft" href="https://juju.is/model-driven-operations-manifesto"><small>Model Driven Operations Manifesto</small></a>
         </li>
         <li class="p-list__item">
           <a class="p-link--soft" href="#"><small>Why Helm and Kustomize Aren’t Enough: the Future</small> of Kubernetes Apps</a>

--- a/templates/store.html
+++ b/templates/store.html
@@ -70,13 +70,16 @@
             </h3>
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item">
-                <a href="/about">What is an operator?</a>
+                <a href="https://juju.is/docs/sdk">What is an operator?</a>
               </li>
               <li class="p-side-navigation__item">
-                <a href="/publishing">How do I publish here?</a>
+                <a href="https://juju.is/docs/sdk">How do I publish here?</a>
               </li>
               <li class="p-side-navigation__item">
-                <a href="/glossary">Glossary</a>
+                <a href="https://juju.is/docs/">Glossary</a>
+              </li>
+              <li class="p-side-navigation__item">
+                <a href="https://juju.is/model-driven-operations-manifesto">Manifesto</a>
               </li>
             </ul>
           </nav>


### PR DESCRIPTION
## Done
- Add redirect from manifesto to juju.is/model-driven-operations-manifesto
- Blocked on https://github.com/canonical-web-and-design/juju.is/pull/212

## How to QA
-  `dotrun`
- http://localhost:8045/manifesto should redirect to juju.is/model-driven-operations-manifesto
