### PR TITLE
Fix notification markup

### DIFF
--- a/templates/details/configure-bundle.html
+++ b/templates/details/configure-bundle.html
@@ -36,18 +36,22 @@
     {% else %}
       <h3>{{ subpackage.name }}</h3>
       <div class="p-notification--information">
-        <p class="p-notification__response">
-          No configuration details have been added for this charm yet.
-        </p>
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            No configuration details have been added for this charm yet.
+          </p>
+        </div>
       </div>
     {% endif %}
   </div>
   {% else %}
   <div class="col-12">
     <div class="p-notification--information">
-      <p class="p-notification__response">
-        No configuration details have been added for this bundle yet.
-      </p>
+      <div class="p-notification__content">
+        <p class="p-notification__message">
+          No configuration details have been added for this bundle yet.
+        </p>
+      </div>
     </div>
   </div>
   {% endif %}

--- a/templates/details/configure-charm.html
+++ b/templates/details/configure-charm.html
@@ -33,9 +33,11 @@
   </div>
   {% else %}
   <div class="p-notification--information">
-    <p class="p-notification__response">
-      No configuration details have been added yet.
-    </p>
+    <div class="p-notification__content">
+      <p class="p-notification__message">
+        No configuration details have been added yet.
+      </p>
+    </div>
   </div>
   {% endif %}
 </div>

--- a/templates/details/docs.html
+++ b/templates/details/docs.html
@@ -69,18 +69,22 @@
               Most of this documentation can be collaboratively discussed and changed on the respective topic in the doc category of the <a href="{{ forum_url }}" class="p-link--external">Charmhub forum</a>. See the <a href="https://discourse.charmhub.io/t/how-to-write-docs-our-documentation-guidelines-for-contributors/1245" class="p-link--external">documentation guidelines</a> if you’d like to contribute.
             </p>
             <div class="p-notification--information">
-              <p class="p-notification__response">
-                Last updated {{ last_update }}. <a href="{{ forum_url }}{{ topic_path }}" class="p-link--external">Help improve this document in the forum</a>.
-              </p>
+              <div class="p-notification__content">
+                <p class="p-notification__message">
+                  Last updated {{ last_update }}. <a href="{{ forum_url }}{{ topic_path }}" class="p-link--external">Help improve this document in the forum</a>.
+                </p>
+              </div>
             </div>
           </div>
         </div>
       </div>
     {% else %}
       <div class="p-notification--information">
-        <p class="p-notification__response">
-          No documentation has been added yet.
-        </p>
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            No documentation has been added yet.
+          </p>
+        </div>
       </div>
     {% endif %}
   </div>

--- a/templates/publisher/list.html
+++ b/templates/publisher/list.html
@@ -31,10 +31,12 @@
     <div class="u-fixed-width">
       {% for category, message in messages %}
       <div id="notification" class="p-notification p-notification--{{ category }}">
-        <p class="p-notification__response">
-          {{ message }}
-        </p>
-        <button class="p-icon--close" aria-label="Close notification" aria-controls="notification">Close</button>
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            {{ message }}
+          </p>
+        </div>
+        <button class="p-notification__close" aria-label="Close notification" aria-controls="notification">Close</button>
       </div>
       {% endfor %}
     </div>

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -33,9 +33,11 @@
       <div class="u-fixed-width">
         {% for category, message in messages %}
         <div id="market-form-status" class="p-notification--{{ category }}">
-          <p class="p-notification__response">
-            {{ message }}
-          </p>
+          <div class="p-notification__content">
+            <p class="p-notification__message">
+              {{ message }}
+            </p>
+          </div>
         </div>
         {% endfor %}
       </div>

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -14,9 +14,11 @@
       <div class="u-fixed-width">
         {% for category, message in messages %}
         <div id="market-form-status" class="p-notification--{{ category }}">
-          <p class="p-notification__response">
-            {{ message }}
-          </p>
+          <div class="p-notification__content">
+            <p class="p-notification__message">
+              {{ message }}
+            </p>
+          </div>
         </div>
         {% endfor %}
       </div>


### PR DESCRIPTION
## Done
Fixed the notification markup

## QA
- Go to https://charmhub-io-1369.demos.haus/charms
- Register a charm name
- The notification close button should be in the top right

## Issue
Fixes #1368