### PR TITLE
Updating styling to only increase the font of the first paragraph

### DIFF
--- a/static/sass/_pattern_p-docstring.scss
+++ b/static/sass/_pattern_p-docstring.scss
@@ -149,7 +149,7 @@
       }
     }
 
-    .p-docstring__intro {
+    .p-docstring__intro > {
       p:first-child {
         @extend %vf-heading-4;
       }


### PR DESCRIPTION
## Done
- Updating styling to only increase the font of the first paragraph in the docstring__intro block 

## How to QA
- Visit the demo in your browser and go to /loki-k8s/libraries/loki_push_api
- See that the list items are normal font-size
- Remove the first heading in the description and see the paragraph is enlarged

## Issue / Card
Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/1157

## Screenshots
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1413534/137766744-62a96628-5185-453d-ac28-91ac7c52f55f.png) | ![image](https://user-images.githubusercontent.com/1413534/137766863-e6d4d864-40d2-49bf-b5a2-c12d9d143fb3.png) |
