### PR TITLE
Ensure that the fetch-lib commands can be copied&pasted

### DIFF
--- a/templates/details/libraries/introduction.html
+++ b/templates/details/libraries/introduction.html
@@ -24,15 +24,15 @@
       a library.
     </p>
     <p>
-      The fetch&dash;lib command will download the most recent version of the library specified via the provided import path. If the library already exists on disk, it will be updated.
+      The fetch-lib command will download the most recent version of the library specified via the provided import path. If the library already exists on disk, it will be updated.
     </p>
-    <pre><code>$ charmcraft fetch&dash;lib charms.mysql.v3.foo
+    <pre><code>$ charmcraft fetch-lib charms.mysql.v3.foo
 Library charms.mysql.v3.foo version 3.4 downloaded.
 
-$ charmcraft fetch&dash;lib charms.foobar.v2.plugin
+$ charmcraft fetch-lib charms.foobar.v2.plugin
 Library charms.foobar.v2.plugin updated to version 2.7.
 
-$ charmcraft fetch&dash;lib charms.foobar.v3.metrics
+$ charmcraft fetch-lib charms.foobar.v3.metrics
 Library charms.mysql.v3.metris was already up to date in version 3.2.</code></pre>
     <p>
       If no library name is provided, all libraries already under <code>lib/charms/</code> will be updated to the most recent version available in the store, if possible, indicating what happened in each case:


### PR DESCRIPTION
## Done
- This change used the actual `-` character instead of `&dash` in the page about charm libraries, to ensure that you can copy and paste the commands listed and now having `charmcraft` tell you that the `fetch-lib` command does not exist. See https://chat.canonical.com/canonical/pl/ybxpw4n5gjndd8yy3aytbennky for a very confused PM being very confused.

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card
Fixes a bug Michele could not bring himself to formally open, so have a PR instead :-)

## Screenshots
[if relevant, include a screenshot]
