### PR TITLE
New filter for package type

### DIFF
--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -347,11 +347,15 @@ class initPackages {
       filter.disabled = false;
     });
 
-    // If the user is using the patform or type filters
-    if (this._filters.base[0] !== "all" || this._filters.type[0] !== "all") {
+    // If the user is searching or using filters
+    if (
+      this._filters.q.length > 0 ||
+      this._filters.base[0] !== "all" ||
+      this._filters.type[0] !== "all"
+    ) {
       const categories = [];
 
-      this.packages.forEach((entity) => {
+      this.filteredPackagesAllCategories.forEach((entity) => {
         if (entity.store_front.categories) {
           entity.store_front.categories.forEach((cat) => {
             if (!categories.includes(cat.slug)) {
@@ -428,6 +432,8 @@ class initPackages {
         entity["type"].includes(this._filters.type[0])
       );
     }
+
+    this.filteredPackagesAllCategories = this.packages;
 
     if (this._filters.filter.length > 0) {
       this.packages = this.packages.filter((entity) =>

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -390,6 +390,19 @@ h3 {
   border-top: 3px solid $color-accent;
 }
 
+.l-fluid-breakout__aside .p-side-navigation__form {
+  margin-bottom: 1rem;
+
+  @media (max-width: $breakpoint-large - 1) {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .p-form__label {
+    min-width: 5rem;
+  }
+}
+
 .l-fluid-section {
   grid-column: 1/-1;
   margin-bottom: 1rem;

--- a/templates/store.html
+++ b/templates/store.html
@@ -37,6 +37,37 @@
               </ul>
               {% endif %}
             </form>
+
+            <div class="p-side-navigation__form">
+              <div class="p-container--inline">
+                <form class="p-form p-form--inline u-flex">
+                  <div class="p-form__group u-no-margin--right" style="flex-grow: 1;">
+                    <label for="base" aria-label="Filter platforms" class="p-form__label u-no-margin--bottom">Platform</label>
+                    <select name="base" data-js="base-handler" class="p-form__control u-no-margin--bottom" value="{{ base }}" id="base" disabled style="min-width: unset;">
+                      <option value="all" {% if active_filter('base', 'all' ) %}selected{% endif %}>All</option>
+                      <option value="vm" {% if active_filter('base', 'vm' ) %}selected{% endif %}>VM</option>
+                      <option value="kubernetes" {% if active_filter('base', 'kubernetes' ) %}selected{% endif %}>Kubernetes</option>
+                    </select>
+                  </div>
+                </form>
+              </div>
+            </div>
+
+            <div class="p-side-navigation__form">
+              <div class="p-container--inline">
+                <form class="p-form p-form--inline u-flex">
+                  <div class="p-form__group u-no-margin--right" style="flex-grow: 1;">
+                    <label for="type" aria-label="Filter type" class="p-form__label u-no-margin--bottom">Filter by</label>
+                    <select name="type" data-js="package-type-handler" class="p-form__control u-no-margin--bottom" value="{{ type }}" id="type" disabled style="min-width: unset;">
+                      <option value="all" {% if active_filter('type', 'all' ) %}selected{% endif %}>All</option>
+                      <option value="charm" {% if active_filter('type', 'charm' ) %}selected{% endif %}>Charms</option>
+                      <option value="bundle" {% if active_filter('type', 'bundle' ) %}selected{% endif %}>Bundles</option>
+                    </select>
+                  </div>
+                </form>
+              </div>
+            </div>
+
           </nav>
         </div>
       </div>
@@ -56,16 +87,6 @@
               </form>
               <div class="p-container--inline">
                 <a href="#drawer" class="p-button has-icon u-hide--large js-drawer-toggle u-align--left" data-js="filter-button-mobile-open"><i class="p-icon--arrow-right"></i><span>Filters</span></a>
-                <form class="p-form p-form--inline">
-                  <div class="p-form__group u-no-margin--right">
-                    <label for="base" aria-label="Filter platforms" class="p-form__label u-no-margin--bottom u-hide--small u-hide--medium">Platform</label>
-                    <select name="base" data-js="base-handler" class="p-form__control u-no-margin--bottom" value="{{ base }}" id="base" disabled>
-                      <option value="all" {% if active_filter('base', 'all' ) %}selected{% endif %}>All</option>
-                      <option value="vm" {% if active_filter('base', 'vm' ) %}selected{% endif %}>VM</option>
-                      <option value="kubernetes" {% if active_filter('base', 'kubernetes' ) %}selected{% endif %}>Kubernetes</option>
-                    </select>
-                  </div>
-                </form>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Done
- New filter for the package type. It's possible to filter by **charm** or **bundle**.
- Move filters to the sidenav

**Note:** We discovered that the bundles come from the API without categories (with the exception of Linstor). This bug was reported to the store team on https://bugs.launchpad.net/snapstore-server/+bug/1979343


## How to QA
- Visit the demo in your browser
- Use all the filters on the homepage and try the mobile version as well

## Issue / Card
Fixes #1358
