### PR TITLE
Redirect rules from jujucharms

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -14,4 +14,8 @@ canonical-kubernetes: charmed-kubernetes
 
 jaas: https://jaas.ai/jaas
 docs/stable/about-juju: https://juju.is/about
+
+# jujucharms.com redirections
 q/(?P<search>.*)/?: /?q={search}
+u/(?P<author>.*)/(?P<charm>.*)/?: /{author}-{charm}
+u/(?P<author>.*)/?: /?q={author}


### PR DESCRIPTION
## Done
- Added redirections for `/u/*` URLs coming from jujucharms.com (https://github.com/canonical-web-and-design/charmhub.io/issues/1004)

## How to QA
- Go to demo `/u/containers/vsphere-integrator` or `/u/dimitern/pinger`
- You should be redirected to `/containers-vsphere-integrator` and `/dimitern-pinger`
- You can find more URLs to QA here [Google search: site:jujucharms.com/u/](https://www.google.com/search?q=site%3Ajujucharms.com)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/1004
