### PR TITLE
Add kube-state-metrics to ops badges

### DIFF
--- a/webapp/store/badges.py
+++ b/webapp/store/badges.py
@@ -296,4 +296,13 @@ OPS_BADGES = {
         "unit-testing": True,
         "high-availability": False,
     },
+    "kube-state-metrics": {
+        "detailed-documentation": False,
+        "guaranteed-getting-started": True,
+        "secrets-management": False,
+        "implements-sidecar-pattern": True,
+        "seamless-upgrades": True,
+        "unit-testing": True,
+        "high-availability": False,
+    },
 }


### PR DESCRIPTION
## Done
Add [kube-state-metrics charm](https://charmhub.io/kube-state-metrics) to ops badges

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Verify that the kube-state-metrics charm renders as Operator Framework and using the sidecar pattern.