### PR TITLE
Smaller card icons

### DIFF
--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -36,13 +36,12 @@
     }
 
     animation: shine 3s infinite ease-in-out;
-    background-image:
-      linear-gradient(
-        to bottom right,
-        $color-mid-x-light calc(50% - 2rem),
-        $color-light 50%,
-        $color-mid-x-light calc(50% + 2rem)
-      );
+    background-image: linear-gradient(
+      to bottom right,
+      $color-mid-x-light calc(50% - 2rem),
+      $color-light 50%,
+      $color-mid-x-light calc(50% + 2rem)
+    );
     background-size: 300% 300%;
     clip-path: url("#animation-mask");
   }
@@ -81,21 +80,17 @@
 
     .p-card__thumbnail {
       border-radius: 50%;
-      height: 2.5rem;
+      height: 1.5rem;
       max-height: none;
-      width: 2.5rem;
+      width: 1.5rem;
     }
 
     .p-card__thumbnail-container {
       border-radius: 50%;
-      height: 2.5rem;
+      height: 1.5rem;
       margin-block-end: 0.375rem;
       overflow: hidden;
-      width: 2.5rem;
-
-      .p-card__thumbnail {
-        transform: scale(1.1);
-      }
+      width: 1.5rem;
     }
 
     .p-card__content {

--- a/templates/partial/_featured-charms.html
+++ b/templates/partial/_featured-charms.html
@@ -4,9 +4,9 @@
       <div class="p-card__header">
         <div class="p-card__thumbnail-container">
           {% if charm.result.media %}
-            <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_64,h_64/{{ charm['result']['media'][0]['url'] }}" width="64" height="64" class="p-card__thumbnail" alt="{{ charm['name'] }}">
+            <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_24,h_24/{{ charm['result']['media'][0]['url'] }}" width="24" height="24" class="p-card__thumbnail" alt="{{ charm['name'] }}">
             {% else %}
-            <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_64,h_64/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" width="64" height="64" class="p-card__thumbnail" alt="{{ charm['name'] }}">
+            <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_24,h_24/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" width="24" height="24" class="p-card__thumbnail" alt="{{ charm['name'] }}">
           {% endif %}
         </div>
         <h3 class="p-card__title p-heading--4 u-no-margin--bottom package-card-title">{{ charm['store_front']['display-name'] | replace("-", " ") }}</h3>

--- a/templates/store.html
+++ b/templates/store.html
@@ -134,7 +134,7 @@
       <a href="" class="p-card--button">
         <div class="p-card__header">
           <div class="p-card__thumbnail-container">
-            <img src="" alt="" width="40" height="40" class="p-card__thumbnail">
+            <img src="" alt="" width="24" height="24" class="p-card__thumbnail">
           </div>
           <div class="p-bundle-icons" style="margin-block-end: 6px; margin-block-start: 6px;">
             <img src="" alt="">


### PR DESCRIPTION
## Done
- Resize card icon size as per https://app.zeplin.io/project/623c85b9b27d9fa62165f655/screen/624d4b3079f687143e35527e

## How to QA
- Visit the demo, see the homepage card sizes

## Issue / Card
Fixes #

## Screenshots
![image](https://user-images.githubusercontent.com/479384/180462026-ea001445-969e-4951-86dd-6db458dcc76c.png)
