### PR TITLE
Update topics filters list

### DIFF
--- a/static/sass/_pattern_l-fluid-breakout.scss
+++ b/static/sass/_pattern_l-fluid-breakout.scss
@@ -18,7 +18,8 @@
         }
       }
 
-      .p-side-navigation:target .p-side-navigation__drawer {
+      .p-side-navigation:target .p-side-navigation__drawer,
+      .p-side-navigation.is-expanded .p-side-navigation__drawer {
         @media (max-width: $breakpoint-large - 1px) {
           position: fixed;
           transform: translateX(0);

--- a/templates/topics/index.html
+++ b/templates/topics/index.html
@@ -32,7 +32,7 @@
           <div class="p-side-navigation__drawer-header">
             <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" data-js="filter-button-mobile-close" aria-controls="drawer">Hide filters</a>
           </div>
-          <h3 class="p-heading--5" style="color: #111;">Categories</h3>
+          <h3 class="p-muted-heading">Filters</h3>
           <form>
             <ul class="p-side-navigation__list">
               {% for cat in categories %}


### PR DESCRIPTION
## Done
- Updated CSS to ensure the `is-expanded` show's the side-nav

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
-Visit https://charmhub-io-1322.demos.haus/topics make your browser narrow and flick the 'filters' button

## Issue / Card
Fixes #1320 

## Screenshots
![image](https://user-images.githubusercontent.com/479384/162225562-4295448e-dd9c-410a-91cf-1be8f42f471c.png)