### PR TITLE
Filter by architecture

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -103,8 +103,8 @@
         {% for track, track_data in package.store_front.channel_map.items() %}
           {% for channel, channel_data in track_data.items() %}
             {% if channel == package["default-release"]["channel"]["name"] %}
-              {% if channel_data[0]["channel_bases"] %}
-                {% for base in channel_data[0]["channel_bases"] %}
+              {% if channel_data.latest["channel_bases"] %}
+                {% for base in channel_data.latest["channel_bases"] %}
                   <div class="series-base">
                     <div class="series-base__title">
                       {% if base["name"] == "ubuntu" %}

--- a/templates/embeddable-card.html
+++ b/templates/embeddable-card.html
@@ -170,8 +170,8 @@
           {% for channel, channel_data in track_data.items() %}
           <tr>
             <td>{{ track }}/{{ channel }}</td>
-            <td>{{ channel_data[0].version }}</td>
-            <td>{{ channel_data[0].released_at }}</td>
+            <td>{{ channel_data.latest.version }}</td>
+            <td>{{ channel_data.latest.released_at }}</td>
           </tr>
           {% endfor %}
           {% endfor %}

--- a/templates/partial/_channel-map.html
+++ b/templates/partial/_channel-map.html
@@ -13,12 +13,12 @@
         <div class="u-fixed-width">
           <div class="p-form p-form--inline">
             <div class="p-form__group">
-              <label class="p-form__label">Filter by series:</label>
+              <label class="p-form__label">Architecture:</label>
               <div class="p-form__control">
                 <select data-js="channel-map-filter">
                   <option value="any">Any</option>
-                  {% for serie in package.store_front.series %}
-                  <option value="{{ version }}">{{ serie }}</option>
+                  {% for arch in package.store_front.architectures %}
+                  <option value="{{ arch }}">{{ arch }}</option>
                   {% endfor %}
                 </select>
               </div>
@@ -39,14 +39,14 @@
             <tbody>
               {% for track, track_data in package.store_front.channel_map.items() %}
               {% for channel, channel_data in track_data.items() %}
-              <tr data-channel-map-track="{{ track }}" data-channel-map-channel="{{ channel }}" data-channel-map-version="{{ channel_data.version }}" data-channel-map-filter="{% for base in channel_data[0].revision.bases %}{{ base.channel }} {% endfor %}">
+              <tr data-channel-map-track="{{ track }}" data-channel-map-channel="{{ channel }}" data-channel-map-version="{{ channel_data.latest.version }}" data-channel-map-filter="{% for arch in channel_data.latest.architectures %}{{ arch }} {% endfor %}">
                 <td>{{ track }}/{{ channel }}</td>
-                <td>{{ channel_data[0].version }}</td>
-                <td>{{ channel_data[0].revision.revision }}</td>
-                <td>{{ channel_data[0].released_at }}</td>
+                <td>{{ channel_data.latest.version }}</td>
+                <td>{{ channel_data.latest.revision.revision }}</td>
+                <td>{{ channel_data.latest.released_at }}</td>
                 <td>
                   <div class="series-tags u-no-margin--top">
-                    {% for base in channel_data[0].bases %}
+                    {% for base in channel_data.latest.bases %}
                       <span class="series-tag">{{ base }}</span>
                     {% endfor %}
                   </div>


### PR DESCRIPTION
## Done
- Fixed duplication when a charm is built for multiple architectures: https://github.com/canonical-web-and-design/charmhub.io/issues/1104
- Added filtering per architecture: https://app.zeplin.io/project/611ccdbe4070b81404df20cb/screen/61376ffbb9ea62b9c099f3c3

## How to QA
- Visit the this charm: https://charmhub.io/juju-controller on the demo
- Check there is no duplication for the ubuntu versions:
- ![image](https://user-images.githubusercontent.com/6353928/157113221-7636cbaf-8f68-4659-889b-c8ba26e25ed4.png)
- Open the channel map dropdown and check that there is a filter for architectures:
- ![image](https://user-images.githubusercontent.com/6353928/157113100-f97a3fb3-3b0e-4c42-b8a6-36a1cd6945d1.png)
- Check other charms with fewer architectures

## Issue / Card
Fixes #1104
