### PR TITLE
Integrate LMA 2 docs in juju.is navigation

### DIFF
--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -37,7 +37,7 @@
         </li>
 
         <li class="p-list__item">
-          <a class="p-link--soft" href="/?base=all&filter=logging-tracing,monitoring"><small>Observability</small></a>
+          <a class="p-link--soft" href="https://juju.is/docs/lma2"><small>Observability (LMA 2)</small></a>
         </li>
 
         <li class="p-list__item">

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -59,6 +59,9 @@
               <a href="https://juju.is/docs/sdk" class="p-subnav__item">Charmed Operator SDK</a>
             </li>
             <li>
+              <a href="https://juju.is/docs/lma2" class="p-subnav__item">Logs, Metrics and Alerts (LMA) 2</a>
+            </li>
+            <li>
               <a href="https://juju.is/tutorials" class="p-subnav__item">Tutorials</a>
             </li>
           </ul>


### PR DESCRIPTION
## Done
- Include the new LMA 2 Discourse topic as "Learn" and footer entry. Since LMA 2 is a proper feature of the Juju ecosystem like Charmed Kubernetes or Charmed Openstack, let's make it equally discoverable :-)

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

Depends on https://github.com/canonical-web-and-design/juju.is/pull/331 being merged!

## Issue / Card
Fixes an issue Michele did not file, cuz he likes PRs better :-)

## Screenshots
[if relevant, include a screenshot]
