### PR TITLE
Fix platform for machine bundles

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -92,6 +92,13 @@
             <img src="https://assets.ubuntu.com/v1/9f8a8273-2018-logo-kubernetes+%282%29.svg" alt="" width="160" height="27" class="p-image--base">
           </div>
         </div>
+      {% elif package.type == "bundle" and package.store_front.bundle.series %}
+        {# Machine bundles and they have the "series" attribute: we mark them as Ubuntu platform #}
+        <div class="series-base">
+          <div class="series-base__title">
+              <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20" class="p-image--base">
+          </div>
+        </div>
       {% else %}
         {% for track, track_data in package.store_front.channel_map.items() %}
           {% for channel, channel_data in track_data.items() %}


### PR DESCRIPTION
## Done
- Fix platform for machine bundles

## How to QA
- Visit the demo and check that you see machine bundles with the Ubuntu platform:
- [charmed-kubernetes](https://charmhub-io-1250.demos.haus/charmed-kubernetes)
- [juju-qa-bundle-test](https://charmhub-io-1250.demos.haus/charmed-kubernetes)

## Issue / Card
Fixes #1203
