### PR TITLE
[Topics] Update topic page to handle categories without topics

### DIFF
--- a/templates/topics/index.html
+++ b/templates/topics/index.html
@@ -56,7 +56,6 @@
             <p class="p-card__content">{{ item.description | truncate(202) }}</p>
         </a>
       {% endfor %}
-      <p class="u-hide" data-js="no-topics-message">No topics found</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
- Removed the 'no topics' element
- Updated DOM on load to disable categories without topics
- Removed filters that don't have topics on page load

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit https://charmhub-io-1290.demos.haus/topics
- See that the 'Security' topic is disabled
- Visit https://charmhub-io-1290.demos.haus/topics?filters=security
- See that 'Security' is disabled, unchecked and the topics displayed are all topics.

## Issue / Card
Fixes #1288

## Screenshots
![image](https://user-images.githubusercontent.com/479384/159011234-d99db9e3-92fb-482b-9f6e-4c22fb78e6e1.png)
