### PR TITLE
Remove links from store page

### DIFF
--- a/templates/store.html
+++ b/templates/store.html
@@ -64,24 +64,6 @@
               </ul>
               {% endif %}
             </form>
-            <hr />
-            <h3 class="p-muted-heading">
-              Useful links
-            </h3>
-            <ul class="p-side-navigation__list">
-              <li class="p-side-navigation__item">
-                <a href="https://juju.is/docs/sdk">What is an operator?</a>
-              </li>
-              <li class="p-side-navigation__item">
-                <a href="https://juju.is/docs/sdk">How do I publish here?</a>
-              </li>
-              <li class="p-side-navigation__item">
-                <a href="https://juju.is/docs/">Glossary</a>
-              </li>
-              <li class="p-side-navigation__item">
-                <a href="https://juju.is/model-driven-operations-manifesto">Manifesto</a>
-              </li>
-            </ul>
           </nav>
         </div>
       </div>


### PR DESCRIPTION
## Done
- Remove old links from store page

## How to QA
- `dotrun`
- Homepage shouldn't have anymore the useful links
