### PR TITLE
Fix broken syntax highlighting on inline code blocks

### DIFF
--- a/templates/details/details_layout.html
+++ b/templates/details/details_layout.html
@@ -43,7 +43,7 @@
   <script src="{{ versioned_static('js/dist/highlight-js.js') }}" defer></script>
   <script>
     window.addEventListener("DOMContentLoaded", function () {
-      var codeblocks = Array.prototype.slice.call(document.querySelectorAll("code"));
+      var codeblocks = Array.prototype.slice.call(document.querySelectorAll("pre code"));
 
       codeblocks.forEach(function(block) {
         charmhub.highlight.hljs.highlightBlock(block);


### PR DESCRIPTION
## Done
- _A changelist description explaining what the change achieves and why you’re making it._

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card
Fixes #

## Screenshots
[if relevant, include a screenshot]
