### PR TITLE
Embedded 404 page

### DIFF
--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -47,7 +47,7 @@
     clip-path: url("#animation-mask");
   }
 
-  a.p-card--button {
+  .p-card--button {
     @extend %vf-has-box-shadow;
     @extend %vf-has-round-corners;
 
@@ -181,5 +181,10 @@
     &:visited {
       color: $color-dark;
     }
+  }
+
+  #not-found .p-card__thumbnail,
+  #not-found .p-card__thumbnail-container {
+    border-radius: 0;
   }
 }

--- a/templates/embeddable-404.html
+++ b/templates/embeddable-404.html
@@ -53,23 +53,17 @@
     </span>
   </div>
   {% else %}
-  <div  style="padding: 2px;">
-    <div class="p-card--button" style="display: block; margin-bottom: 0;">
-    </div>
-  </div>
-  <caption>
     <div class="p-strip">
       <div class="row">
-        <div class="u-align--right col-4 col-medium-2 col-small-1">
+        <div class="u-align--right col-small-1 col-medium-1 col-2">
           <img src="https://assets.ubuntu.com/v1/4de1c56c-404_v1.svg" alt="Charm not found">
         </div>
-        <div class="u-align--left col-8 col-medium-4 col-small-3">
+        <div class="u-align--left col-small-3 col-medium-5 col-10">
           <p class="p-heading--4 u-no-margin--bottom">"{{ entity_name }}" not found</p>
-          <p class="u-hide--small">The requested charm or bundle could not be found, sorry.</p>
+          <p>The requested charm or bundle could not be found, sorry.</p>
         </div>
       </div>
     </div>
-  </caption>
   {% endif %}
 </body>
 

--- a/templates/embeddable-404.html
+++ b/templates/embeddable-404.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block meta_title %}Charmhub - The Open Operator Collection{% endblock %}</title>
+
+  <!-- Preconnect to establish early connections to important third-party origins -->
+  <link rel="preconnect" href="https://assets.ubuntu.com">
+
+  {% if store_design %}
+  <link rel="stylesheet" type="text/css" media="screen" href="/static/css/styles.css" />
+  {% else %}
+  <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles-embedded.css') }}" />
+  {% endif %}
+
+  <meta name="description" content="{% block meta_description %}Universal operators for application lifecycle management on Linux, Windows and Kubernetes.{% endblock %}">
+  <meta name="robots" content="noindex">
+
+  <meta property="og:title" content="{{ self.meta_title() }}" />
+  <meta property="og:site_name" content="Charmhub" />
+  <meta property="og:type" content="{% block meta_type %}website{% endblock %}" />
+  <meta property="og:description" content="{{ self.meta_description() }}" />
+  <meta property="og:image" content="{% block meta_image %}https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_1080,h_512/https://assets.ubuntu.com/v1/3f1974e5-CH+Logo+Metadata.jpg{% endblock %}" />
+  <meta property="og:url" content="https://charmhub.io" />
+
+  <meta property="twitter:card" content="summary_large_image" />
+  <meta property="twitter:site" content="@ubuntucloud" />
+  <meta property="twitter:creator" content="@ubuntucloud" />
+  <meta property="twitter:url" content="https://charmhub.io" />
+
+  <link rel="apple-touch-icon" href="https://assets.ubuntu.com/v1/905b8df0-apple-touch-icon-180x180-precomposed.png" />
+  <base target="_blank">
+</head>
+
+<body>
+  {% if store_design %}
+    <div id="not-found" style="padding: 2px;">
+    <span class="p-card--button" style="display: block; margin-bottom: 0;">
+      <div class="p-card__header">
+        
+        <div class="p-card__thumbnail-container">
+          <img src="https://assets.ubuntu.com/v1/4de1c56c-404_v1.svg" alt="Not found" class="p-card__thumbnail" style="border-radius: 0" loading="lazy" width="40" height="40">
+        </div>
+
+        <h3 class="p-card__title p-heading--4 u-no-margin--bottom package-card-title" style="white-space: nowrap;overflow: hidden;text-overflow: ellipsis;">"{{ entity_name }}" not found</h3>
+      </div>
+      <div class="p-card__content" style="height: 5rem; max-height: 5rem;">
+        <p><small class="package-card-summary">The requested charm or bundle could not be found, sorry.</small></p>
+      </div>
+    </span>
+  </div>
+  {% else %}
+  <div  style="padding: 2px;">
+    <div class="p-card--button" style="display: block; margin-bottom: 0;">
+    </div>
+  </div>
+  <caption>
+    <div class="p-strip">
+      <div class="row">
+        <div class="u-align--right col-4 col-medium-2 col-small-1">
+          <img src="https://assets.ubuntu.com/v1/4de1c56c-404_v1.svg" alt="Charm not found">
+        </div>
+        <div class="u-align--left col-8 col-medium-4 col-small-3">
+          <p class="p-heading--4 u-no-margin--bottom">"{{ entity_name }}" not found</p>
+          <p class="u-hide--small">The requested charm or bundle could not be found, sorry.</p>
+        </div>
+      </div>
+    </div>
+  </caption>
+  {% endif %}
+</body>
+
+</html>

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -560,8 +560,10 @@ def entity_embedded_card(entity_name):
     try:
         package = get_package(entity_name, channel_request, FIELDS)
 
