### PR TITLE
Fix library fetch command

### DIFF
--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -90,7 +90,7 @@ than the latest.</span>
                     <span class="p-contextual-menu__group">
                       <div class="p-contextual-menu__body">
                         <p class="u-no-padding--top"><i class="p-icon--code"></i> Fetch library</p>
-                        <pre class="u-no-margin--bottom">charmcraft fetch-libs {{ library_name }}</pre>
+                        <pre class="u-no-margin--bottom">charmcraft fetch-lib {{ fetch_string }}</pre>
                       </div>
                     </span>
                     <span class="p-contextual-menu__group">

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -317,6 +317,11 @@ def details_library(entity_name, library_name):
 
     docstrings = logic.process_python_docs(library, module_name=library_name)
 
+    # Charmcraft string to fetch the library
+    fetch_charm = entity_name.replace("-", "_")
+    fetch_api = library["api"]
+    fetch_string = f"charms.{fetch_charm}.v{fetch_api}.{library_name}"
+
     if "source-code" in request.path[1:]:
         template = "details/libraries/source-code.html"
     else:
@@ -331,6 +336,7 @@ def details_library(entity_name, library_name):
         docstrings=docstrings,
         channel_requested=channel_request,
         library_name=library_name,
+        fetch_string=fetch_string,
         creation_date=logic.convert_date(library["created-at"]),
     )
 


### PR DESCRIPTION
## Done
- Fix library fetch command

## How to QA
- Go to https://charmhub-io-1065.demos.haus/nginx-ingress-integrator/libraries/ingress
- Click on download
- The command should be `charmcraft fetch-lib charms.nginx_ingress_integrator.v0.ingress`

## Issue / Card
Fixes #1057
