### PR TITLE
Add subordinate label to details pages

### DIFF
--- a/templates/details/overview.html
+++ b/templates/details/overview.html
@@ -11,6 +11,9 @@
           <span data-js="summary-content" style="overflow-wrap: break-word;">{{ package.result.summary }}</span>
           <a href="/{{ package.name }}" class="is-always-color-link u-hide" data-js="summary-read-more">Read more</a>
         </p>
+        {% if package["default-release"].revision.subordinate %}
+          <div class="p-status-label--information">Subordinate</div>
+        {% endif %}
         <hr class="p-separator--shallow">
       {% endif %}
       <!-- Once there is a topology image available, uncomment the section below -->


### PR DESCRIPTION
## Done
Added a status label to subordinate charm details pages

## QA
- Go to https://charmhub-io-1366.demos.haus/nrpe
- Check that there is a "Subordinate" label in the sidebar
- Go to https://charmhub-io-1366.demos.haus/mongodb-k8s
- Check that there is not a "Subordinate" label in the sidebar

## Issue
Fixes https://github.com/canonical-web-and-design/charmhub.io/issues/1015