### PR TITLE
Fix 500 errors for some charms

### DIFF
--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -141,10 +141,12 @@ def convert_channel_maps(channel_map):
             )
         )
 
-    # Order releases by version
+    # Order releases by revision
     for risk, releases in result[track].items():
         result[track][risk] = sorted(
-            releases, key=lambda k: int(k["version"]), reverse=True
+            releases,
+            key=lambda k: int(k["revision"]["revision"]),
+            reverse=True,
         )
 
     return result


### PR DESCRIPTION
## Done
- Order by revision number instead of version, since the revision is an integer

## How to QA
- https://charmhub-io-1047.demos.haus/slurmdbd should work instead of 500
- Check other charms are showing the right version number, like:
- https://charmhub-io-1047.demos.haus/hello-kubecon
- https://charmhub-io-1047.demos.haus/ceph-mon

## Issue / Card
Fixes #1046
