### PR TITLE
Add notification to charm pages

### DIFF
--- a/static/sass/charmhub_utils.scss
+++ b/static/sass/charmhub_utils.scss
@@ -19,7 +19,7 @@
 
   .col-3.has-space--right {
     @media screen and (min-width: $breakpoint-large) {
-      margin-inline-end: 4rem;
+      margin-inline-end: 1rem;
     }
   }
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -374,3 +374,11 @@ h3 {
     max-width: 30rem;
   }
 }
+
+.juju-notification {
+  margin: 0.5rem 0;
+
+  @media (min-width: $breakpoint-medium) {
+    margin: 1rem 0 0;
+  }
+}

--- a/templates/details/overview.html
+++ b/templates/details/overview.html
@@ -73,7 +73,14 @@
       <p>Share your thoughts on this charm with the community on discourse.</p>
       <p><a class="p-button--neutral" href="https://discourse.charmhub.io/">Join the discussion</a></p>
     </div>
-    <div class="col-9 col-large-6">
+    <div class="col-9">
+      {% if show_notification %}
+        <div class="p-notification--caution">
+          <p class="p-notification__response" style=" background-image: none; padding-left: 1rem;">
+            While many Reactive Framework charms work on machines today, it&rsquo;s recommended to create new charms with the Operator Framework. <a href="https://discourse.charmhub.io/t/a-brief-history-of-juju-and-charm-development/4474">Learn more about the history of charms</a>.
+          </p>
+        </div>
+      {% endif %}
       {{ readme | safe }}
     </div>
   </div>

--- a/templates/partial/_channel-map.html
+++ b/templates/partial/_channel-map.html
@@ -32,6 +32,10 @@
     </div>
   </div>
 </div>
+<div class="juju-notification">
+  <i class="p-icon--warning" style="margin-right: 0.25rem;"></i>
+  You will need Juju 2.9 to be able to run this command. <a href="https://juju.is/docs/olm/upgrading">Learn how to upgrade to Juju 2.9</a>.
+</div>
 <div class="p-channel-map u-hide">
   <div class="p-channel-map__mask">
   </div>

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -159,7 +159,7 @@ def details_overview(entity_name):
 
     excluded_packages = [
         "mattermost-charmers-mattermost",
-        "prometheus",
+        "charmcraft-prometheus",
         "hello-kubecon",
         "nginx-ingress-integrator",
     ]

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -155,6 +155,18 @@ def details_overview(entity_name):
     # Remove Markdown comments
     readme = re.sub("(<!--.*-->)", "", readme, flags=re.DOTALL)
 
+    show_notification = True
+
+    excluded_packages = [
+        "mattermost-charmers-mattermost",
+        "prometheus",
+        "hello-kubecon",
+        "nginx-ingress-integrator",
+    ]
+
+    if entity_name in excluded_packages:
+        show_notification = False
+
     readme = md_parser(readme)
     readme = decrease_headers(readme)
     return render_template(
@@ -163,6 +175,7 @@ def details_overview(entity_name):
         readme=readme,
         package_type=package["type"],
         channel_requested=channel_request,
+        show_notification=show_notification,
     )
 
 


### PR DESCRIPTION
## Done
- Added notifications to charm pages
- Added badges to charm cards

## QA
- Go to https://charmhub-io-969.demos.haus
- Go to https://charmhub-io-969.demos.haus/postgresql-k8s
- Check that there is a notification above the overview content
- Check that there is a notification in the grey bar with the logo and heading
- For the following pages check that there is no notification above the overview content:
  - https://charmhub-io-969.demos.haus/mattermost-charmers-mattermost
  - https://charmhub-io-969.demos.haus/prometheus
  - https://charmhub-io-969.demos.haus/hello-kubecon
  - https://charmhub-io-969.demos.haus/nginx-ingress-integrator