### PR TITLE
Update spacing and text for resource table

### DIFF
--- a/templates/details/resources.html
+++ b/templates/details/resources.html
@@ -11,7 +11,7 @@
       <ul class="p-side-navigation__list">
         {% for resource in package['default-release']['resources'] %}
         <li class="p-side-navigation__item">
-          <a href="#" class="p-side-navigation__link is-active">{{ resource.name }}</a>
+          <a href="/{{ package.name }}/resources/{{ resource.name }}" class="p-side-navigation__link is-active">{{ resource.name }}</a>
         </li>
         {% endfor %}
       </ul>
@@ -56,7 +56,7 @@
 
     <h3 class="p-heading--5">Release history</h3>
 
-    <table class="js-revisions-table">
+    <table class="u-no-margin--bottom js-revisions-table">
       <thead>
         <tr>
           <th>Revision</th>
@@ -89,7 +89,7 @@
             {{ revisions_limit }}
           {% endif %}
         </span>
-        of {{ total_revisions }} versions
+        of {{ total_revisions }} revisions
       </small>
 
       {% if total_revisions > revisions_limit %}


### PR DESCRIPTION
## Done
- Remove bottom margin from resources table and updated the count text
- Drive by: Fix the href of side navigation links

## QA
- Go to https://charmhub-io-1089.demos.haus/mlmd/resources/oci-image
- Check that the side nav link has the correct href value
- Check that there is no margin beneath the table and the text says "revisions" and not "versions"