### PR TITLE
Better formatting for docstring functions

### DIFF
--- a/templates/details/libraries/docstring.html
+++ b/templates/details/libraries/docstring.html
@@ -43,8 +43,15 @@
           <h4 id="{{ group['name'].lower() }}" class="p-docstring-block__heading">
             {% if group["type"].lower() == "function" %}
               <span class="token keyword">def</span>
-              <span class="token function">{{ group["name"] }}(</span>{% for arg in group["arguments"] %}<span class="token string">{{ arg }}</span>{% endfor %}
-              <span class="token function u-no-horizontal-space">)</span>
+              <span class="token function">{{ group["name"] }}(</span>
+              {% if group["arguments"]|length > 0 %}
+                <br />
+                {% for arg in group["arguments"] %}
+                  &nbsp;&nbsp;&nbsp;&nbsp;<span class="token string">{{ arg }}{{ ", " if not loop.last else "" }}</span>
+                  <br />
+                {% endfor %}
+              {% endif %}
+              <span class="token function">)</span>
               {% elif group["type"].lower() == "class" %}
               <span class="token keyword">{{ group["type"].lower() }}</span>
               <span class="token class-name">{{ group["name"] }}</span>


### PR DESCRIPTION
## Done
- Add better formatting for function signatures

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://charmhub-io-1294.demos.haus/loki-k8s/libraries/loki_push_api#_validate_relation_by_interface_and_direction

## Issue / Card
Partial fix for #1167

## Screenshots
![image](https://user-images.githubusercontent.com/479384/159538821-1a845448-d78c-408e-938c-4fc6f8c73c7d.png)

