### PR TITLE
Remove space to make markdown look good

### DIFF
--- a/templates/details/libraries/introduction.html
+++ b/templates/details/libraries/introduction.html
@@ -10,7 +10,7 @@
     <p>
       Inside the charm there is a specific directory, under which there are subdirectories named as:
     </p>
-    <pre> <code>$CHARMDIR/lib/charms/&lt;charm&gt;/v&lt;API&gt;/&lt;libname&gt;.py</code></pre>
+    <pre><code>$CHARMDIR/lib/charms/&lt;charm&gt;/v&lt;API&gt;/&lt;libname&gt;.py</code></pre>
     <p>
       <code>$CHARMDIR</code> is the project&rsquo;s root (contains <code>src/</code>, <code>hooks/</code>, etc), and the <code>&lt;charm&gt;</code> placeholder represents the charm responsible for the library named as <code>&lt;libname&gt;.py</code> with API version <code>&lt;API&gt;</code>. So, as a more concrete example:
     </p>


### PR DESCRIPTION
## Done
- Remove random space that adds extra line on library page

![image](https://user-images.githubusercontent.com/2707508/130636514-02271069-e511-4a89-b903-65d1e6173bdc.png)

 to 

![image](https://user-images.githubusercontent.com/2707508/130636549-352a2105-273f-41a2-b731-da2aa429663b.png)


## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/nginx-ingress-integrator/libraries
- Markdown should look good 
