### PR TITLE
Add framework labels to homepage cards

### DIFF
--- a/static/js/src/public/store/buildPackageCard.js
+++ b/static/js/src/public/store/buildPackageCard.js
@@ -89,6 +89,41 @@ function buildPackageCard(entity) {
     );
   }
 
+  const charmFrameworkTypeIcon = clone.querySelector(
+    "[data-js-charm-framework-type-icon]"
+  );
+
+  const charmFrameworkTypeText = clone.querySelector(
+    "[data-js-charm-framework-type-text]"
+  );
+
+  const charmFrameworkTypeTooltipWrapper = clone.querySelector(
+    "[data-js-tooltip-wrapper]"
+  );
+
+  const excludedPackages = [
+    "mattermost-charmers-mattermost",
+    "charmhub-prometheus",
+    "hello-kubecon",
+    "nginx-ingress-integrator",
+  ];
+
+  const tooltip = document.createElement("span");
+  tooltip.classList.add("p-tooltip__message");
+  tooltip.innerText = `While many Reactive Framework charms work
+on machines today, it is recommended to
+create new charms with the Operator Framework.`;
+
+  if (excludedPackages.includes(entity.name)) {
+    charmFrameworkTypeIcon.classList.add("p-icon--success");
+    charmFrameworkTypeText.innerText = "Operator framework";
+  } else {
+    charmFrameworkTypeIcon.classList.add("p-icon--information");
+    charmFrameworkTypeText.innerText = "Reactive";
+    charmFrameworkTypeTooltipWrapper.classList.add("p-tooltip--btm-center");
+    charmFrameworkTypeTooltipWrapper.appendChild(tooltip);
+  }
+
   const entityCardSummary = clone.querySelector(".package-card-summary");
 
   if (entity.result.summary) {
@@ -96,7 +131,7 @@ function buildPackageCard(entity) {
   }
 
   const entityCardIcons = clone.querySelector(".package-card-icons");
-  if (entity.store_front['deployable-on'].includes("kubernetes")) {
+  if (entity.store_front["deployable-on"].includes("kubernetes")) {
     buildPlatformIcons(
       entityCardIcons,
       "Kubernetes",
@@ -105,7 +140,7 @@ function buildPackageCard(entity) {
     );
   }
 
-  if (entity.store_front['deployable-on'].includes("windows")) {
+  if (entity.store_front["deployable-on"].includes("windows")) {
     buildPlatformIcons(
       entityCardIcons,
       "Windows",
@@ -114,7 +149,7 @@ function buildPackageCard(entity) {
     );
   }
 
-  if (entity.store_front['deployable-on'].includes("linux")) {
+  if (entity.store_front["deployable-on"].includes("linux")) {
     buildPlatformIcons(
       entityCardIcons,
       "Linux",
@@ -123,7 +158,7 @@ function buildPackageCard(entity) {
     );
   }
 
-  if (entity.store_front['deployable-on'].includes("all")) {
+  if (entity.store_front["deployable-on"].includes("all")) {
     buildPlatformIcons(
       entityCardIcons,
       "Linux",

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -54,9 +54,9 @@
     background-color: $color-x-light;
     color: $color-dark;
     display: grid;
-    grid-template-rows: 9.5rem auto 2.25rem;
+    grid-template-rows: 9.5rem auto auto 2.25rem;
     // Force obey parent's border-radius
-    height: 16.75rem;
+    height: 17.75rem;
     margin-bottom: $spv-outer--scaleable;
     width: 100%;
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -382,3 +382,19 @@ h3 {
     margin: 1rem 0 0;
   }
 }
+
+.charm-framework-type {
+  border-top: 1px solid $color-mid-x-light;
+  margin-top: 1rem;
+  padding: 0.25rem 1rem 0.3rem;
+
+  @media (min-width: $breakpoint-large) {
+    padding-top: 0.1rem;
+  }
+
+  i {
+    margin-right: 4px;
+    position: relative;
+    top: 1px;
+  }
+}

--- a/templates/partial/_featured-charms.html
+++ b/templates/partial/_featured-charms.html
@@ -16,6 +16,23 @@
         <p><small class="package-card-summary">{{ charm.result.summary|truncate(85) }}</small></p>
       </div>
 
+      <div class="charm-framework-type">
+        <small>
+          {% if charm["name"] == "mattermost-charmers-mattermost" or charm["name"] == "prometheus" or charm["name"] == "hello-kubecon" or charm["name"] == "nginx-ingress-integrator" %}
+            <i class="p-icon--success"></i>
+            Operator framework
+          {% else %}
+            <span class="p-tooltip--btm-center">
+              <i class="p-icon--information"></i>
+              <span class="p-tooltip__message">While many Reactive Framework charms work
+on machines today, it is recommended to
+create new charms with the Operator Framework.</span>
+            </span>
+            Reactive
+          {% endif %}
+        </small>
+      </div>
+
       <div class="p-card__footer">
         <div class="package-card-icons">
           {% if "linux" in charm.store_front["deployable-on"] %}

--- a/templates/store.html
+++ b/templates/store.html
@@ -126,6 +126,14 @@
         <div class="p-card__content">
           <p><small class="package-card-summary"></small></p>
         </div>
+        <div class="charm-framework-type">
+          <small>
+            <span data-js-tooltip-wrapper>
+              <i data-js-charm-framework-type-icon></i>
+            </span>
+            <span data-js-charm-framework-type-text></span>
+          </small>
+        </div>
         <div class="p-card__footer">
           <div class="package-card-icons"></div>
         </div>


### PR DESCRIPTION
## Done
Added framework type labels to homepage cards

## QA
- Go to https://charmhub-io-972.demos.haus/
- Check that the homepage cards have labels for either "Operator framework" or "Reactive"
- Check that reactive has a tooltip