### PR TITLE
Remove resources from charm details navigation

### DIFF
--- a/templates/details/_details-tab-navigation.html
+++ b/templates/details/_details-tab-navigation.html
@@ -8,11 +8,6 @@
       <li class="p-tabs__item" role="presentation">
         <a href="/{{ package.name }}/docs{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'docs' %}aria-selected="true" {% endif %}>Docs</a>
       </li>
-      {% if package['default-release']['resources'] %}
-      <li class="p-tabs__item" role="presentation">
-        <a href="/{{ package.name }}/resources{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'resources' %}aria-selected="true" {% endif %}>Resources</a>
-      </li>
-      {% endif %}
       <li class="p-tabs__item" role="presentation">
         <a href="/{{ package.name }}/libraries{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'libraries' %}aria-selected="true" {% endif %}>Libraries</a>
       </li>


### PR DESCRIPTION
## Done
Removed resources from navigation

## QA
- Go to http://localhost:8045/mlmd/resources/oci-image
- Check that "resources" isn't in the navigation