### PR TITLE
Send robots=noindex if charm/bundle is unlisted

### DIFF
--- a/templates/details/details_layout.html
+++ b/templates/details/details_layout.html
@@ -8,6 +8,12 @@
 {% block meta_image_height %}200{% endblock %}
 {% block meta_image_alt %}{{ package.store_front["display-name"] }} charm logo{% endblock %}
 
+{% block extra_meta %}
+  {% if package.result.unlisted %}
+    <meta name="robots" content="noindex" />
+  {% endif %}
+{% endblock %}
+
 {% block structure_data_markup %}
 <script type="application/ld+json">
  {

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -96,6 +96,7 @@ FIELDS = [
     "result.categories",
     "result.publisher.display-name",
     "result.title",
+    "result.unlisted",
     "channel-map",
     "result.deployable-on",
 ]


### PR DESCRIPTION
## Done
- Request the new 'unlisted' field
- Add robots noindex meta tag if 'unlisted' is true

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit a charm that is unlisted https://charmhub-io-1314.demos.haus/admcleod-magpie - ensure all the tabs contain the `<meta name="robots" content="noindex" />` tag in the `<head>`
- Visit a charm that isn't unlisted https://charmhub-io-1314.demos.haus/graylog-k8s - ensure all the tabs *don't* contain the meta tag

## Issue / Card
Fixes #1304 