-        package["default-release"]["channel"]["released-at"] = logic.convert_date(
-            package["default-release"]["channel"]["released-at"]
+        package["default-release"]["channel"]["released-at"] = (
+            logic.convert_date(
+                package["default-release"]["channel"]["released-at"]
+            )
         )
 
         button = request.args.get("button")

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -560,10 +560,10 @@ def entity_embedded_card(entity_name):
     try:
         package = get_package(entity_name, channel_request, FIELDS)
 
-        package["default-release"]["channel"]["released-at"] = (
-            logic.convert_date(
-                package["default-release"]["channel"]["released-at"]
-            )
+        package["default-release"]["channel"][
+            "released-at"
+        ] = logic.convert_date(
+            package["default-release"]["channel"]["released-at"]
         )
 
         button = request.args.get("button")
@@ -587,7 +587,7 @@ def entity_embedded_card(entity_name):
         return render_template(
             "embeddable-404.html",
             store_design=store_design,
-            entity_name=entity_name
+            entity_name=entity_name,
         )
 
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -588,7 +588,7 @@ def entity_embedded_card(entity_name):
             "embeddable-404.html",
             store_design=store_design,
             entity_name=entity_name,
-        )
+        ), 404
 
 
 @store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/icon')

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -584,11 +584,14 @@ def entity_embedded_card(entity_name):
             **context,
         )
     except Exception:
-        return render_template(
-            "embeddable-404.html",
-            store_design=store_design,
-            entity_name=entity_name,
-        ), 404
+        return (
+            render_template(
+                "embeddable-404.html",
+                store_design=store_design,
+                entity_name=entity_name,
+            ),
+            404,
+        )
 
 
 @store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/icon')

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -557,29 +557,36 @@ def entity_badge(entity_name):
 def entity_embedded_card(entity_name):
     store_design = request.args.get("store_design", default=False, type=bool)
     channel_request = request.args.get("channel", default=None, type=str)
-    package = get_package(entity_name, channel_request, FIELDS)
+    try:
+        package = get_package(entity_name, channel_request, FIELDS)
 
-    package["default-release"]["channel"]["released-at"] = logic.convert_date(
-        package["default-release"]["channel"]["released-at"]
-    )
+        package["default-release"]["channel"]["released-at"] = logic.convert_date(
+            package["default-release"]["channel"]["released-at"]
+        )
 
-    button = request.args.get("button")
-    if button and button not in ["black", "white"]:
-        button = None
+        button = request.args.get("button")
+        if button and button not in ["black", "white"]:
+            button = None
 
-    context = {
-        "store_design": store_design,
-        "button": button,
-        "package": package,
-        "show_channels": request.args.get("channels"),
-        "show_summary": request.args.get("summary"),
-        "show_base": request.args.get("base"),
-    }
+        context = {
+            "store_design": store_design,
+            "button": button,
+            "package": package,
+            "show_channels": request.args.get("channels"),
+            "show_summary": request.args.get("summary"),
+            "show_base": request.args.get("base"),
+        }
 
-    return render_template(
-        "embeddable-card.html",
-        **context,
-    )
+        return render_template(
+            "embeddable-card.html",
+            **context,
+        )
+    except Exception:
+        return render_template(
+            "embeddable-404.html",
+            store_design=store_design,
+            entity_name=entity_name
+        )
 
 
 @store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/icon')


### PR DESCRIPTION
## Done
- In the embedded view, capture exceptions and show an error page

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit https://charmhub-io-1329.demos.haus/hello/embedded and https://charmhub-io-1329.demos.haus/hello/embedded?store_design=true

## Issue / Card
Fixes #1274 

## Screenshots
In-store:
![image](https://user-images.githubusercontent.com/479384/163993906-59a88964-8d92-4194-99e7-a383f46742d3.png)
General embed:
![image](https://user-images.githubusercontent.com/479384/163993946-af7161d9-ffca-4d68-a384-5a17fc4eb64b.png)

