### PR TITLE
Tweak the spacing on the platform icon and added a top boarder to provide some visual separation

### DIFF
--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -107,6 +107,7 @@
     .p-card__footer {
       align-items: center;
       background-color: $color-light;
+      border-top: 1px solid #6666661f;
       color: $color-mid-dark;
       display: flex;
       font-size: 0.875rem;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -336,7 +336,7 @@ h3 {
     display: inline-block;
     margin-right: 0.5rem;
     position: relative;
-    top: 4px;
+    top: 3px;
 
     &:last-child {
       margin-right: 0;


### PR DESCRIPTION

## Done
- Fixed the spacing on the platform icon.
- Added a border to the top of the charm card footer to add some visual separation.

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Screenshots
| Time | Image |
| -- | -- |
| new | <img width="444" alt="Screen Shot 2021-08-08 at 10 35 34 AM" src="https://user-images.githubusercontent.com/532033/128639033-37eb5825-f3c6-486f-8453-174c69c4a42d.png"> |
| old | <img width="443" alt="Screen Shot 2021-08-08 at 10 35 42 AM" src="https://user-images.githubusercontent.com/532033/128639035-26c18917-f794-47b1-b34e-320286fc8572.png"> |
