### PR TITLE
Remove unimplemented command from details page

### DIFF
--- a/templates/details/resources.html
+++ b/templates/details/resources.html
@@ -54,8 +54,6 @@
       </li>
     </ul>
 
-    <pre><code>juju download --include-resources</code></pre>
-
     <p>{{ resource.description }}</p>
 
     <h3 class="p-heading--5">Release history</h3>


### PR DESCRIPTION
## Done

## QA
- Go to https://charmhub-io-1145.demos.haus/candid-idm/resources/candid-idm-image
- Check that in the details page there is no code block with the following command: `juju download --include-resources` ([compare to live](https://charmhub.io/candid-idm/resources/candid-idm-image))

Referenced in https://github.com/canonical-web-and-design/charmhub.io/issues/1135#issuecomment-929957840