### PR TITLE
Publishers: Remove visibility field (Public/Private)

### DIFF
--- a/templates/publisher/register-name.html
+++ b/templates/publisher/register-name.html
@@ -87,27 +87,6 @@
       </div>
     </div>
     <div class="u-fixed-width">
-      <hr class="p-separator--2rem">
-    </div>
-    <div class="row p-form__group">
-      <div class="col-2">
-        <p class="is-label p-form__label">Visibility:</p>
-      </div>
-      <div class="col-8 col-x-large-6">
-        <p>This can be changed at any time after the initial upload</p>
-        <label class="p-radio">
-          <input type="radio" class="p-radio__input" name="private" checked="" aria-labelledby="is-public" value="public">
-          <span class="p-radio__label" id="is-public">Public</span>
-        </label>
-        <p class="p-form-help-text" style="padding-inline-start: 2rem;">Anyone can find your charm in the Charmhub</p>
-        <label class="p-radio">
-          <input type="radio" class="p-radio__input" name="private" aria-labelledby="is-private" value="private">
-          <span class="p-radio__label" id="is-private">Private</span>
-        </label>
-        <p class="p-form-help-text" style="padding-inline-start: 2rem;">Charm is hidden in the store and only accessible by the publisher and collaborators</p>
-      </div>
-    </div>
-    <div class="u-fixed-width">
       <hr style="margin-block-end: 1rem; margin-block-start: 2rem;">
       <div class="u-align--right">
         <a class="p-button--neutral" href="/charms" style="margin-inline-end: 1rem;">Cancel</a>

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -24,28 +24,6 @@
     {% endwith %}
     <div class="row p-form__group">
       <div class="col-2">
-        <p class="is-label">Visibility:</p>
-      </div>
-      <div class="col-8">
-        <div class="p-form__control">
-          <input type="radio" name="private" id="is-public" {% if not package.private %}checked="checked"{% endif %} value="public">
-          <label for="is-public">Public
-          </label>
-          <p class="p-form-help-text">Anyone can find your charm in the Charmhub</p>
-        </div>
-        <div class="p-form__control">
-          <input type="radio" name="private" id="is-private" {% if package.private %}checked="checked"{% endif %} value="private">
-          <label for="is-private">Private
-          </label>
-          <p class="p-form-help-text u-no-margin--bottom">Hidden in the Charmhub. Only accessible by the publisher and collaborators.</p>
-        </div>
-      </div>
-    </div>
-    <div class="u-fixed-width">
-      <hr class="p-separator--2rem">
-    </div>
-    <div class="row p-form__group">
-      <div class="col-2">
         <p class="is-label">Status:</p>
       </div>
       <div class="col-8">


### PR DESCRIPTION
## Done
- Remove visibility field as requested by the store team

## How to QA
- Visit the demo in your browser
- Authenticate
- Go to any of your charms settings tab
- The `Visibility` option shouldn't appear
- Same when you visit `/register-name`

## Issue / Card
Fixes #1164
