### PR TITLE
Make side nav sticky

### DIFF
--- a/static/sass/_pattern_p-navigation.scss
+++ b/static/sass/_pattern_p-navigation.scss
@@ -156,6 +156,10 @@
     }
   }
 
+  .p-navigation .p-navigation__item.is-selected > .p-navigation__link::before {
+    display: none;
+  }
+
   .p-navigation__row:nth-child(2) .p-navigation__nav {
     @media (max-width: $breakpoint-medium - 1px) {
       &::after {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -297,6 +297,12 @@ body {
 }
 
 .p-details-tab__content {
+  .p-side-navigation {
+    @media (min-width: $breakpoint-medium) {
+      top: 56px;
+    }
+  }
+
   .p-side-navigation__link.u-truncate {
     display: block;
   }

--- a/templates/details/actions.html
+++ b/templates/details/actions.html
@@ -7,7 +7,7 @@
   {% if package.store_front.actions %}
     <div class="row">
       <div class="col-3">
-        <div class="p-side-navigation">
+        <div class="p-side-navigation is-sticky">
           <ul class="p-side-navigation__list">
             {% for action in package.store_front.actions %}
               <li class="p-side-navigation__item">

--- a/templates/details/configure.html
+++ b/templates/details/configure.html
@@ -6,7 +6,7 @@
 <div class="row p-details-tab__content">
   {% if package.store_front.config.options %}
   <div class="col-3">
-    <div class="p-side-navigation" data-js="{{ section_slug }}">
+    <div class="p-side-navigation is-sticky" data-js="{{ section_slug }}">
       <ul class="p-side-navigation__list">
         {% for config in package.store_front.config.options.keys() %}
         <li class="p-side-navigation__item">


### PR DESCRIPTION
## Done
Made the side navigation sticky on charm details page

## QA
- Go to https://charmhub-io-1019.demos.haus/elasticsearch-k8s/configure
- Scroll the page and check that the side navigation is sticky

## Issue
Fixes #330 