### PR TITLE
Support multiple lines for default values in the configuration screen

### DIFF
--- a/templates/details/configure.html
+++ b/templates/details/configure.html
@@ -24,7 +24,7 @@
       <li class="p-list__item" id="{{ key }}">
         <p class="p-heading--4">{{ key }} <span class="u-text--muted">&VerticalLine; {{ value.type }}</span></p>
         {% if value.default %}
-        <p style="overflow-wrap: break-word;"><span class="u-text--muted">Default:</span> {{ value.default }}</p>
+        <p style="overflow-wrap: break-word; white-space: pre-wrap;"><span class="u-text--muted">Default:</span> {{ value.default }}</p>
         {% endif %}
         <p style="overflow-wrap: break-word; white-space: pre-wrap;">{{ value.description | escape }}</p>
       </li>


### PR DESCRIPTION
## Done
- Add white-space property for default in the configuration screen

## How to QA
- Check the default value in https://charmhub-io-968.demos.haus/postgresql/configure#extra_pg_conf is multiple lines

## Issue / Card
Fixes #856
