### PR TITLE
Authentication changes to use new endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.candid==0.9.0
 canonicalwebteam.discourse==4.0.6
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.search==1.0.0
-canonicalwebteam.store-api==3.2.6
+canonicalwebteam.store-api==3.2.7
 canonicalwebteam.docstring-extractor==1.0.0
 Flask-WTF==0.14.3
 humanize==2.6.0

--- a/templates/publisher/account-details.html
+++ b/templates/publisher/account-details.html
@@ -13,7 +13,7 @@
       Full name:
     </div>
     <div class="col-6">
-      <p class="u-no-padding--top"><strong>{{ publisher["display-name"] }}</strong></p>
+      <p class="u-no-padding--top"><strong>{{ account["display-name"] }}</strong></p>
       <p class="p-form-help-text">
         Who your users will see as the publisher of your charms and bundles.
       </p>
@@ -24,7 +24,7 @@
       Username:
     </div>
     <div class="col-6">
-      <p class="u-no-padding--top"><strong>{{ publisher["username"] }}</strong></p>
+      <p class="u-no-padding--top"><strong>{{ account["username"] }}</strong></p>
       <p class="p-form-help-text">
         This is a shorthand version of your name, used when space on screen is limited.
       </p>
@@ -35,7 +35,7 @@
     Email address:
     </div>
     <div class="col-6">
-      <p class="u-no-padding--top"><strong>{{ publisher["email"] }}</strong></p>
+      <p class="u-no-padding--top"><strong>{{ account["email"] }}</strong></p>
       <p class="p-form-help-text">
       Your email address will not be shared publicly.
       </p>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -37,8 +37,8 @@ def get_account_json():
     """
     account = None
 
-    if "publisher" in session:
-        account = session["publisher"]
+    if "account" in session:
+        account = session["account"]
 
     response = {"account": account}
     response = make_response(response)

--- a/webapp/authentication.py
+++ b/webapp/authentication.py
@@ -3,13 +3,13 @@ def is_authenticated(session):
     Checks if the user is authenticated from the session
     Returns True if the user is authenticated
     """
-    return "publisher-auth" in session
+    return "account-auth" in session
 
 
 def empty_session(session):
     """
     Empty the session, used to logout.
     """
-    session.pop("publisher", None)
-    session.pop("publisher-auth", None)
-    session.pop("publisher-macaroon", None)
+    session.pop("account", None)
+    session.pop("account-auth", None)
+    session.pop("account-macaroon", None)

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -24,15 +24,15 @@ def set_handlers(app):
         """
 
         if authentication.is_authenticated(session):
-            publisher = session["publisher"]
+            account = session["account"]
         else:
-            publisher = None
+            account = None
 
         return {
             "add_filter": helpers.add_filter,
             "active_filter": helpers.active_filter,
             "remove_filter": helpers.remove_filter,
-            "publisher": publisher,
+            "account": account,
             "image": image_template,
         }
 

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -32,6 +32,8 @@ def logout():
 
 @login.route("/login")
 def publisher_login():
+    user_agent = flask.request.headers.get("User-Agent")
+
     # Get a bakery v2 macaroon from the publisher API to be discharged
     # and save it in the session
     flask.session["account-macaroon"] = publisher_api.issue_macaroon(
@@ -40,7 +42,8 @@ def publisher_login():
             "account-view-packages",
             "package-manage",
             "package-view",
-        ]
+        ],
+        description=f"charmhub.io - {user_agent}",
     )
 
     login_url = candid.get_login_url(

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -34,7 +34,7 @@ def get_account_details():
 @login_required
 def list_page():
     publisher_charms = publisher_api.get_account_packages(
-        session["publisher-auth"], "charm", include_collaborations=True
+        session["account-auth"], "charm", include_collaborations=True
     )
 
     page_type = request.path[1:-1]
@@ -60,7 +60,7 @@ def list_page():
 @login_required
 def listing(entity_name):
     package = publisher_api.get_package_metadata(
-        session["publisher-auth"], "charm", entity_name
+        session["account-auth"], "charm", entity_name
     )
 
     licenses = []
@@ -89,7 +89,7 @@ def post_listing(entity_name):
     }
 
     result = publisher_api.update_package_metadata(
-        session["publisher-auth"], "charm", entity_name, data
+        session["account-auth"], "charm", entity_name, data
     )
 
     if result:
@@ -102,7 +102,7 @@ def post_listing(entity_name):
 @login_required
 def settings(entity_name):
     package = publisher_api.get_package_metadata(
-        session["publisher-auth"], "charm", entity_name
+        session["account-auth"], "charm", entity_name
     )
 
     context = {
@@ -124,7 +124,7 @@ def post_settings(entity_name):
     }
 
     result = publisher_api.update_package_metadata(
-        session["publisher-auth"], "charm", entity_name, data
+        session["account-auth"], "charm", entity_name, data
     )
 
     if result:
@@ -173,7 +173,7 @@ def post_register_name():
 
     try:
         result = publisher_api.register_package_name(
-            session["publisher-auth"], data
+            session["account-auth"], data
         )
         if result:
             flash(
@@ -263,7 +263,7 @@ def get_publicise(entity_name):
         "ua": {"title": "українськa мовa", "text": "Завантажте з Charmhub"},
     }
     package = publisher_api.get_package_metadata(
-        session["publisher-auth"], "charm", entity_name
+        session["account-auth"], "charm", entity_name
     )
 
     if not package["status"] == "published":
@@ -284,7 +284,7 @@ def get_publicise(entity_name):
 @login_required
 def get_publicise_badges(entity_name):
     package = publisher_api.get_package_metadata(
-        session["publisher-auth"], "charm", entity_name
+        session["account-auth"], "charm", entity_name
     )
 
     if not package["status"] == "published":
@@ -304,7 +304,7 @@ def get_publicise_badges(entity_name):
 @login_required
 def get_publicise_cards(entity_name):
     package = publisher_api.get_package_metadata(
-        session["publisher-auth"], "charm", entity_name
+        session["account-auth"], "charm", entity_name
     )
 
     if not package["status"] == "published":


### PR DESCRIPTION
Blocked until https://github.com/canonical-web-and-design/canonicalwebteam.store-api/pull/80 is merged

## Done
- Use new endpoint for the login callback process
- Update word `publisher` -> `account`
- Add a description when we request a macaroon with `charmhub.io` + user agent from the user.

## How to QA
- Visit the demo in your browser
- Check that you can login as usual
- Check /account/details is displaying the right information

## Issue / Card
Fixes #1184
