### PR TITLE
Fix syntax highlighting on libraries page

### DIFF
--- a/templates/details/details_layout.html
+++ b/templates/details/details_layout.html
@@ -43,10 +43,10 @@
   <script src="{{ versioned_static('js/dist/highlight-js.js') }}" defer></script>
   <script>
     window.addEventListener("DOMContentLoaded", function () {
-      var codeblocks = Array.prototype.slice.call(document.querySelectorAll("pre"));
+      var codeblocks = Array.prototype.slice.call(document.querySelectorAll("code"));
 
       codeblocks.forEach(function(block) {
-        charmhub.highlight.hljs.highlightBlock(block.querySelector("code"));
+        charmhub.highlight.hljs.highlightBlock(block);
       });
 
       charmhub.details.init("{{ package.name }}");


### PR DESCRIPTION
## Done
Fixed the syntax highlighting on the libraries page

## QA
- Go to https://charmhub-io-1198.demos.haus/fluentbit/libraries/fluentbit
- Check that the code example is highlighted

## Issue
Fixes #1143