### PR TITLE
Changes for Mattermost charm

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,5 +1,6 @@
 tutorials(?P<page>.*)/?: https://juju.is/tutorials{page}
-mattermost: mattermost-charmers-mattermost
+mattermost: mattermost-k8s
+mattermost-charmers-mattermost: mattermost-k8s
 about: https://juju.is/about
 manifesto: https://juju.is/model-driven-operations-manifesto
 publishing: https://juju.is/docs/sdk

--- a/webapp/store/badges.py
+++ b/webapp/store/badges.py
@@ -152,11 +152,11 @@ OPS_BADGES = {
         "unit-testing": True,
         "high-availability": False,
     },
-    "mattermost-charmers-mattermost": {
+    "mattermost-k8s": {
         "detailed-documentation": True,
         "guaranteed-getting-started": True,
         "secrets-management": True,
-        "implements-sidecar-pattern": False,
+        "implements-sidecar-pattern": True,
         "seamless-upgrades": True,
         "unit-testing": True,
         "high-availability": True,


### PR DESCRIPTION
## Done
- Update Mattermost badges
- Add redirection

## How to QA
- https://charmhub.io/mattermost-charmers-mattermost should redirect to https://charmhub.io/mattermost-k8s

## Issue / Card
Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/1016
