### PR TITLE
Capture click for tooltip button on charm cards

### DIFF
--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -65,6 +65,8 @@ class initPackages {
         }
       })
       .catch((e) => console.error(e));
+
+    this.captureTooltipButtonClick();
   }
 
   addBundleApps() {
@@ -484,6 +486,8 @@ class initPackages {
           buildPackageCard(entity, this.opsBadges)
         );
       });
+
+      this.captureTooltipButtonClick();
     } else {
       throw new Error(
         `There is no element containing ${this.domEl.packageContainer.selector} selector.`
@@ -553,6 +557,19 @@ class initPackages {
         `There is no element containing ${this.domEl.filterButtonMobileOpen.selector} selector.`
       );
     }
+  }
+
+  captureTooltipButtonClick() {
+    const charmCardButtons = document.querySelectorAll(
+      "[data-js-functionality-button]"
+    );
+
+    charmCardButtons.forEach((btn) => {
+      btn.addEventListener("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      });
+    });
   }
 }
 

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -133,6 +133,14 @@
       }
     }
 
+    .charm-card-button .p-tooltip__message--list {
+      display: none !important;
+    }
+
+    .charm-card-button:hover .p-tooltip__message--list {
+      display: inline !important;
+    }
+
     &.is-topic-card {
       grid-template-rows: 9rem auto;
 

--- a/templates/partial/_featured-charms.html
+++ b/templates/partial/_featured-charms.html
@@ -51,7 +51,7 @@ create new charms with the Operator Framework.</span>
         </div>
 
         {% if ops_badges[charm["name"]] %}
-          <button type="button" class="p-button--neutral is-small is-inline p-tooltip--btm-center" style=" margin-left: 10px; position: relative; top: 7px;">
+          <button type="button" class="p-button--neutral is-small is-inline p-tooltip--btm-center charm-card-button" style=" margin-left: 10px; position: relative; top: 7px;" data-js-functionality-button>
             Functionality
             <span class="p-tooltip__message--list">
               <ul class="p-list u-no-margin--bottom u-no-margin--left">

--- a/templates/store.html
+++ b/templates/store.html
@@ -136,7 +136,7 @@
         </div>
         <div class="p-card__footer" data-js-card-footer>
           <div class="package-card-icons"></div>
-          <button type="button" class="p-button--neutral is-small is-inline p-tooltip--btm-center" style=" margin-left: 10px; position: relative; top: 7px;" data-js-functionality-button>
+          <button type="button" class="p-button--neutral is-small is-inline p-tooltip--btm-center charm-card-button" style=" margin-left: 10px; position: relative; top: 7px;" data-js-functionality-button>
             Functionality
             <span class="p-tooltip__message--list">
               <ul class="p-list u-no-margin--bottom u-no-margin--left">


### PR DESCRIPTION
## Done
Captured click on the functionality buttons in charm cards so that they work on touch screens

## QA
- Go to https://charmhub-io-989.demos.haus/ (ideally on a touch device)
- Tap the functionality button in a card and check that the tooltip is visible
- Go to https://charmhub-io-989.demos.haus/?q=graylog
- Tap the functionality button in a card and check that the tooltip is visible

## Issue
Fixes #987 