### PR TITLE
Remove unused canonicalwebteam.search dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ beautifulsoup4==4.10.0
 canonicalwebteam.candid==0.9.0
 canonicalwebteam.discourse==4.0.8
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.search==1.1.0
 canonicalwebteam.store-api==3.2.9
 canonicalwebteam.docstring-extractor==1.1.0
 Flask-WTF==0.15.1


### PR DESCRIPTION
Since docs were removed in 9c618fe30945fd85164bdeff687de80cd3602722,
this module doesn't appear to be used by this site anywhere.
