### PR TITLE
Add "Runs on" column to embeddable cards

### DIFF
--- a/templates/embeddable-card.html
+++ b/templates/embeddable-card.html
@@ -174,14 +174,14 @@
             <td>{{ channel_data.latest.version }}</td>
             <td>{{ channel_data.latest.released_at }}</td>
             {% if show_base %}
-	      <td>
+              <td>
                 <div class="series-tags u-no-margin--top">
                   {% for base in channel_data.latest.bases %}
                     <span class="series-tag">{{ base }}</span>
                   {% endfor %}
                 </div>
               </td>
-	    {% endif %}
+            {% endif %}
           </tr>
           {% endfor %}
           {% endfor %}
@@ -190,15 +190,15 @@
             <td>{{ package["default-release"]["channel"]["track"] }}/{{ package["default-release"]["channel"]["risk"] }}</td>
             <td>{{ package["default-release"]["revision"]["version"] }}</td>
             <td>{{ package["default-release"]["channel"]["released-at"] }}</td>
-	    {% if show_base %}
-	      <td>
-		<div class="series-tags u-no-margin--top">
+            {% if show_base %}
+              <td>
+                <div class="series-tags u-no-margin--top">
                 {% for base in package["default-release"]["revision"]["bases"] %}
                   <span class="series-tag">{{ base.name }} {{ base.channel }}</span>
                 {% endfor %}
-              </div>
-	      </td>
-	     {% endif %}
+                </div>
+              </td>
+            {% endif %}
           </tr>
           {% endif %}
         </tbody>

--- a/templates/embeddable-card.html
+++ b/templates/embeddable-card.html
@@ -162,6 +162,7 @@
             <th>Channel</th>
             <th>Version</th>
             <th>Published</th>
+            {% if show_base %}<th>Runs on</td>{% endif %}
           </tr>
         </thead>
         <tbody>
@@ -172,6 +173,15 @@
             <td>{{ track }}/{{ channel }}</td>
             <td>{{ channel_data.latest.version }}</td>
             <td>{{ channel_data.latest.released_at }}</td>
+            {% if show_base %}
+	      <td>
+                <div class="series-tags u-no-margin--top">
+                  {% for base in channel_data.latest.bases %}
+                    <span class="series-tag">{{ base }}</span>
+                  {% endfor %}
+                </div>
+              </td>
+	    {% endif %}
           </tr>
           {% endfor %}
           {% endfor %}
@@ -180,6 +190,15 @@
             <td>{{ package["default-release"]["channel"]["track"] }}/{{ package["default-release"]["channel"]["risk"] }}</td>
             <td>{{ package["default-release"]["revision"]["version"] }}</td>
             <td>{{ package["default-release"]["channel"]["released-at"] }}</td>
+	    {% if show_base %}
+	      <td>
+		<div class="series-tags u-no-margin--top">
+                {% for base in package["default-release"]["revision"]["bases"] %}
+                  <span class="series-tag">{{ base.name }} {{ base.channel }}</span>
+                {% endfor %}
+              </div>
+	      </td>
+	     {% endif %}
           </tr>
           {% endif %}
         </tbody>

--- a/templates/publisher/publicise/embedded_cards.html
+++ b/templates/publisher/publicise/embedded_cards.html
@@ -22,12 +22,12 @@
       Options:
     </div>
     <div class="col-7" data-js="options">
-      <input type="checkbox" name="show-base" id="option-show-base" checked>
-      <label for="option-show-base">Supported base</label>
       <input type="checkbox" name="show-channels" id="option-show-channels" checked>
       <label for="option-show-channels">All channels</label>
       <input type="checkbox" name="show-summary" id="option-show-summary" checked>
       <label for="option-show-summary">Show summary</label>
+      <input type="checkbox" name="show-base" id="option-show-base" checked>
+      <label for="option-show-base">Show runs on</label>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done
- Implemented the "base" flag (wasn't doing anything before)
- Renamed the label to "Runs on"
- If "Runs on" is checked, show the "runs on" column

## How to QA
- Visit the demo https://charmhub-io-1361.demos.haus/landscape-keystone/publicise/cards or visit the embedded card directly and change params https://charmhub-io-1361.demos.haus/landscape-keystone/embedded?button=black&channels=true&summary=true&base=true
- check and uncheck the toggles

## Issue / Card
Fixes #1076 

## Screenshots
![image](https://user-images.githubusercontent.com/479384/173869703-f29ba9dc-0a9a-4fd4-bde8-647798a4096e.png)