### PR TITLE
Use a grey cross icon for non-existing features

### DIFF
--- a/static/js/src/public/store/buildPackageCard.js
+++ b/static/js/src/public/store/buildPackageCard.js
@@ -119,7 +119,7 @@ create new charms with the Operator Framework.`;
       if (badge[icon.dataset.jsFunction] === true) {
         icon.classList.add("p-icon--success");
       } else {
-        icon.classList.add("p-icon--error");
+        icon.classList.add("p-icon--cross-grey");
       }
     });
   } else {

--- a/static/sass/_pattern_p-icon.scss
+++ b/static/sass/_pattern_p-icon.scss
@@ -4,6 +4,10 @@
   @include charmhub-p-icon-forum;
 }
 
+@mixin vf-icon-error($color: $color-negative) {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Ccircle stroke='#{vf-url-friendly-color($color)}' stroke-width='1.5' fill='#{vf-url-friendly-color($color)}' cx='8' cy='8' r='6.25'/%3E%3Cpath fill='%23FFF' fill-rule='nonzero' d='M10.282 4.638l1.06 1.06L9.05 7.99l2.293 2.292-1.06 1.06L7.99 9.05 5.7 11.343l-1.06-1.06 2.29-2.293L4.64 5.7l1.06-1.06 2.291 2.29z'/%3E%3C/g%3E%3C/svg%3E");
+}
+
 @mixin p-charmhub-icon {
   .p-icon--arrow-up {
     @extend %icon;
@@ -103,6 +107,12 @@
     @extend %icon;
 
     background-image: url("https://assets.ubuntu.com/v1/434fb519-Docstrings.svg");
+  }
+
+  .p-icon--cross-grey {
+    @extend %icon;
+
+    @include vf-icon-error($color-mid-dark);
   }
 }
 

--- a/templates/partial/_featured-charms.html
+++ b/templates/partial/_featured-charms.html
@@ -59,7 +59,7 @@ create new charms with the Operator Framework.</span>
                   {% if ops_badges[charm["name"]]["detailed-documentation"] == True %}
                     <i class="p-icon--success"></i>
                   {% else %}
-                    <i class="p-icon--error"></i>
+                    <i class="p-icon--cross-grey"></i>
                   {% endif %}
                   Detailed documentation
                 </li>
@@ -67,7 +67,7 @@ create new charms with the Operator Framework.</span>
                   {% if ops_badges[charm["name"]]["guaranteed-getting-started"] == True %}
                     <i class="p-icon--success"></i>
                   {% else %}
-                    <i class="p-icon--error"></i>
+                    <i class="p-icon--cross-grey"></i>
                   {% endif %}
                   Guaranteed getting started
                 </li>
@@ -75,7 +75,7 @@ create new charms with the Operator Framework.</span>
                   {% if ops_badges[charm["name"]]["secrets-management"] == True %}
                     <i class="p-icon--success"></i>
                   {% else %}
-                    <i class="p-icon--error"></i>
+                    <i class="p-icon--cross-grey"></i>
                   {% endif %}
                   Secrets management
                 </li>
@@ -83,7 +83,7 @@ create new charms with the Operator Framework.</span>
                   {% if ops_badges[charm["name"]]["implements-sidecar-pattern"] == True %}
                     <i class="p-icon--success"></i>
                   {% else %}
-                    <i class="p-icon--error"></i>
+                    <i class="p-icon--cross-grey"></i>
                   {% endif %}
                   Implements sidecar pattern
                 </li>
@@ -91,7 +91,7 @@ create new charms with the Operator Framework.</span>
                   {% if ops_badges[charm["name"]]["seamless-upgrades"] == True %}
                     <i class="p-icon--success"></i>
                   {% else %}
-                    <i class="p-icon--error"></i>
+                    <i class="p-icon--cross-grey"></i>
                   {% endif %}
                   Seamless upgrades
                 </li>
@@ -99,7 +99,7 @@ create new charms with the Operator Framework.</span>
                   {% if ops_badges[charm["name"]]["unit-testing"] == True %}
                     <i class="p-icon--success"></i>
                   {% else %}
-                    <i class="p-icon--error"></i>
+                    <i class="p-icon--cross-grey"></i>
                   {% endif %}
                   Unit testing
                 </li>
@@ -107,7 +107,7 @@ create new charms with the Operator Framework.</span>
                   {% if ops_badges[charm["name"]]["high-availability"] == True %}
                     <i class="p-icon--success"></i>
                   {% else %}
-                    <i class="p-icon--error"></i>
+                    <i class="p-icon--cross-grey"></i>
                   {% endif %}
                   High availability
                 </li>


### PR DESCRIPTION
# Done

Use a grey cross icon for non-existing features

Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/981