### PR TITLE
Fix side navigation

### DIFF
--- a/templates/details/configure.html
+++ b/templates/details/configure.html
@@ -10,7 +10,7 @@
       <ul class="p-side-navigation__list">
         {% for config in package.store_front.config.options.keys() %}
         <li class="p-side-navigation__item">
-          <a href="#{{ config }}" class="p-side-navigation__link u-truncate" role="tab" aria-controls="{{ config }}" {% if loop.index == 1 %}aria-selected="false" {% endif %}>
+          <a href="#{{ config }}" class="p-side-navigation__link u-truncate {% if loop.index == 1 %}is-active{% endif %}" role="tab" aria-controls="{{ config }}" {% if loop.index == 1 %}aria-selected="false" {% endif %}>
             {{ config }}
           </a>
         </li>

--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -6,7 +6,7 @@
 
   <div class="row p-details-tab__content">
     <div class="col-3">
-      <div class="p-side-navigation" id="drawer" style="overflow-y: visible; position: relative;">
+      <div class="p-side-navigation is-sticky" id="drawer" style="overflow-y: visible;">
         <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation
         </a>


### PR DESCRIPTION
## Done
- Fixed the top position of the side navigation on the libraries page
- Fixed the navigation highlighting on the side navigation of the configure page

## QA
- Go to https://charmhub-io-1025.demos.haus/elasticsearch-k8s/libraries
- Check that the side navigation is inline with the start of the content
- Go to https://charmhub-io-1025.demos.haus/elasticsearch-k8s/configure
- Check that the first link in the side navigation is highlighted

## Issue
Fixed #957, #1023