### PR TITLE
Add 'Operator's Corner' topic

### DIFF
--- a/webapp/topics/topics.json
+++ b/webapp/topics/topics.json
@@ -19,5 +19,12 @@
         "topic_id": 5832,
         "description": "Juju and Charms are the easiest way to quickly try FINOS projects in your laptop. Here you can also find information about enterprise-grade deployment options that covers day-2 operations.",
         "categories": ["featured", "cloud", "big-data"]
+    },
+    {
+        "name": "Operator’s Corner",
+        "slug": "operators-corner",
+        "topic_id": 5990,
+        "description": "Welcome to the Operator’s Corner, where you can find information about the best practices on developing your Charmed Operators!",
+        "categories": ["cloud"]
     }
 ]


### PR DESCRIPTION
## Done
- Add 'Operator's Corner' topic (https://discourse.charmhub.io/t/operators-corner/5990) Author: Pedro Leão da Cruz @pedroleaoc 

## How to QA
- Visit the demo in your browser
- Filter by the cloud category and see if the topic is there.
- Perform a custom search related to this topic and see if the topic appears.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/marketplace-tribe/issues/2464
