### PR TITLE
Show multiple OS in header

### DIFF
--- a/static/sass/_charmhub_p-series-tag.scss
+++ b/static/sass/_charmhub_p-series-tag.scss
@@ -1,6 +1,22 @@
 @mixin charmhub-p-series-tag {
-  .series-tags {
-    margin-top: $spv-outer--small;
+  .series-base {
+    margin-bottom: $spv-inner--medium;
+
+    @media only screen and (min-width: $breakpoint-x-small) {
+      align-items: flex-start;
+      display: flex;
+      margin-bottom: $spv-inner--small;
+    }
+  }
+
+  .series-base__title {
+    margin-bottom: $spv-inner--small;
+
+    @media only screen and (min-width: $breakpoint-x-small) {
+      margin-bottom: 0;
+      margin-right: 1rem;
+      min-width: 90px;
+    }
   }
 
   .series-tag {
@@ -10,7 +26,7 @@
     display: inline-block;
     font-size: 0.875rem;
     font-weight: 500;
-    margin-bottom: $spv-inner--x-small;
+    margin-bottom: $spv-inner--small;
     margin-right: $spv-inner--x-small;
     padding: 0 $spv-inner--small;
     text-transform: capitalize;

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -86,30 +86,36 @@
         </small>
       </p>
 
-      {% for base in channel_bases %}
+      {% if package.store_front["deployable-on"]|length == 1 and package.store_front["deployable-on"][0] == "kubernetes" %}
         <div class="series-base">
           <div class="series-base__title">
-            {% if base["name"] == "ubuntu" %}
-              <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20" class="p-image--base">
-            {% elif base["name"] == "kubernetes" %}
-              <img src="https://assets.ubuntu.com/v1/9f8a8273-2018-logo-kubernetes+%282%29.svg" alt="kubernetes" width="160" height="27" class="p-image--base">
-            {% elif base["name"] == "centos" %}
-              <img src="https://assets.ubuntu.com/v1/fd5cc5d8-CentOS.svg" alt="CentOS" width="85" height="24" class="p-image--base">
-            {% else %}
-              {{ base["name"] }}
-            {% endif %}
-          </div>
-          <div>
-            {% if base["name"] != "kubernetes" %}
-              {% for channel in base["channels"] %}
-                <span class="series-tag">
-                  {{ channel }}
-                </span>
-              {% endfor %}
-            {% endif %}
+            <img src="https://assets.ubuntu.com/v1/9f8a8273-2018-logo-kubernetes+%282%29.svg" alt="" width="160" height="27" class="p-image--base">
           </div>
         </div>
-      {% endfor %}
+      {% else %}
+        {% for base in channel_bases %}
+          <div class="series-base">
+            <div class="series-base__title">
+              {% if base["name"] == "ubuntu" %}
+                <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20" class="p-image--base">
+              {% elif base["name"] == "centos" %}
+                <img src="https://assets.ubuntu.com/v1/fd5cc5d8-CentOS.svg" alt="CentOS" width="85" height="24" class="p-image--base">
+              {% else %}
+                {{ base["name"] }}
+              {% endif %}
+            </div>
+            <div>
+              {% if base["name"] != "kubernetes" %}
+                {% for channel in base["channels"] %}
+                  <span class="series-tag">
+                    {{ channel }}
+                  </span>
+                {% endfor %}
+              {% endif %}
+            </div>
+          </div>
+        {% endfor %}
+      {% endif %}
     </div>
   </div>
 </div>

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -80,21 +80,36 @@
       </div>
     </div>
     <div class="col-4">
-      <p style="margin-bottom: 0.5rem;"><small class="u-no-padding--top u-text--muted">Platform:</small></p>
-      {% if package.store_front["deployable-on"]|length == 1 and package.store_front["deployable-on"][0] == "kubernetes" %}
-      <img src="https://assets.ubuntu.com/v1/9f8a8273-2018-logo-kubernetes+%282%29.svg" alt="" width="160" height="27" class="p-image--base">
-      {% else %}
-      <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="" width="89" height="20" class="p-image--base">
-      <div class="series-tags">
-        {% for version in package.store_front.series %}
-        {% if version != "Kubernetes" %}
-        <span class="series-tag">
-          {{ version }}
-        </span>
-        {% endif %}
-        {% endfor %}
-      </div>
-      {% endif %}
+      <p style="margin-bottom: 0.5rem;">
+        <small class="u-no-padding--top u-text--muted">
+          Platform:
+        </small>
+      </p>
+
+      {% for base in channel_bases %}
+        <div class="series-base">
+          <div class="series-base__title">
+            {% if base["name"] == "ubuntu" %}
+              <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20" class="p-image--base">
+            {% elif base["name"] == "kubernetes" %}
+              <img src="https://assets.ubuntu.com/v1/9f8a8273-2018-logo-kubernetes+%282%29.svg" alt="kubernetes" width="160" height="27" class="p-image--base">
+            {% elif base["name"] == "centos" %}
+              <img src="https://assets.ubuntu.com/v1/fd5cc5d8-CentOS.svg" alt="CentOS" width="85" height="24" class="p-image--base">
+            {% else %}
+              {{ base["name"] }}
+            {% endif %}
+          </div>
+          <div>
+            {% if base["name"] != "kubernetes" %}
+              {% for channel in base["channels"] %}
+                <span class="series-tag">
+                  {{ channel }}
+                </span>
+              {% endfor %}
+            {% endif %}
+          </div>
+        </div>
+      {% endfor %}
     </div>
   </div>
 </div>

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -96,28 +96,28 @@
         {% for track, track_data in package.store_front.channel_map.items() %}
           {% for channel, channel_data in track_data.items() %}
             {% if channel == package["default-release"]["channel"]["name"] %}
-              {% for base in channel_data[0]["channel_bases"] %}
-                <div class="series-base">
-                  <div class="series-base__title">
-                    {% if base["name"] == "ubuntu" %}
-                      <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20" class="p-image--base">
-                    {% elif base["name"] == "centos" %}
-                      <img src="https://assets.ubuntu.com/v1/fd5cc5d8-CentOS.svg" alt="CentOS" width="85" height="24" class="p-image--base">
-                    {% else %}
-                      {{ base["name"] }}
-                    {% endif %}
-                  </div>
-                  <div>
-                    {% if base["name"] != "kubernetes" %}
+              {% if channel_data[0]["channel_bases"] %}
+                {% for base in channel_data[0]["channel_bases"] %}
+                  <div class="series-base">
+                    <div class="series-base__title">
+                      {% if base["name"] == "ubuntu" %}
+                        <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20" class="p-image--base">
+                      {% elif base["name"] == "centos" %}
+                        <img src="https://assets.ubuntu.com/v1/fd5cc5d8-CentOS.svg" alt="CentOS" width="85" height="24" class="p-image--base">
+                      {% else %}
+                        {{ base["name"] }}
+                      {% endif %}
+                    </div>
+                    <div>
                       {% for channel in base["channels"] %}
                         <span class="series-tag">
                           {{ channel }}
                         </span>
                       {% endfor %}
-                    {% endif %}
+                    </div>
                   </div>
-                </div>
-              {% endfor %}
+                {% endfor %}
+              {% endif %}
             {% endif %}
           {% endfor %}
         {% endfor %}

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -93,27 +93,33 @@
           </div>
         </div>
       {% else %}
-        {% for base in channel_bases %}
-          <div class="series-base">
-            <div class="series-base__title">
-              {% if base["name"] == "ubuntu" %}
-                <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20" class="p-image--base">
-              {% elif base["name"] == "centos" %}
-                <img src="https://assets.ubuntu.com/v1/fd5cc5d8-CentOS.svg" alt="CentOS" width="85" height="24" class="p-image--base">
-              {% else %}
-                {{ base["name"] }}
-              {% endif %}
-            </div>
-            <div>
-              {% if base["name"] != "kubernetes" %}
-                {% for channel in base["channels"] %}
-                  <span class="series-tag">
-                    {{ channel }}
-                  </span>
-                {% endfor %}
-              {% endif %}
-            </div>
-          </div>
+        {% for track, track_data in package.store_front.channel_map.items() %}
+          {% for channel, channel_data in track_data.items() %}
+            {% if channel == package["default-release"]["channel"]["name"] %}
+              {% for base in channel_data[0]["channel_bases"] %}
+                <div class="series-base">
+                  <div class="series-base__title">
+                    {% if base["name"] == "ubuntu" %}
+                      <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20" class="p-image--base">
+                    {% elif base["name"] == "centos" %}
+                      <img src="https://assets.ubuntu.com/v1/fd5cc5d8-CentOS.svg" alt="CentOS" width="85" height="24" class="p-image--base">
+                    {% else %}
+                      {{ base["name"] }}
+                    {% endif %}
+                  </div>
+                  <div>
+                    {% if base["name"] != "kubernetes" %}
+                      {% for channel in base["channels"] %}
+                        <span class="series-tag">
+                          {{ channel }}
+                        </span>
+                      {% endfor %}
+                    {% endif %}
+                  </div>
+                </div>
+              {% endfor %}
+            {% endif %}
+          {% endfor %}
         {% endfor %}
       {% endif %}
     </div>

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -164,6 +164,9 @@ def extract_bases(channel):
     channel_bases = []
 
     for i in bases:
+        if i is None:
+            return
+
         has_base = False
 
         for b in channel_bases:

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -82,6 +82,7 @@ def convert_channel_maps(channel_map):
             "risk": channel["channel"]["risk"],
             "size": channel["revision"]["download"]["size"],
             "bases": extract_series(channel, True),
+            "channel_bases": extract_bases(channel),
             "revision": channel["revision"],
         }
 
@@ -156,6 +157,33 @@ def extract_series(channel, long_name=False):
         )
 
     return sorted(series, reverse=True)
+
+
+def extract_bases(channel):
+    bases = channel["revision"]["bases"]
+    channel_bases = []
+
+    for i in bases:
+        has_base = False
+
+        for b in channel_bases:
+            if b["name"] == i["name"]:
+                has_base = True
+
+        if not has_base:
+            channel_bases.append(
+                {
+                    "name": i["name"],
+                    "channels": [],
+                }
+            )
+
+    for i in channel_bases:
+        for b in bases:
+            if b["name"] == i["name"]:
+                i["channels"].append(b["channel"])
+
+    return channel_bases
 
 
 def convert_date(date_to_convert):
@@ -273,6 +301,7 @@ def add_store_front_data(package, details=False):
 
         # Extract all supported series
         extra["series"] = extract_series(package["default-release"])
+        extra["channel_bases"] = extract_bases(package["default-release"])
 
         # Some needed fields
         extra["publisher_name"] = package["result"]["publisher"][

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -158,30 +158,6 @@ def details_overview(entity_name):
 
     # Remove Markdown comments
     readme = re.sub("(<!--.*-->)", "", readme, flags=re.DOTALL)
-
-    bases = package["default-release"]["revision"]["bases"]
-    channel_bases = []
-
-    for i in bases:
-        has_base = False
-
-        for b in channel_bases:
-            if b["name"] == i["name"]:
-                has_base = True
-
-        if not has_base:
-            channel_bases.append(
-                {
-                    "name": i["name"],
-                    "channels": [],
-                }
-            )
-
-    for i in channel_bases:
-        for b in bases:
-            if b["name"] == i["name"]:
-                i["channels"].append(b["channel"])
-
     readme = md_parser(readme)
     readme = decrease_headers(readme)
     return render_template(
@@ -190,7 +166,6 @@ def details_overview(entity_name):
         readme=readme,
         package_type=package["type"],
         channel_requested=channel_request,
-        channel_bases=channel_bases,
     )
 
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -158,6 +158,7 @@ def details_overview(entity_name):
 
     # Remove Markdown comments
     readme = re.sub("(<!--.*-->)", "", readme, flags=re.DOTALL)
+
     readme = md_parser(readme)
     readme = decrease_headers(readme)
     return render_template(

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -159,6 +159,29 @@ def details_overview(entity_name):
     # Remove Markdown comments
     readme = re.sub("(<!--.*-->)", "", readme, flags=re.DOTALL)
 
+    bases = package["default-release"]["revision"]["bases"]
+    channel_bases = []
+
+    for i in bases:
+        has_base = False
+
+        for b in channel_bases:
+            if b["name"] == i["name"]:
+                has_base = True
+
+        if not has_base:
+            channel_bases.append(
+                {
+                    "name": i["name"],
+                    "channels": [],
+                }
+            )
+
+    for i in channel_bases:
+        for b in bases:
+            if b["name"] == i["name"]:
+                i["channels"].append(b["channel"])
+
     readme = md_parser(readme)
     readme = decrease_headers(readme)
     return render_template(
@@ -167,6 +190,7 @@ def details_overview(entity_name):
         readme=readme,
         package_type=package["type"],
         channel_requested=channel_request,
+        channel_bases=channel_bases,
     )
 
 


### PR DESCRIPTION
## Done
Updated the charm listing header to display multiple OS in the header

## QA
- Go to https://charmhub-io-1178.demos.haus/slurmd
- Go to https://charmhub-io-1178.demos.haus/openstack-dashboard
- Check that the Operating systems under the platform heading in the header is inline with [the design](https://camo.githubusercontent.com/87916e4503b7d3b4f655e3425cd89121e46171860f18cbd97f0c1781e495c4c8/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3565316335333637663464626532626665346337376164382f32666463366536342d626665322d343534352d383862612d613866393262386635643935)

## Issue
Fixes https://github.com/canonical-web-and-design/snap-squad/issues/2229