### PR TITLE
Increase width of embedded cards on smaller screen

### DIFF
--- a/webapp/topics/views.py
+++ b/webapp/topics/views.py
@@ -87,7 +87,7 @@ class TopicParser(DocParser):
                 "{% for package in packages %}"
                 '<div class="col-small-5 col-medium-3 col-3">'
                 '<iframe src="{{ package }}/embedded?store_design=true" '
-                'frameborder="0" width="266px" height="266px" '
+                'frameborder="0" width="100%" height="266px" '
                 'style="border: 0"></iframe>'
                 "</div>"
                 "{% endfor %}"


### PR DESCRIPTION
## Done
- Change embed to be 100% width to fill it's container

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit https://charmhub-io-1327.demos.haus/topics/kubeflow
- Resize the browser

## Issue / Card
Fixes #1287 

## Screenshots
Full width page:
![image](https://user-images.githubusercontent.com/479384/162928515-7e90c00f-c57f-4a78-8387-b821ba3e40a0.png)

Medium width page:
![image](https://user-images.githubusercontent.com/479384/162928603-43645bd2-14b3-4e1a-b577-9898d37a8539.png)

Small page:
![image](https://user-images.githubusercontent.com/479384/162928689-7997d6a3-51d5-41d6-b653-cf6411e9c62f.png)

