### PR TITLE
Fix homepage link color

### DIFF
--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -52,7 +52,7 @@
     @extend %vf-has-round-corners;
 
     background-color: $color-x-light;
-    color: $color-dark;
+    color: $color-dark !important;
     display: grid;
     grid-template-rows: 9.5rem 3.9rem;
 


### PR DESCRIPTION
## Done
Fixed homepage link colours in cards

## QA 
- Go to https://charmhub-io-1335.demos.haus/
- Check that the text in the cards is black

## Issue
Fixes #1334 
