### PR TITLE
Make PR checks badge use correct branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![charmhub.io](https://user-images.githubusercontent.com/6353928/94026467-9dff1480-fdb1-11ea-8026-e866246815fc.png "Charmhub") charmhub.io codebase
 
-![Github Actions Status](https://github.com/canonical-web-and-design/charmhub.io/workflows/PR%20checks/badge.svg?branch=master) [![Code coverage](https://codecov.io/gh/canonical-web-and-design/charmhub.io/branch/main/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/charmhub.io)
+![Github Actions Status](https://github.com/canonical-web-and-design/charmhub.io/workflows/PR%20checks/badge.svg?branch=main) [![Code coverage](https://codecov.io/gh/canonical-web-and-design/charmhub.io/branch/main/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/charmhub.io)
 
 A charm is a software package that bundles an operator together with metadata that supports the integration of many operators in a coherent aggregated system.
 


### PR DESCRIPTION
## Done 
Changed the PR checks badge in the README to use `main` instead of `master`

## Issue
Fixes #1372 