### PR TITLE
Redirect canonical-kubernetes to charmed-kubernetes

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -10,4 +10,6 @@ overview: https://juju.is/about
 kubeflow-charmers-kubeflow-edge: kubeflow-edge
 openstack-charmers-keystone-saml-mellon: keystone-saml-mellon
 containers-etcd: etcd
+canonical-kubernetes: charmed-kubernetes
+
 jaas: https://jaas.ai/jaas


### PR DESCRIPTION
## Done
Redirect canonical-kubernetes to charmed-kubernetes

## How to QA
- Go to /canonical-kubernetes and check it redirects to /charmed-kubernetes

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/runs/4905710943?check_suite_focus=true
