### PR TITLE
Add external link icons to menu to match juju.is

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -80,13 +80,13 @@
               <p class="p-subnav__item is-title">Join the community</p>
             </li>
             <li>
-              <a href="http://discourse.charmhub.io" class="p-subnav__item">Forum</a>
+              <a href="http://discourse.charmhub.io" class="p-subnav__item p-link--external">Forum</a>
             </li>
             <li>
-              <a href="https://chat.charmhub.io/charmhub/channels/juju" class="p-subnav__item">Chat</a>
+              <a href="https://chat.charmhub.io/charmhub/channels/juju" class="p-subnav__item p-link--external">Chat</a>
             </li>
             <li>
-              <a href="http://bugs.launchpad.net/juju" class="p-subnav__item">Report a bug</a>
+              <a href="http://bugs.launchpad.net/juju" class="p-subnav__item p-link--external">Report a bug</a>
             </li>
             <li>
               <a href="https://juju.is/careers" class="p-subnav__item">Careers</a>


### PR DESCRIPTION
## Done
Added the external link class to the "JOIN THE COMMUNITY" menu to match juju.is

## QA
- Go to https://charmhub-io-1131.demos.haus/
- Open the "Contribute" navigation
- Check that the external link icons match the same menu on juju.is

## Issue
Fixes #1130 