### PR TITLE
Preserve channel in docs navigation

### DIFF
--- a/templates/details/docs.html
+++ b/templates/details/docs.html
@@ -9,7 +9,7 @@
     {% for element in nav_items %}
     <li>
       {% if element.navlink_href %}
-        <a href="{{ element.navlink_href }}"
+        <a href="{{ element.navlink_href }}{% if channel_requested %}?channel={{ channel_requested }}{% endif %}"
           {% if request.path == element.navlink_href %}aria-current="page"{% endif %}
         >{{ element.navlink_text }}</a>
       {% else %}


### PR DESCRIPTION
## Done
- Preserve channel in docs navigation

## How to QA
- Go to: https://charmhub-io-1044.demos.haus/mattermost-k8s/docs?channel=edge
- Check all the links on the docs navigation have `?channel=edge` at the end of the URL
- If you switch back to the stable channel the links shouldn't have it

## Issue / Card
Fixes #1005
