### PR TITLE
Fix broken link on unpublished charms page

### DIFF
--- a/templates/publisher/list.html
+++ b/templates/publisher/list.html
@@ -15,7 +15,7 @@
           <a href="/register-name" class="p-button--neutral">Register a new charm or bundle</a>
         </li>
         <li class="p-inline-list__item">
-          <a href="/tutorials/publish-on-charmhub">
+          <a href="https://juju.is/tutorials/publish-on-charmhub">
             Learn how to publish an operator&nbsp;&rsaquo;
           </a>
         </li>
@@ -144,7 +144,7 @@
                 <div class="p-tooltip__dialog" role="dialog" aria-labelledby="modal-content">
                   <button class="p-tooltip__close" aria-controls="icon-tooltip-modal" aria-label="Close tooltip modal">Close</button>
                   <span id="modal-content" class="u-no-margin--bottom u-no-padding--top">
-                    <a href="/tutorials/publish-on-charmhub">Learn how to publish your operator in Charmhub.</a>
+                    <a href="https://juju.is/tutorials/publish-on-charmhub">Learn how to publish your operator in Charmhub.</a>
                   </span>
                 </div>
               </div>
@@ -225,7 +225,7 @@
         <h4 class="p-heading--5 u-no-margin--bottom">Your first Kubernetes operator</h4>
         <p>Create a minimal charmed operator with the Python Operator Framework.</p>
         <p class="u-sv3">
-          <a href="/tutorials/build-a-minimal-operator">Complete this tutorial&nbsp;&rsaquo;</a>
+          <a href="https://juju.is/tutorials/build-a-minimal-operator">Complete this tutorial&nbsp;&rsaquo;</a>
         </p>
       </div>
       <div class="col-4">

--- a/templates/publisher/list.html
+++ b/templates/publisher/list.html
@@ -208,7 +208,7 @@
         <h4 class="p-heading--5 u-no-margin--bottom">Understand the basics</h4>
         <p>Learn everything about charms and all the best practices of how to use them and write them.</p>
         <p class="u-sv3">
-          <a href="/docs">Read the docs&nbsp;&rsaquo;</a>
+          <a href="https://juju.is/docs">Read the docs&nbsp;&rsaquo;</a>
         </p>
       </div>
       <div class="col-4">


### PR DESCRIPTION
## Done
Fixed a broken docs link

## QA
- Login with an account that has no published charms
- Go to https://charmhub-io-1181.demos.haus/charms
- Click on the "Read the docs" link and check that it takes you to https://juju.is/docs

## Issue
Fixes #1172 