### PR TITLE
[Details] Force readme content to be left-aligned

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -228,6 +228,19 @@ body {
   display: none;
 }
 
+.package-card-icons {
+  > * {
+    display: inline-block;
+    margin-right: 0.5rem;
+    position: relative;
+    top: 4px;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+}
+
 .p-details-tab__content {
   .p-side-navigation {
     @media (min-width: $breakpoint-small) {
@@ -255,10 +268,10 @@ body {
       }
     }
   }
-
-	.p-details-tab__content__body * {
-	  text-align: left;
-	}
+	
+  .p-details-tab__content__body * {
+    text-align: left;
+  }
 }
 
 .row,
@@ -277,19 +290,6 @@ h3 {
   display: inline-block;
   margin-right: 0.5rem;
   padding-right: 0.5rem;
-}
-
-.package-card-icons {
-  > * {
-    display: inline-block;
-    margin-right: 0.5rem;
-    position: relative;
-    top: 4px;
-
-    &:last-child {
-      margin-right: 0;
-    }
-  }
 }
 
 .charm-empty-docs-icon {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -268,7 +268,7 @@ body {
       }
     }
   }
-	
+
   .p-details-tab__content__body * {
     text-align: left;
   }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -255,6 +255,10 @@ body {
       }
     }
   }
+
+	.p-details-tab__content__body * {
+	  text-align: left;
+	}
 }
 
 .row,

--- a/templates/details/overview.html
+++ b/templates/details/overview.html
@@ -4,7 +4,7 @@
 
 {% block details_content %}
   <div class="row p-details-tab__content">
-    <div class="col-3">
+    <div class="col-3 p-details-tab__content__sidebar">
       {% if package.result.summary %}
         <h4 class="p-heading--5 u-no-margin--bottom">About</h4>
         <p data-js="summary" data-summary="{{ package.result.summary }}">
@@ -73,7 +73,7 @@
       <p>Share your thoughts on this charm with the community on discourse.</p>
       <p><a class="p-button--base" href="https://discourse.charmhub.io/">Join the discussion</a></p>
     </div>
-    <div class="col-9">
+    <div class="col-9 p-details-tab__content__body">
       {{ readme | safe }}
     </div>
   </div>


### PR DESCRIPTION
## Done
- Added a couple of new wrapper classes
- Added a `class *: {text-align: left;}` to all user-generated content

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit the `hello-kubecon` charm

## Issue / Card
Fixes #

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/479384/157433059-7ed6f26e-ecd2-424e-855a-0d48e60413d4.png)

### After
![image](https://user-images.githubusercontent.com/479384/157433121-f687a746-534b-4769-abef-239e76b1e60c.png)

