### PR TITLE
Configure tab improvements

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -4,11 +4,11 @@
       <div class="p-charm-header">
         <div class="p-media-object--medium u-no-margin--bottom">
           {% if package.type == "bundle" %}
-            {% if package.store_front.bundle.applications %}
-              {% set charms = package.store_front.bundle.applications.keys() | list %}
+            {% if package.store_front.bundle.charms %}
+              {% set charms = package.store_front.bundle.charms %}
               <div class="p-bundle-icons">
-                <img src="/{{ package.store_front.bundle.charms[0].name }}/icon" alt="" />
-                <img src="/{{ package.store_front.bundle.charms[1].name }}/icon" alt="" />
+                <img src="/{{ charms[0].name }}/icon" alt="" />
+                <img src="/{{ charms[1].name }}/icon" alt="" />
                 {% if charms | length > 2 %}
                 <span class="p-bundle-icons__count u-text--muted">
                   +{{ charms | length - 2 }}

--- a/templates/details/configure-bundle.html
+++ b/templates/details/configure-bundle.html
@@ -4,27 +4,16 @@
 
 {% block details_content %}
 <div class="row p-details-tab__content bundle-config">
+  {% if package.store_front.bundle.charms %}
   <div class="col-3">
     <div class="p-side-navigation is-sticky" data-js="{{ section_slug }}">
       <ul class="p-side-navigation__list">
         {% for charm in package.store_front.bundle.charms %}
         <li class="p-side-navigation__item">
-          <a href="{{ charm.name }}" class="p-side-navigation__link u-truncate" role="tab" aria-controls="{{ charm.name }}" aria-selected="{% if subpackage.name == charm.name %}true{% else %}false{% endif %}">
+          <a href="{{ charm.name }}" class="p-side-navigation__link u-truncate{% if subpackage_path == charm.name %} is-active{% endif %}" role="tab" aria-controls="{{ charm.name }}" aria-selected="{% if subpackage.name == charm.name %}true{% else %}false{% endif %}">
             <img class="p-side-navigation__icon" src="/{{ charm.name }}/icon" alt="{{ charm.name }}" width="16" height="16">
             {{ charm.title }}
           </a>
-
-          {% if subpackage.name == charm.name %}
-          <ul class="p-side-navigation__list">
-            {% for config in subpackage.store_front.config.options.keys() %}
-            <li class="p-side-navigation__item">
-              <a href="#{{ config }}" class="p-side-navigation__link u-truncate {% if loop.index == 1 %}is-active{% endif %}" role="tab" aria-controls="{{ config }}" aria-selected="{% if loop.index == 1 %}true{% else %}false{% endif %}">
-                {{ config }}
-              </a>
-            </li>
-            {% endfor %}
-          </ul>
-          {% endif %}
         </li>
         {% endfor %}
       </ul>
@@ -45,13 +34,23 @@
         {% endfor %}
       </ul>
     {% else %}
+      <h3>{{ subpackage.name }}</h3>
       <div class="p-notification--information">
         <p class="p-notification__response">
-          No configuration details have been added yet.
+          No configuration details have been added for this charm yet.
         </p>
       </div>
     {% endif %}
   </div>
+  {% else %}
+  <div class="col-12">
+    <div class="p-notification--information">
+      <p class="p-notification__response">
+        No configuration details have been added for this bundle yet.
+      </p>
+    </div>
+  </div>
+  {% endif %}
 </div>
 
 <script>

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -256,7 +256,9 @@ def add_store_front_data(package, details=False):
 
             # List charms
             extra["bundle"]["charms"] = get_bundle_charms(
-                extra["bundle"].get("applications")
+                extra["bundle"].get(
+                    "applications", extra["bundle"].get("services")
+                )
             )
 
         # Reshape channel maps
@@ -288,8 +290,10 @@ def get_bundle_charms(charm_apps):
             # Charm names could be with the old prefix/suffix
             # Like: cs:~charmed-osm/mariadb-k8s-35
             name = data["charm"]
-            if name.startswith("cs:"):
-                name = re.match(r"(?:cs:)(?:~.+/)?(\S*?)(?:-\d+)?$", name)[1]
+            if name.startswith("cs:") or name.startswith("ch:"):
+                name = re.match(r"(?:cs:|ch:)(?:.+/)?(\S*?)(?:-\d+)?$", name)[
+                    1
+                ]
 
             charm = {"title": format_slug(name), "name": name}
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -245,22 +245,29 @@ def details_configuration(entity_name, path=None):
     subpackage = None
 
     if package["type"] == "bundle":
-        if not path:
-            default_charm = package["store_front"]["bundle"]["charms"][0]
+        bundle_charms = package["store_front"]["bundle"]["charms"]
+
+        if not path and bundle_charms:
+            default_charm = bundle_charms[0]
             return redirect(
                 f"/{entity_name}/configure/{default_charm['name']}"
             )
 
-        try:
-            subpackage = get_package(path)
-        except StoreApiResponseErrorList:
-            subpackage = None
+        if path:
+            if not any(d["name"] == path for d in bundle_charms):
+                abort(404)
+
+            try:
+                subpackage = get_package(path)
+            except StoreApiResponseErrorList:
+                subpackage = None
 
     return render_template(
         f"details/configure-{package['type']}.html",
         package=package,
         subpackage=subpackage,
         channel_requested=channel_request,
+        subpackage_path=path,
     )
 
 


### PR DESCRIPTION
## Done

Configure tab for bundles:
- Added title with charm's name
- Remove anchor links from the navigation
- Display a notification when the charm doesn't have any config details
- Fix issue with older bundles that use `services` instead of `applications` (also their icons)
- Display 404s for charms that are not part of a bundle

## How to QA
- Visit the demo in your browser
- Go to different bundles, like:
- https://charmhub-io-1177.demos.haus/kubeflow/
- https://charmhub-io-1177.demos.haus/charmed-kubernetes/
- https://charmhub-io-1177.demos.haus/canonical-kubernetes-canal/
- https://charmhub-io-1177.demos.haus/ceph-base/configure/
- Click on their configure tab and see that everything is working as expected

## Issue / Card
Fixes #1163
