### PR TITLE
Remove sorting on packages.json

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -84,7 +84,7 @@ def get_packages():
         packages.append(package)
 
     return {
-        "packages": sorted(packages, key=lambda c: c["name"]),
+        "packages": packages,
         "q": query,
         "size": total_packages,
     }


### PR DESCRIPTION
## Done
- Remove sorting on packages.json

## How to QA
- Visit the demo in your browser
- Perform a search, like `kubernetes`
- Check that the results are ordered by relevance

## Issue / Card
Fixes #1271
