### PR TITLE
Increase width of resources digest key

### DIFF
--- a/static/sass/_charmhub_p-detail-inline-list.scss
+++ b/static/sass/_charmhub_p-detail-inline-list.scss
@@ -49,7 +49,7 @@
             display: none;
             left: 0;
             margin-top: 0;
-            max-width: 340px;
+            max-width: 360px;
             padding: 0.5rem 1rem;
             position: absolute;
             top: 100%;


### PR DESCRIPTION
## Done
Increased the width of the resources digest key popup

## QA
- Go to https://charmhub-io-1085.demos.haus/mlmd/resources/oci-image
- Click the digest key under the title
- Check that the width of the popup is OK