### PR TITLE
Fix typo in menu

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -75,7 +75,7 @@
               <hr>
             </li>
             <li>
-              <p class="p-subnav__item is-title">Join the comunity</p>
+              <p class="p-subnav__item is-title">Join the community</p>
             </li>
             <li>
               <a href="http://discourse.charmhub.io" class="p-subnav__item">Forum</a>


### PR DESCRIPTION
## Done
Fixed typo in the menu

## QA
- Go to https://charmhub-io-1125.demos.haus/
- Click on the "Contribute" menu
- Check that the "JOIN THE COMMUNITY" heading is spelled correctly

## Issue
Fixes https://github.com/canonical-web-and-design/juju.is/issues/324