### PR TITLE
Update juju 2.9 notification link

### DIFF
--- a/templates/partial/_channel-map.html
+++ b/templates/partial/_channel-map.html
@@ -34,7 +34,7 @@
 </div>
 <div class="juju-notification">
   <i class="p-icon--warning" style="margin-right: 0.25rem;"></i>
-  You will need Juju 2.9 to be able to run this command. <a href="https://juju.is/docs/olm/upgrading">Learn how to upgrade to Juju 2.9</a>.
+  You will need Juju 2.9 to be able to run this command. <a href="https://discourse.charmhub.io/t/juju-2-9-0-release-notes/4525">Learn how to upgrade to Juju 2.9</a>.
 </div>
 <div class="p-channel-map u-hide">
   <div class="p-channel-map__mask">


### PR DESCRIPTION
## Done
- _Update juju 2.9 notification link._

## How to QA
- Go to  https://charmhub.io/charmcraft-alertmanager and click on the "Learn how to upgrade to Juju 2.9" and see it takes you to https://discourse.charmhub.io/t/juju-2-9-0-release-notes/4525

## Issue / Card
Fixes #

## Screenshots
[if relevant, include a screenshot]
