### PR TITLE
Temporarily remove "What is Charmhub" from the footer

### DIFF
--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -10,9 +10,9 @@
           <a class="p-link--soft" href="https://juju.is/#what-is-juju"><small>What is Juju?</small></a>
         </li>
 
-        <li class="p-list__item">
+        <!--<li class="p-list__item">
           <a class="p-link--soft" href="https://charmhub.io"><small>What is Charmhub?</small></a>
-        </li>
+        </li>-->
 
         <li class="p-list__item">
           <a class="p-link--soft" href="https://juju.is/docs/olm/quick-reference"><small>What are Charmed Operators?</small></a>


### PR DESCRIPTION
## Done
- Removed the footer link to "What is Charmhub?" - it's a dead link and there's no clear direction for it

## How to QA
- Run the site and check the footer doesn't contain "What is Charmhub?"

## Issue / Card
Fixes #1190

