### PR TITLE
Add jenkins-agent-k8s to ops badges

### DIFF
--- a/webapp/store/badges.py
+++ b/webapp/store/badges.py
@@ -197,4 +197,13 @@ OPS_BADGES = {
         "unit-testing": True,
         "high-availability": False,
     },
+    "jenkins-agent-k8s": {
+        "detailed-documentation": True,
+        "guaranteed-getting-started": True,
+        "secrets-management": True,
+        "implements-sidecar-pattern": False,
+        "seamless-upgrades": False,
+        "unit-testing": True,
+        "high-availability": False,
+    },
 }


### PR DESCRIPTION
## Done
Add jenkins-agent-k8s to ops badges

## How to QA
- Visit the demo in your browser, link commented below
- Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
- If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the jenkins-agent-k8s charm as the Operator framework badge.
