### PR TITLE
Get bundle docs

### DIFF
--- a/templates/details/_details-tab-navigation.html
+++ b/templates/details/_details-tab-navigation.html
@@ -4,10 +4,10 @@
       <li class="p-tabs__item" role="presentation">
         <a href="/{{ package.name }}{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'overview' %}aria-selected="true" {% endif %}>Overview</a>
       </li>
-      {% if package.type == "charm" %}
       <li class="p-tabs__item" role="presentation">
         <a href="/{{ package.name }}/docs{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'docs' %}aria-selected="true" {% endif %}>Docs</a>
       </li>
+      {% if package.type == "charm" %}
       {% if package['default-release']['resources'] %}
       <li class="p-tabs__item" role="presentation">
         <a href="/{{ package.name }}/resources{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'resources' %}aria-selected="true" {% endif %}>Resources</a>

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -254,12 +254,18 @@ def add_store_front_data(package, details=False):
                 package["default-release"]["revision"]["bundle-yaml"]
             )
 
+            # Get bundle docs
+            extra["docs_topic"] = get_docs_topic_id(extra["bundle"])
+
             # List charms
             extra["bundle"]["charms"] = get_bundle_charms(
                 extra["bundle"].get(
                     "applications", extra["bundle"].get("services")
                 )
             )
+        else:
+            # Get charm docs
+            extra["docs_topic"] = get_docs_topic_id(extra["metadata"])
 
         # Reshape channel maps
         extra["channel_map"] = convert_channel_maps(package["channel-map"])
@@ -272,11 +278,9 @@ def add_store_front_data(package, details=False):
         extra["publisher_name"] = package["result"]["publisher"][
             "display-name"
         ]
+
         if "summary" in package["result"]:
             extra["summary"] = package["result"]["summary"]
-
-        # Get charm docs
-        extra["docs_topic"] = get_docs_topic_id(extra["metadata"])
 
     package["store_front"] = extra
     return package


### PR DESCRIPTION
## Done
- For bundles the `docs` property to link a discourse topic comes from the `bundle.yaml` not the `metadata.yaml` like for charms

## Issue / Card
Fixes #751
