### PR TITLE
Update linux template to vm

### DIFF
--- a/static/js/src/public/store/buildPackageCard.js
+++ b/static/js/src/public/store/buildPackageCard.js
@@ -118,7 +118,7 @@ function buildPackageCard(entity) {
     buildPlatformIcons(
       entityCardIcons,
       "Linux",
-      "https://assets.ubuntu.com/v1/dc11bd39-Linux.svg",
+      "https://assets.ubuntu.com/v1/a911ecf6-vm-badge.svg",
       "This operator drives the application on Linux servers"
     );
   }
@@ -127,7 +127,7 @@ function buildPackageCard(entity) {
     buildPlatformIcons(
       entityCardIcons,
       "Linux",
-      "https://assets.ubuntu.com/v1/dc11bd39-Linux.svg",
+      "https://assets.ubuntu.com/v1/a911ecf6-vm-badge.svg",
       "This operator drives the application on Linux servers"
     );
     buildPlatformIcons(

--- a/templates/partial/_featured-charms.html
+++ b/templates/partial/_featured-charms.html
@@ -20,7 +20,7 @@
         <div class="package-card-icons">
           {% if "linux" in charm.store_front["deployable-on"] %}
             <span class="p-tooltip" aria-describedby="linux-tooltip">
-              <img alt="Linux" src="https://assets.ubuntu.com/v1/dc11bd39-Linux.svg" width="24" height="24">
+              <img alt="Linux" src="https://assets.ubuntu.com/v1/a911ecf6-vm-badge.svg" width="24" height="24">
               <span class="p-tooltip__message" role="tooltip" id="linux-tooltip">This operator drives the application on Linux servers</span>
             </span>
           {% endif %}


### PR DESCRIPTION
## Done
- We are now using the VM icon instead of the linux one

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
- You should see VM instead of the linux one

