### PR TITLE
[Topics] Always display 'See all topics' link

### DIFF
--- a/templates/partial/_topics.html
+++ b/templates/partial/_topics.html
@@ -5,40 +5,38 @@
       <p>Top related topics</p>
       <div class="u-equal-height u-hide" data-js="topics-placeholder-container">
         {% for _ in range(0, 2) %}
-          <a class="p-card--highlighted p-card--href has-top-color">
-            <svg width="100%" height="80%" class="p-card--placeholder">
-              <defs>
-                <clipPath id="animation-mask">
-                  <rect x="16" y="15" width="40%" height="18" />
-                  <rect x="16" y="69.5" width="60%" height="18" />
-                  <rect x="16" y="95" width="25%" height="18" />
-                </clipPath>
-              </defs>
-            </svg>
-          </a>
+        <a class="p-card--highlighted p-card--href has-top-color">
+          <svg width="100%" height="80%" class="p-card--placeholder">
+            <defs>
+              <clipPath id="animation-mask">
+                <rect x="16" y="15" width="40%" height="18" />
+                <rect x="16" y="69.5" width="60%" height="18" />
+                <rect x="16" y="95" width="25%" height="18" />
+              </clipPath>
+            </defs>
+          </svg>
+        </a>
         {% endfor %}
       </div>
 
       <div class="u-equal-height u-hide" data-js="featured-topics-container">
         {% for topic in featured_topics[:3] %}
-          <a
-            id="{{ topic.slug }}"
-            class="p-card--highlighted p-card--href has-top-color"
-            href="/topics/{{ topic.slug }}"
-            data-js="topic-card"
-          >
-            <h3 class="p-muted-heading">{{ topic.name }}</h3>
-            <hr />
-            <p class="p-card__content">{{ topic.description }}</p>
-          </a>
+        <a
+          id="{{ topic.slug }}"
+          class="p-card--highlighted p-card--href has-top-color"
+          href="/topics/{{ topic.slug }}"
+          data-js="topic-card"
+        >
+          <h3 class="p-muted-heading">{{ topic.name }}</h3>
+          <hr />
+          <p class="p-card__content">{{ topic.description }}</p>
+        </a>
         {% endfor %}
       </div>
       <div class="u-equal-height u-hide" data-js="topics-container"></div>
-      {% if featured_topics|length > 3 %}
-        <div>
-          <a href="/topics">See all topics&nbsp;&rsaquo;</a>
-        </div>
-      {% endif %}
+      <div>
+        <a href="/topics">See all topics&nbsp;&rsaquo;</a>
+      </div>
     </div>
   </div>
 </div>

--- a/templates/partial/_topics.html
+++ b/templates/partial/_topics.html
@@ -21,19 +21,23 @@
 
       <div class="u-equal-height u-hide" data-js="featured-topics-container">
         {% for topic in featured_topics[:3] %}
-          <a id="{{ topic.slug }}" class="p-card--highlighted p-card--href has-top-color" href="/topics/{{ topic.slug }}" data-js="topic-card">
+          <a
+            id="{{ topic.slug }}"
+            class="p-card--highlighted p-card--href has-top-color"
+            href="/topics/{{ topic.slug }}"
+            data-js="topic-card"
+          >
             <h3 class="p-muted-heading">{{ topic.name }}</h3>
-            <hr>
+            <hr />
             <p class="p-card__content">{{ topic.description }}</p>
           </a>
         {% endfor %}
       </div>
-      <div class="u-equal-height u-hide" data-js="topics-container">
-      </div>
-      {% if featured_topics|length > 2 %}
-      <div>
-        <a href="/topics">See all topics&nbsp;&rsaquo;</a>
-      </div>
+      <div class="u-equal-height u-hide" data-js="topics-container"></div>
+      {% if featured_topics|length > 3 %}
+        <div>
+          <a href="/topics">See all topics&nbsp;&rsaquo;</a>
+        </div>
       {% endif %}
     </div>
   </div>
@@ -41,9 +45,12 @@
 {% endif %}
 
 <template id="topic-card-template">
-  <a class="p-card--highlighted p-card--href has-top-color" data-js="topic-card">
+  <a
+    class="p-card--highlighted p-card--href has-top-color"
+    data-js="topic-card"
+  >
     <h3 class="p-muted-heading"></h3>
-    <hr>
+    <hr />
     <p class="p-card__content"></p>
-  </div>
+  </a>
 </template>


### PR DESCRIPTION
## Done
- Remove the check for number of topics
- Change a closing tag from `div` to `a` to match the opening tag
- Prettier did some formatting :shrug:

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the 'Show all topics' link doesn't show on the homepage

## Issue / Card
Fixes #

## Screenshots
