### PR TITLE
Vertically align os-logos

### DIFF
--- a/static/sass/_charmhub_p-series-tag.scss
+++ b/static/sass/_charmhub_p-series-tag.scss
@@ -1,8 +1,8 @@
 @mixin charmhub-p-series-tag {
   .series-base {
-    margin-bottom: $spv--medium;
-    display: flex;
     align-items: center;
+    display: flex;
+    margin-bottom: $spv--medium;
 
     @media only screen and (min-width: $breakpoint-x-small) {
       margin-bottom: $spv--small;

--- a/static/sass/_charmhub_p-series-tag.scss
+++ b/static/sass/_charmhub_p-series-tag.scss
@@ -10,11 +10,10 @@
   }
 
   .series-base__title {
-    margin-bottom: $spv--small;
+    margin-bottom: 0;
+    margin-right: 1rem;
 
     @media only screen and (min-width: $breakpoint-x-small) {
-      margin-bottom: 0;
-      margin-right: 1rem;
       min-width: 90px;
     }
   }

--- a/static/sass/_charmhub_p-series-tag.scss
+++ b/static/sass/_charmhub_p-series-tag.scss
@@ -1,10 +1,10 @@
 @mixin charmhub-p-series-tag {
   .series-base {
     margin-bottom: $spv--medium;
+    display: flex;
+    align-items: center;
 
     @media only screen and (min-width: $breakpoint-x-small) {
-      align-items: flex-start;
-      display: flex;
       margin-bottom: $spv--small;
     }
   }


### PR DESCRIPTION
## Done
- Ensure things line up a little nicer

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit https://charmhub-io-1298.demos.haus/slurmd and see that the icons are aligned

## Issue / Card
Fixes #1299

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/479384/159717913-1f10c846-9b68-4d67-957d-9af2d6b4fb63.png)

### After
![image](https://user-images.githubusercontent.com/479384/159717987-b126d71f-a533-4df0-be15-bc904c95003f.png)
