### PR TITLE
Fix duplicate platforms on Charm details pages

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -102,30 +102,28 @@
       {% else %}
         {% for track, track_data in package.store_front.channel_map.items() %}
           {% for channel, channel_data in track_data.items() %}
-            {% if channel == package["default-release"]["channel"]["name"] %}
-              {% if channel_data.latest["channel_bases"] %}
-                {% for base in channel_data.latest["channel_bases"] %}
-                  <div class="series-base">
-                    <div class="series-base__title">
-                      {% if base["name"] == "ubuntu" %}
-                        <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20" class="p-image--base">
-                      {% elif base["name"] == "centos" %}
-                        <img src="https://assets.ubuntu.com/v1/fd5cc5d8-CentOS.svg" alt="CentOS" width="85" height="24" class="p-image--base">
-                      {% else %}
-                        {{ base["name"] }}
-                      {% endif %}
-                    </div>
-                    <div>
-                      {% for channel in base["channels"] %}
-                        <span class="series-tag">
-                          {{ channel }}
-                        </span>
-                      {% endfor %}
-                    </div>
+            {% for base in channel_data.latest["channel_bases"] %}
+              {% if track == package["default-release"].channel.track and channel == package["default-release"].channel.risk %}
+                <div class="series-base">
+                  <div class="series-base__title">
+                    {% if base["name"] == "ubuntu" %}
+                      <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20" class="p-image--base">
+                    {% elif base["name"] == "centos" %}
+                      <img src="https://assets.ubuntu.com/v1/fd5cc5d8-CentOS.svg" alt="CentOS" width="85" height="24" class="p-image--base">
+                    {% else %}
+                      {{ base["name"] }}
+                    {% endif %}
                   </div>
-                {% endfor %}
+                  <div>
+                    {% for channel in base["channels"] %}
+                      <span class="series-tag">
+                        {{ channel }}
+                      </span>
+                    {% endfor %}
+                  </div>
+                </div>
               {% endif %}
-            {% endif %}
+            {% endfor %}
           {% endfor %}
         {% endfor %}
       {% endif %}


### PR DESCRIPTION
## Done
Fixed platforms from all tracks showing at the same time on the charm detail pages

## QA
- Go to https://charmhub-io-1348.demos.haus/kafka
  - Change the channels
  - Check that there are no duplicate platforms
  - Check that the platform versions match those in the channels dropdown
- Go to https://charmhub-io-1348.demos.haus/keystone-kerberos
  - Change the channels
  - Check that there are no duplicate platforms
  - Check that the platform versions match those in the channels dropdown

## Issue
Fixes #1346 