### PR TITLE
Add ids to readme headers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ humanize==2.6.0
 mistune==0.8.4
 pybadges==3.0.0
 pymacaroons==0.13.0
+python-slugify==6.1.1
 ruamel.yaml.clib==0.2.2
 ruamel.yaml==0.16.12

--- a/static/js/src/public/details/index.js
+++ b/static/js/src/public/details/index.js
@@ -2,12 +2,6 @@ import { HistoryState } from "./historyState";
 import { TableOfContents } from "./tableOfContents";
 import { channelMap } from "./channelMap";
 
-if (window.location.hash) {
-  setTimeout(() => {
-    window.scrollTo(0, 0);
-  }, 1);
-}
-
 const init = (packageName) => {
   const historyState = new HistoryState();
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -272,6 +272,25 @@ body {
   .p-details-tab__content__body * {
     text-align: left;
   }
+
+  .p-details-tab__content__body {
+    h1[id],
+    h2[id],
+    h3[id],
+    h4[id],
+    h5[id],
+    h6[id] {
+      margin-top: -65px;
+
+      &::before {
+        content: " ";
+        display: block;
+        height: 65px;
+        pointer-events: none;
+        visibility: hidden;
+      }
+    }
+  }
 }
 
 .row,

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -19,7 +19,12 @@ from webapp.decorators import (
     redirect_uppercase_to_lowercase,
     store_maintenance,
 )
-from webapp.helpers import decrease_headers, discourse_api, md_parser
+from webapp.helpers import (
+    add_header_ids,
+    decrease_headers,
+    discourse_api,
+    md_parser,
+)
 from webapp.store import logic
 from webapp.topics.views import topic_list
 
@@ -155,6 +160,7 @@ def details_overview(entity_name):
 
     readme = md_parser(readme)
     readme = decrease_headers(readme)
+    readme = add_header_ids(readme)
     return render_template(
         "details/overview.html",
         package=package,


### PR DESCRIPTION
## Done
- Generate a slug for all headings in the README
- Apply the slug for any heading that doesn't already have an id
- Remove JS that stopped scrolling of the page if there was a location hash
- Add CSS so when the page scrolls the title isn't blocked by the header

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://localhost:8045/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit https://charmhub-io-1337.demos.haus/nova-compute#usage--availability-zones the page should scroll down to the appropriate section

## Issue / Card
Fixes #1296

