### PR TITLE
Change name of library to filename

### DIFF
--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -51,7 +51,7 @@
     <div class="col-9">
       {% if not is_introduction %}
       <div class="u-fixed-width">
-        <h2>{{ library_name }}</h2>
+        <h2>{{ fetch_string }}</h2>
         <ul class="p-inline-list--stretch p-list--reversed u-no-margin--bottom">
           <li class="p-inline-list__item u-no-margin--right">
             <div class="p-button-group">


### PR DESCRIPTION
## Done
Change the name of a library to its filename

## QA
- Go to https://charmhub-io-1196.demos.haus/nginx-ingress-integrator/libraries/ingress
- The title should be `charms.nginx_ingress_integrator.v0.ingress` instead of `ingress`

## Issue
Fixes #1187