### PR TITLE
Remove is-wide class and tidy up the layout on all pages

### DIFF
--- a/static/sass/_pattern_grid.scss
+++ b/static/sass/_pattern_grid.scss
@@ -23,12 +23,6 @@
     }
   }
 
-  .col-large-6 {
-    @media (min-width: 1300px) {
-      grid-column-end: span 6;
-    }
-  }
-
   .row.has-small-gap {
     grid-gap: 1rem;
     margin-bottom: 1.2rem;

--- a/static/sass/charmhub_utils.scss
+++ b/static/sass/charmhub_utils.scss
@@ -17,20 +17,10 @@
     display: flex;
   }
 
-  .col-3.has-space--right {
-    @media screen and (min-width: $breakpoint-large) {
-      margin-inline-end: 1rem;
-    }
-  }
-
   .is-input--narrow {
     @media screen and (min-width: $breakpoint-medium) {
       max-width: 18.25rem;
     }
-  }
-
-  .is-wide {
-    max-width: $grid-max-width !important;
   }
 
   .u-position-sticky--bottom {

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -1,5 +1,5 @@
 <div class="p-strip--light is-shallow">
-  <div class="row is-wide">
+  <div class="row">
     <div class="col-8">
       <div class="p-charm-header">
         <div class="p-media-object--medium u-no-margin--bottom">

--- a/templates/details/_details-tab-navigation.html
+++ b/templates/details/_details-tab-navigation.html
@@ -1,4 +1,4 @@
-<div class="u-fixed-width is-wide">
+<div class="u-fixed-width">
   <nav class="p-tabs" data-js="tabs" aria-label="Details pages navigation">
     <ul class="p-tabs__list" role="tablist">
       <li class="p-tabs__item" role="presentation">

--- a/templates/details/actions.html
+++ b/templates/details/actions.html
@@ -5,8 +5,8 @@
 {% block details_content %}
 <div class="p-details-tab__content">
   {% if package.store_front.actions %}
-    <div class="row is-wide">
-      <div class="col-3 has-space--right">
+    <div class="row">
+      <div class="col-3">
         <div class="p-side-navigation">
           <ul class="p-side-navigation__list">
             {% for action in package.store_front.actions %}
@@ -19,7 +19,7 @@
           </ul>
         </div>
       </div>
-      <div class="col-9 col-large-6">
+      <div class="col-9">
         <ul class="p-list--divided has-separator-centered">
           {% for action, action_data in package.store_front.actions.items() %}
             <li class="p-list__item" style="margin-bottom: 1rem;" id="{{ action }}">
@@ -50,7 +50,7 @@
                   <dl>
                     <p style="margin-left: 1rem;">
                       {% for item in action_data.required %}
-                      {{ item }}{% if not loop.last %},{% endif %}
+                        {{ item }}{% if not loop.last %},{% endif %}
                       {% endfor %}
                     </p>
                   </dl>
@@ -64,7 +64,7 @@
     </div>
   {% else %}
     <div class="p-strip u-no-padding--top">
-      <div class="u-fixed-width u-equal-height is-wide">
+      <div class="u-fixed-width u-equal-height">
         <div class="charm-empty-docs-icon u-vertically-center">
           <img src="https://assets.ubuntu.com/v1/3234f995-Generic_chamhub_NoDocs.svg" alt="" width="121" height="121">
         </div>

--- a/templates/details/configure.html
+++ b/templates/details/configure.html
@@ -3,9 +3,9 @@
 {% extends '/details/details_layout.html' %}
 
 {% block details_content %}
-<div class="row is-wide p-details-tab__content">
+<div class="row p-details-tab__content">
   {% if package.store_front.config.options %}
-  <div class="col-3 has-space--right">
+  <div class="col-3">
     <div class="p-side-navigation" data-js="{{ section_slug }}">
       <ul class="p-side-navigation__list">
         {% for config in package.store_front.config.options.keys() %}
@@ -18,7 +18,7 @@
       </ul>
     </div>
   </div>
-  <div class="col-9 col-large-6">
+  <div class="col-9">
     <ul class="p-list--divided has-separator-centered">
       {% for key, value in package.store_front.config.options.items() %}
       <li class="p-list__item" id="{{ key }}">

--- a/templates/details/docs.html
+++ b/templates/details/docs.html
@@ -24,10 +24,10 @@
   </ul>
 {% endmacro %}
 
-  <div class="u-fixed-width is-wide p-details-tab__content">
+  <div class="u-fixed-width p-details-tab__content">
     {% if navigation and body_html %}
-      <div class="row is-wide u-no-padding--left u-no-padding--right">
-        <aside class="col-3 has-space--right">
+      <div class="row u-no-padding--left u-no-padding--right">
+        <aside class="col-3">
           {% if versions | length > 1 %}
           <label for="version-select" class="u-hide">Version</label>
           <select name="version-select" id="version-select" onChange="window.location.href=this.value">
@@ -58,7 +58,7 @@
             </div>
           </nav>
         </aside>
-        <div class="col-9 col-large-6">
+        <div class="col-9">
           {{ body_html | safe }}
           <div class="u-fixed-width">
             <hr class="p-separator--medium">

--- a/templates/details/empty-docs.html
+++ b/templates/details/empty-docs.html
@@ -4,7 +4,7 @@
 
 {% block details_content %}
   <div class="p-strip u-no-padding--top">
-    <div class="u-fixed-width u-equal-height is-wide">
+    <div class="u-fixed-width u-equal-height">
       <div class="charm-empty-docs-icon u-vertically-center">
         <img src="https://assets.ubuntu.com/v1/3234f995-Generic_chamhub_NoDocs.svg" alt="" width="121" height="121">
       </div>

--- a/templates/details/history.html
+++ b/templates/details/history.html
@@ -3,7 +3,7 @@
 {% extends '/details/details_layout.html' %}
 
 {% block details_content %}
-  <div class="u-fixed-width is-wide p-details-tab__content">
+  <div class="u-fixed-width p-details-tab__content">
     <p>Displaying release history for the <strong>‘latest/stable’</strong> channel:</p>
     <table class="p-table--mobile-card" role="grid" data-js="history-table">
       <thead>

--- a/templates/details/integrate.html
+++ b/templates/details/integrate.html
@@ -3,10 +3,10 @@
 {% extends '/details/details_layout.html' %}
 
 {% block details_content %}
-  <div class="u-fixed-width is-wide">
+  <div class="u-fixed-width">
     <p>Charms that integrate with {{ package.name }}:</p>
   </div>
-  <div class="row is-wide">
+  <div class="row">
     <div class="col-4 col-x-large-3">
       <div class="p-media-object has-separator">
         <img src="https://api.jujucharms.com/charmstore/v5/apache2/icon.svg" alt="" class="p-media-object__image is-round">

--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -4,8 +4,8 @@
 
 {% block details_content %}
 
-  <div class="row is-wide p-details-tab__content">
-    <div class="col-3 has-space--right">
+  <div class="row p-details-tab__content">
+    <div class="col-3">
       <div class="p-side-navigation" id="drawer" style="overflow-y: visible; position: relative;">
         <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation
@@ -62,7 +62,7 @@ than the latest.</span>
       </div>
     </div>
 
-    <div class="col-8">
+    <div class="col-9">
       {% if not is_introduction %}
       <div class="u-fixed-width">
         <h2>{{ library_name }}</h2>

--- a/templates/details/overview.html
+++ b/templates/details/overview.html
@@ -3,8 +3,8 @@
 {% extends '/details/details_layout.html' %}
 
 {% block details_content %}
-  <div class="row is-wide p-details-tab__content">
-    <div class="col-3 has-space--right">
+  <div class="row p-details-tab__content">
+    <div class="col-3">
       {% if package.result.summary %}
         <h4 class="p-heading--5 u-no-margin--bottom">About</h4>
         <p data-js="summary" data-summary="{{ package.result.summary }}">

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -27,7 +27,7 @@
       <h2 class="p-heading--4">
         Listing details
       </h2>
-    <div class="row p-form__group p-form-validation">
+    <div class="row p-form__group p-form-validation u-no-padding--left u-no-padding--right">
       <div class="col-2">
         <p class="is-label">{{ package.type|capitalize }} icon:</p>
       </div>
@@ -61,7 +61,7 @@
         </div>
       </div>
     </div>
-    <div class="row p-form__group p-form-validation">
+    <div class="row p-form__group p-form-validation u-no-padding--left u-no-padding--right">
       <div class="col-2">
         <label for="title" class="p-form__label">Title:</label>
       </div>
@@ -71,7 +71,7 @@
         </div>
       </div>
     </div>
-    <div class="row p-form__group p-form-validation">
+    <div class="row p-form__group p-form-validation u-no-padding--left u-no-padding--right">
       <div class="col-2">
         <label class="p-form__label" for="summary">Summary: </label>
       </div>
@@ -90,7 +90,7 @@
     </div>
 
     {% if package.type == "bundle" %}
-      <div class="row p-form__group p-form__group--top">
+      <div class="row p-form__group p-form__group--top u-no-padding--left u-no-padding--right">
         <div class="col-2">
           <label for="bundle-topology" class="p-form__label">Bundle topology:</label>
         </div>
@@ -118,7 +118,7 @@
       <h2 class="p-heading--4">Additional information</h2>
     </div>
 
-    <div class="row p-form__group p-form-validation">
+    <div class="row p-form__group p-form-validation u-no-padding--left u-no-padding--right">
       <div class="col-2">
         <label for="website" class="p-form__label">Project homepage:</label>
       </div>
@@ -129,7 +129,7 @@
       </div>
     </div>
 
-    <div class="row p-form__group p-form-validation">
+    <div class="row p-form__group p-form-validation u-no-padding--left u-no-padding--right">
       <div class="col-2">
         <label for="contact" class="p-form__input">Contact:</label>
       </div>

--- a/templates/publisher/publicise/embedded_cards.html
+++ b/templates/publisher/publicise/embedded_cards.html
@@ -8,7 +8,7 @@
         Charmhub button style:
       </label>
     </div>
-    <div class="col-5">
+    <div class="col-7">
       <input type="radio" name="charmhub-button" id="charmhub-button-dark" checked="checked" value="black">
       <label for="charmhub-button-dark">Dark</label>
       <input type="radio" name="charmhub-button" id="charmhub-button-light" value="white">
@@ -34,7 +34,7 @@
     <div class="col-2">
       <p>HTML:</p>
     </div>
-    <div class="col-5">
+    <div class="col-7">
       <div class="p-code-snippet">
         <pre class="p-code-snippet__block is-wrapped"><code data-js="snippet-card-html">&lt;iframe src="https://charmhub.io/{{ package.name }}/embedded?button=black&channels=true&summary=true&base=true" frameborder="0" width="100%" height="320px" style="border: 1px solid #CCC; border-radius: 2px;"&gt;&lt;/iframe&gt;</code></pre>
       </div>

--- a/templates/publisher/publicise/github_badges.html
+++ b/templates/publisher/publicise/github_badges.html
@@ -3,7 +3,7 @@
 {% block publicise_content %}
 <h4>Promote your charm using an embeddable GitHub badge</h4>
 <div class="row">
-  <div class="col-5 col-start-large-3">
+  <div class="col-7 col-start-large-3">
     <p>
       <a href="/{{ package.name }}">
         <img alt="" src="/{{ package.name }}/badge.svg" />
@@ -15,7 +15,7 @@
   <div class="col-2">
     <p>HTML:</p>
   </div>
-  <div class="col-5">
+  <div class="col-7">
     <div class="p-code-snippet">
       <pre class="p-code-snippet__block is-wrapped"><code>&lt;a href="https://charmhub.io/{{ package.name }}"&gt;
     &lt;img alt="" src="https://charmhub.io/{{ package.name }}/badge.svg" /&gt;
@@ -27,7 +27,7 @@
   <div class="col-2">
     <p>Markdown:</p>
   </div>
-  <div class="col-5">
+  <div class="col-7">
     <div class="p-code-snippet">
       <pre class="p-code-snippet__block is-wrapped"><code>[![{{ package.title }}](https://charmhub.io/{{ package.name }}/badge.svg)](https://charmhub.io/{{ package.name }})</code></pre>
     </div>

--- a/templates/publisher/publicise/store_buttons.html
+++ b/templates/publisher/publicise/store_buttons.html
@@ -6,7 +6,7 @@
     <div class="col-2">
       <label>Language:</label>
     </div>
-    <div class="col-5">
+    <div class="col-7">
       <form class="p-form--inline">
         <select name="language" data-js="language-select">
 
@@ -80,7 +80,7 @@
     <div id="{{ lang }}-content" class="{% if loop.index > 1 %} u-hide{% endif %}" data-js="language-content">
       <p class="p-heading--4">Dark version</p>
       <div class="row">
-        <div class="col-5 col-start-large-3">
+        <div class="col-7 col-start-large-3">
           <p>
             {% set url="images/badges/"+ lang + "/charmhub-black.svg" %}
             <a href="/{{ package.name }}">
@@ -93,7 +93,7 @@
         <div class="col-2">
           <p>HTML:</p>
         </div>
-        <div class="col-5">
+        <div class="col-7">
           <div class="p-code-snippet">
             <pre class="p-code-snippet__block is-wrapped"><code>&lt;a href="https://charmhub.io/{{ package.name }}"&gt;
   &lt;img alt="" src="https://charmhub.io/static/images/badges/{{ lang }}/charmhub-black.svg" /&gt;
@@ -105,7 +105,7 @@
         <div class="col-2">
           <p>Markdown:</p>
         </div>
-        <div class="col-5">
+        <div class="col-7">
           <div class="p-code-snippet">
             <pre class="p-code-snippet__block is-wrapped"><code>[![{{ data.text }}](https://charmhub.io/{{ package.name }}/badge.svg)](https://charmhub.io/{{ package.name }})</code></pre>
           </div>
@@ -114,7 +114,7 @@
       <hr class="p-separator--shallower">
       <p class="p-heading--4">Light version</p>
       <div class="row">
-        <div class="col-5 col-start-large-3">
+        <div class="col-7 col-start-large-3">
           <p>
             {% set url="images/badges/"+ lang + "/charmhub-white.svg" %}
             <a href="/{{ package.name }}">
@@ -127,7 +127,7 @@
         <div class="col-2">
           <p>HTML:</p>
         </div>
-        <div class="col-5">
+        <div class="col-7">
           <div class="p-code-snippet">
             <pre class="p-code-snippet__block is-wrapped"><code>&lt;a href="https://charmhub.io/{{ package.name }}"&gt;
   &lt;img alt="" src="https://charmhub.io/{{ package.name }}/badge.svg" /&gt;
@@ -139,7 +139,7 @@
         <div class="col-2">
           <p>Markdown:</p>
         </div>
-        <div class="col-5">
+        <div class="col-7">
           <div class="p-code-snippet">
             <pre class="p-code-snippet__block is-wrapped"><code>[![{{ data.text }}](https://charmhub.io/{{ package.name }}/badge.svg)](https://charmhub.io/{{ package.name }})</code></pre>
           </div>

--- a/templates/publisher/register-name-dispute/index.html
+++ b/templates/publisher/register-name-dispute/index.html
@@ -6,14 +6,14 @@
 
 {% block content %}
 <section class="p-strip is-shallow">
-  <div class="u-fixed-width is-wide">
+  <div class="u-fixed-width">
     <a href="/charms">&lsaquo;&nbsp;My charms &amp; bundles</a>
     <h1 class="p-heading--2">
       Claim the name <strong>{{ entity_name }}</strong>
     </h1>
     <p class="u-no-max-width">By completing this form you are requesting for this name to be transferred to you from its owner.</p>
     <form class="p-form p-form--stacked" action="" method="POST">
-      <div class="p-form__group row is-wide u-no-padding">
+      <div class="p-form__group row u-no-padding">
         <div class="col-2">
           <p class="is-label">Charm/bundle name:</p>
         </div>
@@ -24,7 +24,7 @@
           </div>
         </div>
       </div>
-      <div class="p-form__group row is-wide u-no-padding">
+      <div class="p-form__group row u-no-padding">
         <div class="col-2">
           <label for="claim-comment" class="p-form__label">Comment:</label>
         </div>

--- a/templates/publisher/register-name-dispute/thank-you.html
+++ b/templates/publisher/register-name-dispute/thank-you.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <section class="p-strip is-shallow">
-  <div class="u-fixed-width is-wide">
+  <div class="u-fixed-width">
     <a href="/charms">&lsaquo;&nbsp;My charms &amp; bundles</a>
     <h1 class="p-heading--2">
       Thank you for requesting the name <strong>{{ entity_name }}</strong>


### PR DESCRIPTION
## Done
- _Remove classes `is-wide` and `has-space-right` which were used on the wider grid layout_

## How to QA
- Visit the following pages and see they look nice:
    - [ ] https://charmhub-io-991.demos.haus/graylog
    - [ ] https://charmhub-io-991.demos.haus/graylog/docs
    - [ ] https://charmhub-io-991.demos.haus/graylog/libraries
    - [ ] https://charmhub-io-991.demos.haus/graylog/configure
    - [ ] https://charmhub-io-991.demos.haus/graylog/actions
    - [ ] https://charmhub-io-991.demos.haus/charms
    - [ ] https://charmhub-io-991.demos.haus/bundles
    - [ ] https://charmhub-io-991.demos.haus/register-name
    - [ ] https://charmhub-io-991.demos.haus/<charm_name>/listing
    - [ ] https://charmhub-io-991.demos.haus/<charm_name>/publicise
    - [ ] https://charmhub-io-991.demos.haus/<charm_name>/publicise/badges
    - [ ] https://charmhub-io-991.demos.haus/<charm_name>/publicise/cards
    - [ ] https://charmhub-io-991.demos.haus/<charm_name>/settings

## Issue / Card
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/2031
