### PR TITLE
Fix get docs from metadata.yaml

### DIFF
--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -212,20 +212,17 @@ def get_docs_topic_id(metadata_yaml):
     Return discourse topic ID or None
     """
     base_url = discourse_api.base_url
-    # TODO this is a temporary fix (the only charm is mattermost)
-    old_url = "https://discourse.juju.is"
     docs_link = metadata_yaml.get("docs")
 
     if docs_link:
         if docs_link.startswith(base_url):
-            topic_id = docs_link[len(base_url) :].split("/")[3]
-        elif docs_link.startswith(old_url):
-            topic_id = docs_link[len(old_url) :].split("/")[3]
-        else:
-            return None
+            docs_link_parts = docs_link[len(base_url) :].split("/")
 
-        if topic_id.isnumeric():
-            return topic_id
+            if len(docs_link_parts) > 3:
+                topic_id = docs_link_parts[3]
+
+                if topic_id.isnumeric():
+                    return topic_id
 
     return None
 


### PR DESCRIPTION
## Done
- A short URL could cause an index out of range in the previous code
- Removed support for discourse.juju.is in metadata.yaml docs property (mattermost is using discourse.charmhub.io now)

## How to QA
- Visit the demo in your browser
- Check docs for a few charms:
- https://charmhub-io-1013.demos.haus/redis-k8s/docs?channel=edge should show no docs available
- https://charmhub-io-1013.demos.haus/mattermost-k8s/docs should work as usual
- https://charmhub-io-1013.demos.haus/mattermost-charmers-mattermost/docs should work as usual

## Issue / Card
Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/1012
