### PR TITLE
Only display publisher name if not None

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -57,7 +57,9 @@
             <div class="p-media-object__content u-no-margin--bottom">
               <ul class="p-inline-list--middot">
                 <li class="p-inline-list__item">
-                  By {{ package.store_front.publisher_name }}
+                  {% if package.store_front.publisher_name != None %}
+                    By {{ package.store_front.publisher_name }}
+                  {% endif %}
                   {% if developer_validation == "verified" %}
                   <span class="p-tooltip--top-center" aria-describedby="openstack-tooltip">
                     <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg">


### PR DESCRIPTION
## Done
Only display publisher name on details page if not `None`

## QA
- Go to https://charmhub-io-1061.demos.haus/mysql-k8s
- Check that there is no publisher name under the icon and title (compare to live https://charmhub.io/mysql-k8s)

## Issue
Fixes #1060 