### PR TITLE
Add manifesto in navigation

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -58,6 +58,9 @@
             <li>
               <a href="https://juju.is/tutorials" class="p-subnav__item">Tutorials</a>
             </li>
+            <li>
+              <a href="https://juju.is/model-driven-operations-manifesto" class="p-subnav__item">Model driven operations manifesto</a>
+            </li>
           </ul>
         </li>
         <li class="p-navigation__item p-subnav" id="contribute-link">


### PR DESCRIPTION
## Done

![image](https://user-images.githubusercontent.com/2707508/116537357-0715b000-a8de-11eb-8e57-1d90f6b5dd8d.png)

Add manifesto in navigation.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
-  Make sure navigation is updated
- When click should redirect to https://juju.is/model-driven-operations-manifesto
