### PR TITLE
New bundle cards

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,6 +11,7 @@
     ],
     "@babel/preset-react"
   ],
+  "plugins": ["@babel/plugin-transform-runtime"],
   "env": {
     "test": {
       "presets": ["@babel/preset-env"]

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@babel/core": "7.16.7",
     "@babel/preset-env": "7.16.8",
     "@babel/preset-react": "7.16.7",
+    "@babel/plugin-transform-runtime": "7.18.9",
     "@canonical/cookie-policy": "3.4.0",
     "autoprefixer": "9.8.8",
     "babel-eslint": "10.1.0",

--- a/static/js/src/public/store/buildPackageCard.js
+++ b/static/js/src/public/store/buildPackageCard.js
@@ -21,7 +21,7 @@ function buildPlatformIcons(entityCardIcons, altText, srcText, text) {
 }
 
 function buildPackageCard(entity) {
-  const entityCard = document.getElementById("package-card");
+  const entityCard = document.getElementById(`package-card-${entity.type}`);
   const clone = entityCard.content.cloneNode(true);
 
   const entityCardContainer = clone.querySelector("[data-js='card-container']");
@@ -30,45 +30,62 @@ function buildPackageCard(entity) {
   const entityCardButton = clone.querySelector(".p-card--button");
   entityCardButton.href = `/${entity.name}`;
 
-  const charmCardThumbnailContainer = clone.querySelector(
-    ".p-card__thumbnail-container"
-  );
-  const bundleCardThumbnailContainer = clone.querySelector(".p-bundle-icons");
+  const iconContainer = clone.querySelector(".p-card__thumbnail-container");
 
   if (entity.type === "charm") {
-    bundleCardThumbnailContainer.remove();
-    const charmThumbnail =
-      charmCardThumbnailContainer.querySelector(".p-card__thumbnail");
-    charmThumbnail.alt = entity.name;
-    charmThumbnail.setAttribute("loading", "lazy");
+    const charmIcon = iconContainer.querySelector(".p-card__thumbnail");
+    charmIcon.alt = entity.name;
+    charmIcon.setAttribute("loading", "lazy");
 
     if (entity.store_front.icons && entity.store_front.icons[0]) {
-      charmThumbnail.src =
-        "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_64,h_64/" +
+      charmIcon.src =
+        "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_24,h_24/" +
         entity.store_front.icons[0];
     } else {
-      charmThumbnail.src =
-        "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_64,h_64/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg";
+      charmIcon.src =
+        "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_24,h_24/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg";
     }
   } else {
-    charmCardThumbnailContainer.remove();
-    const bundleThumbnails =
-      bundleCardThumbnailContainer.querySelectorAll("img");
-    const bundleIconsCount = bundleCardThumbnailContainer.querySelector(
+    const bundleIconsWrapper = clone.querySelector(".p-bundle-icons");
+    const bundleIcons = bundleIconsWrapper.querySelector("img");
+    const bundleIconsCount = bundleIconsWrapper.querySelector(
       ".p-bundle-icons__count"
     );
 
-    if (entity.apps && entity.apps.length > 2) {
-      bundleIconsCount.innerText = `+${entity.apps.length - 2}`;
+    // if (entity.apps && entity.apps.length > 17) {
+    //   bundleIconsCount.innerText = `+${entity.apps.length - 17}`;
+    // } else {
+    //   bundleIconsWrapper.removeChild(bundleIconsCount);
+    // }
+
+    if (!entity.apps || entity.apps.length === 0) {
+      const icon = new Image();
+      icon.alt = entity.name;
+      icon.setAttribute("loading", "lazy");
+      icon.src =
+        "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_24,h_24/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg";
+      bundleIcons.replaceWith(icon);
+    } else {
+      const icons = [];
+      entity.apps.forEach((app) => {
+        const icon = new Image();
+        icon.alt = app.name;
+        icon.setAttribute("loading", "lazy");
+        icon.addEventListener("error", () => {
+          icon.src =
+            "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_24,h_24/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg";
+        });
+        icon.src = `/${app.name}/icon`;
+
+        icons.push(icon);
+      });
+
+      bundleIconsWrapper.removeChild(bundleIcons);
+
+      icons.forEach((icon) => {
+        bundleIconsWrapper.prepend(icon);
+      });
     }
-    Array.from(bundleThumbnails).forEach((thumbnail, count) => {
-      if (entity.apps && entity.apps[count]) {
-        thumbnail.src = `/${entity.apps[count]["name"]}/icon`;
-      } else {
-        thumbnail.src =
-          "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_64,h_64/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg";
-      }
-    });
   }
 
   const entityCardTitle = clone.querySelector(".package-card-title");
@@ -79,7 +96,7 @@ function buildPackageCard(entity) {
   }
 
   const entityCardPublisher = clone.querySelector(".package-card-publisher");
-  let newCardPublisherText = truncateString(
+  const newCardPublisherText = truncateString(
     entity.result.publisher["display-name"],
     22
   );
@@ -93,7 +110,7 @@ function buildPackageCard(entity) {
 
   const entityCardSummary = clone.querySelector(".package-card-summary");
 
-  if (entity.result.summary) {
+  if (entityCardSummary && entity.result.summary) {
     entityCardSummary.innerHTML = truncateString(entity.result.summary, 90);
   }
 

--- a/static/js/src/public/store/buildPackageCard.js
+++ b/static/js/src/public/store/buildPackageCard.js
@@ -52,12 +52,6 @@ function buildPackageCard(entity) {
       ".p-bundle-icons__count"
     );
 
-    // if (entity.apps && entity.apps.length > 17) {
-    //   bundleIconsCount.innerText = `+${entity.apps.length - 17}`;
-    // } else {
-    //   bundleIconsWrapper.removeChild(bundleIconsCount);
-    // }
-
     if (!entity.apps || entity.apps.length === 0) {
       const icon = new Image();
       icon.alt = entity.name;

--- a/static/js/src/public/store/buildPackageCard.js
+++ b/static/js/src/public/store/buildPackageCard.js
@@ -110,7 +110,7 @@ function buildPackageCard(entity) {
   const entityCardSummary = clone.querySelector(".package-card-summary");
 
   if (entityCardSummary && entity.result.summary) {
-    entityCardSummary.innerHTML = truncateString(entity.result.summary, 90);
+    entityCardSummary.innerHTML = truncateString(entity.result.summary, 60);
   }
 
   const entityCardIcons = clone.querySelector(".package-card-icons");

--- a/static/js/src/public/store/buildPackageCard.js
+++ b/static/js/src/public/store/buildPackageCard.js
@@ -64,12 +64,17 @@ function buildPackageCard(entity) {
       entity.apps.forEach((app) => {
         const icon = new Image();
         icon.alt = app.name;
+        icon.title = app.title;
         icon.setAttribute("loading", "lazy");
         icon.addEventListener("error", () => {
-          icon.src =
-            "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_24,h_24/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg";
+          const spanIcon = document.createElement("span");
+          spanIcon.title = app.title;
+          spanIcon.setAttribute("class", "p-bundle-icon");
+          spanIcon.style.backgroundImage = `url("https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_24,h_24/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg")`;
+          spanIcon.innerText = app.title.substring(0, 2);
+          icon.replaceWith(spanIcon);
         });
-        icon.src = `/${app.name}/icon`;
+        icon.src = `/${app.name}/icon-no-default`;
 
         icons.push(icon);
       });

--- a/static/js/src/public/store/buildPackageCard.js
+++ b/static/js/src/public/store/buildPackageCard.js
@@ -53,30 +53,31 @@ function buildPackageCard(entity) {
     );
 
     if (!entity.apps || entity.apps.length === 0) {
-      const icon = new Image();
-      icon.alt = entity.name;
-      icon.setAttribute("loading", "lazy");
-      icon.src =
-        "https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_24,h_24/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg";
+      const icon = document.createElement("span");
+      icon.setAttribute("class", "p-bundle-icon");
+      icon.style.backgroundImage =
+        "url(https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_24,h_24/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg)";
       bundleIcons.replaceWith(icon);
     } else {
       const icons = [];
       entity.apps.forEach((app) => {
+        const iconWrapper = document.createElement("span");
+        iconWrapper.title = app.title;
+        iconWrapper.setAttribute("class", "p-bundle-icon");
+
         const icon = new Image();
         icon.alt = app.name;
         icon.title = app.title;
         icon.setAttribute("loading", "lazy");
         icon.addEventListener("error", () => {
-          const spanIcon = document.createElement("span");
-          spanIcon.title = app.title;
-          spanIcon.setAttribute("class", "p-bundle-icon");
-          spanIcon.style.backgroundImage = `url("https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_24,h_24/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg")`;
-          spanIcon.innerText = app.title.substring(0, 2);
-          icon.replaceWith(spanIcon);
+          iconWrapper.removeChild(icon);
+          iconWrapper.innerText = app.title.substring(0, 2);
+          iconWrapper.style.backgroundImage = `url("https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_24,h_24/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg")`;
         });
         icon.src = `/${app.name}/icon-no-default`;
 
-        icons.push(icon);
+        iconWrapper.appendChild(icon);
+        icons.push(iconWrapper);
       });
 
       bundleIconsWrapper.removeChild(bundleIcons);

--- a/static/js/src/public/store/index.js
+++ b/static/js/src/public/store/index.js
@@ -1,4 +1,4 @@
-import { initPackages } from "./packages";
+import { initPackages, handleBundleIcons } from "./packages";
 import { initTopics } from "./topics";
 
-export { initPackages, initTopics };
+export { initPackages, initTopics, handleBundleIcons };

--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -536,8 +536,9 @@ class initPackages {
 
   renderButtonMobileOpen() {
     if (this.domEl.filterButtonMobileOpen.el) {
-      const filterSpanEl =
-        this.domEl.filterButtonMobileOpen.el.querySelector("span");
+      const filterSpanEl = this.domEl.filterButtonMobileOpen.el.querySelector(
+        "span"
+      );
       if (this._filters.filter.length > 0) {
         filterSpanEl.innerHTML = `Filters (${this._filters.filter.length})`;
       } else {
@@ -579,7 +580,7 @@ function handleBundleIcons(container) {
       const clientHeight = content.clientHeight;
 
       // Get all the icons
-      const icons = Array.from(content.querySelectorAll("img"));
+      const icons = Array.from(content.querySelectorAll(".p-bundle-icon"));
 
       // If there aren't any icons, skip to the next content area
       if (!icons[0]) {

--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -536,9 +536,8 @@ class initPackages {
 
   renderButtonMobileOpen() {
     if (this.domEl.filterButtonMobileOpen.el) {
-      const filterSpanEl = this.domEl.filterButtonMobileOpen.el.querySelector(
-        "span"
-      );
+      const filterSpanEl =
+        this.domEl.filterButtonMobileOpen.el.querySelector("span");
       if (this._filters.filter.length > 0) {
         filterSpanEl.innerHTML = `Filters (${this._filters.filter.length})`;
       } else {

--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -474,88 +474,7 @@ class initPackages {
         this.domEl.packageContainer.el.appendChild(buildPackageCard(entity));
       });
 
-      const contents = this.domEl.packageContainer.el.querySelectorAll(
-        ".p-card__content"
-      );
-
-      const ensureBundleCharmsFit = () => {
-        const contentStyles = window.getComputedStyle(contents[0], null);
-        const paddingX = Math.round(
-          parseInt(contentStyles.getPropertyValue("padding-left")) +
-            parseInt(contentStyles.getPropertyValue("padding-right")) +
-            parseInt(contentStyles.getPropertyValue("border-left-width")) +
-            parseInt(contentStyles.getPropertyValue("border-right-width"))
-        );
-        const paddingY = Math.round(
-          parseInt(contentStyles.getPropertyValue("padding-top")) +
-            parseInt(contentStyles.getPropertyValue("padding-bottom")) +
-            parseInt(contentStyles.getPropertyValue("border-top-width")) +
-            parseInt(contentStyles.getPropertyValue("border-bottom-width"))
-        );
-
-        const contentsBox = contents[0].getBoundingClientRect();
-        const innerWidth = contentsBox.width - paddingX;
-        const innerHeight = contentsBox.height - paddingY;
-
-        contents.forEach((content) => {
-          const icons = Array.from(content.querySelectorAll("img"));
-          const icon = icons[0];
-          if (icon) {
-            const container = icon.parentNode;
-            const iconBox = icon.getBoundingClientRect();
-            const iconStyles = window.getComputedStyle(icon, null);
-            const iconWidth = Math.round(
-              iconBox.width +
-                parseInt(iconStyles.getPropertyValue("border-left-width")) +
-                parseInt(iconStyles.getPropertyValue("border-right-width")) +
-                parseInt(iconStyles.getPropertyValue("margin-left")) +
-                parseInt(iconStyles.getPropertyValue("margin-right"))
-            );
-            const iconHeight = Math.round(
-              iconBox.height +
-                parseInt(iconStyles.getPropertyValue("border-top-width")) +
-                parseInt(iconStyles.getPropertyValue("border-bottom-width")) +
-                parseInt(iconStyles.getPropertyValue("margin-top")) +
-                parseInt(iconStyles.getPropertyValue("margin-bottom"))
-            );
-            if (iconWidth && innerWidth && iconHeight && innerHeight) {
-              const maxIconsX = Math.floor(innerWidth / iconWidth);
-              const maxIconsY = Math.floor(innerHeight / iconHeight);
-              const maxIcons = maxIconsX * maxIconsY - 1;
-              const removedIcons = icons.length - maxIcons;
-              icons.forEach((icon, index) => {
-                if (index >= maxIcons) {
-                  icon.classList.add("u-hide");
-                } else {
-                  icon.classList.remove("u-hide");
-                }
-              });
-              if (removedIcons > 0) {
-                let extraCount = container.querySelector(
-                  ".p-bundle-icons__count"
-                );
-                if (!extraCount) {
-                  extraCount = document.createElement("span");
-                  extraCount.setAttribute(
-                    "class",
-                    "p-bundle-icons__count u-text--muted"
-                  );
-                  container.appendChild(extraCount);
-                }
-                extraCount.innerHTML = `+${removedIcons}`;
-              }
-            }
-          }
-        });
-      };
-
-      if (contents.length > 0) {
-        ensureBundleCharmsFit();
-
-        window.removeEventListener("resize", ensureBundleCharmsFit);
-        window.addEventListener("resize", ensureBundleCharmsFit);
-      }
-
+      this.handlePackageClick(this.domEl.packageContainer.el);
       this.captureTooltipButtonClick();
     } else {
       throw new Error(
@@ -644,6 +563,88 @@ class initPackages {
         e.stopPropagation();
       });
     });
+  }
+
+  static handleBundleIcons(container) {
+    const contents = container.querySelectorAll(".p-card__content");
+
+    const ensureBundleCharmsFit = () => {
+      const contentStyles = window.getComputedStyle(contents[0], null);
+      const paddingX = Math.round(
+        parseInt(contentStyles.getPropertyValue("padding-left")) +
+          parseInt(contentStyles.getPropertyValue("padding-right")) +
+          parseInt(contentStyles.getPropertyValue("border-left-width")) +
+          parseInt(contentStyles.getPropertyValue("border-right-width"))
+      );
+      const paddingY = Math.round(
+        parseInt(contentStyles.getPropertyValue("padding-top")) +
+          parseInt(contentStyles.getPropertyValue("padding-bottom")) +
+          parseInt(contentStyles.getPropertyValue("border-top-width")) +
+          parseInt(contentStyles.getPropertyValue("border-bottom-width"))
+      );
+
+      const contentsBox = contents[0].getBoundingClientRect();
+      const innerWidth = contentsBox.width - paddingX;
+      const innerHeight = contentsBox.height - paddingY;
+
+      contents.forEach((content) => {
+        const icons = Array.from(content.querySelectorAll("img"));
+        const icon = icons[0];
+        if (icon) {
+          const container = icon.parentNode;
+          const iconBox = icon.getBoundingClientRect();
+          const iconStyles = window.getComputedStyle(icon, null);
+          const iconWidth = Math.round(
+            iconBox.width +
+              parseInt(iconStyles.getPropertyValue("border-left-width")) +
+              parseInt(iconStyles.getPropertyValue("border-right-width")) +
+              parseInt(iconStyles.getPropertyValue("margin-left")) +
+              parseInt(iconStyles.getPropertyValue("margin-right"))
+          );
+          const iconHeight = Math.round(
+            iconBox.height +
+              parseInt(iconStyles.getPropertyValue("border-top-width")) +
+              parseInt(iconStyles.getPropertyValue("border-bottom-width")) +
+              parseInt(iconStyles.getPropertyValue("margin-top")) +
+              parseInt(iconStyles.getPropertyValue("margin-bottom"))
+          );
+          if (iconWidth && innerWidth && iconHeight && innerHeight) {
+            const maxIconsX = Math.floor(innerWidth / iconWidth);
+            const maxIconsY = Math.floor(innerHeight / iconHeight);
+            const maxIcons = maxIconsX * maxIconsY - 1;
+            const removedIcons = icons.length - maxIcons;
+            icons.forEach((icon, index) => {
+              if (index >= maxIcons) {
+                icon.classList.add("u-hide");
+              } else {
+                icon.classList.remove("u-hide");
+              }
+            });
+            if (removedIcons > 0) {
+              let extraCount = container.querySelector(
+                ".p-bundle-icons__count"
+              );
+              if (!extraCount) {
+                extraCount = document.createElement("span");
+                extraCount.setAttribute(
+                  "class",
+                  "p-bundle-icons__count u-text--muted"
+                );
+                container.appendChild(extraCount);
+              }
+              extraCount.innerHTML = `+${removedIcons}`;
+            }
+          }
+        }
+      });
+    };
+
+    if (contents.length > 0) {
+      ensureBundleCharmsFit();
+
+      window.removeEventListener("resize", ensureBundleCharmsFit);
+      window.addEventListener("resize", ensureBundleCharmsFit);
+    }
   }
 }
 

--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -537,9 +537,8 @@ class initPackages {
 
   renderButtonMobileOpen() {
     if (this.domEl.filterButtonMobileOpen.el) {
-      const filterSpanEl = this.domEl.filterButtonMobileOpen.el.querySelector(
-        "span"
-      );
+      const filterSpanEl =
+        this.domEl.filterButtonMobileOpen.el.querySelector("span");
       if (this._filters.filter.length > 0) {
         filterSpanEl.innerHTML = `Filters (${this._filters.filter.length})`;
       } else {

--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -474,6 +474,86 @@ class initPackages {
         this.domEl.packageContainer.el.appendChild(buildPackageCard(entity));
       });
 
+      const contents = this.domEl.packageContainer.el.querySelectorAll(
+        ".p-card__content"
+      );
+
+      const ensureBundleCharmsFit = () => {
+        const contentStyles = window.getComputedStyle(contents[0], null);
+        const paddingX = Math.round(
+          parseInt(contentStyles.getPropertyValue("padding-left")) +
+            parseInt(contentStyles.getPropertyValue("padding-right")) +
+            parseInt(contentStyles.getPropertyValue("border-left-width")) +
+            parseInt(contentStyles.getPropertyValue("border-right-width"))
+        );
+        const paddingY = Math.round(
+          parseInt(contentStyles.getPropertyValue("padding-top")) +
+            parseInt(contentStyles.getPropertyValue("padding-bottom")) +
+            parseInt(contentStyles.getPropertyValue("border-top-width")) +
+            parseInt(contentStyles.getPropertyValue("border-bottom-width"))
+        );
+
+        const contentsBox = contents[0].getBoundingClientRect();
+        const innerWidth = contentsBox.width - paddingX;
+        const innerHeight = contentsBox.height - paddingY;
+
+        contents.forEach((content) => {
+          const icons = Array.from(content.querySelectorAll("img"));
+          const icon = icons[0];
+          if (icon) {
+            const container = icon.parentNode;
+            const iconBox = icon.getBoundingClientRect();
+            const iconStyles = window.getComputedStyle(icon, null);
+            const iconWidth = Math.round(
+              iconBox.width +
+                parseInt(iconStyles.getPropertyValue("border-left-width")) +
+                parseInt(iconStyles.getPropertyValue("border-right-width")) +
+                parseInt(iconStyles.getPropertyValue("margin-left")) +
+                parseInt(iconStyles.getPropertyValue("margin-right"))
+            );
+            const iconHeight = Math.round(
+              iconBox.height +
+                parseInt(iconStyles.getPropertyValue("border-top-width")) +
+                parseInt(iconStyles.getPropertyValue("border-bottom-width")) +
+                parseInt(iconStyles.getPropertyValue("margin-top")) +
+                parseInt(iconStyles.getPropertyValue("margin-bottom"))
+            );
+            if (iconWidth && innerWidth && iconHeight && innerHeight) {
+              const maxIconsX = Math.floor(innerWidth / iconWidth);
+              const maxIconsY = Math.floor(innerHeight / iconHeight);
+              const maxIcons = maxIconsX * maxIconsY - 1;
+              const removedIcons = icons.length - maxIcons;
+              icons.forEach((icon, index) => {
+                if (index >= maxIcons) {
+                  icon.classList.add("u-hide");
+                } else {
+                  icon.classList.remove("u-hide");
+                }
+              });
+              if (removedIcons > 0) {
+                let extraCount = container.querySelector(
+                  ".p-bundle-icons__count"
+                );
+                if (!extraCount) {
+                  extraCount = document.createElement("span");
+                  extraCount.setAttribute(
+                    "class",
+                    "p-bundle-icons__count u-text--muted"
+                  );
+                  container.appendChild(extraCount);
+                }
+                extraCount.innerHTML = `+${removedIcons}`;
+              }
+            }
+          }
+        });
+      };
+
+      ensureBundleCharmsFit();
+
+      window.removeEventListener("resize", ensureBundleCharmsFit);
+      window.addEventListener("resize", ensureBundleCharmsFit);
+
       this.captureTooltipButtonClick();
     } else {
       throw new Error(
@@ -536,8 +616,9 @@ class initPackages {
 
   renderButtonMobileOpen() {
     if (this.domEl.filterButtonMobileOpen.el) {
-      const filterSpanEl =
-        this.domEl.filterButtonMobileOpen.el.querySelector("span");
+      const filterSpanEl = this.domEl.filterButtonMobileOpen.el.querySelector(
+        "span"
+      );
       if (this._filters.filter.length > 0) {
         filterSpanEl.innerHTML = `Filters (${this._filters.filter.length})`;
       } else {

--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -194,6 +194,7 @@ class initPackages {
         this.renderButtonMobileOpen();
         this.toggleFeaturedContainer();
         this.toggleShowAllPackagesButton();
+        handleBundleIcons(this.domEl.packageContainer.el);
         window.scrollTo(0, 0);
       });
     } else {
@@ -271,6 +272,7 @@ class initPackages {
         this.toggleFeaturedContainer();
         this.toggleShowAllPackagesButton();
         this.togglePackageContainer(true);
+        handleBundleIcons(this.domEl.packageContainer.el);
       });
     } else {
       throw new Error(
@@ -293,6 +295,7 @@ class initPackages {
         this.toggleFeaturedContainer();
         this.toggleShowAllPackagesButton();
         this.togglePackageContainer(true);
+        handleBundleIcons(this.domEl.packageContainer.el);
       });
     } else {
       throw new Error(
@@ -332,6 +335,7 @@ class initPackages {
           this.toggleFeaturedContainer();
           this.toggleShowAllPackagesButton();
           this.togglePackageContainer(true);
+          handleBundleIcons(this.domEl.packageContainer.el);
         });
       });
     } else {

--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -549,10 +549,12 @@ class initPackages {
         });
       };
 
-      ensureBundleCharmsFit();
+      if (contents.length > 0) {
+        ensureBundleCharmsFit();
 
-      window.removeEventListener("resize", ensureBundleCharmsFit);
-      window.addEventListener("resize", ensureBundleCharmsFit);
+        window.removeEventListener("resize", ensureBundleCharmsFit);
+        window.addEventListener("resize", ensureBundleCharmsFit);
+      }
 
       this.captureTooltipButtonClick();
     } else {

--- a/static/js/src/public/store/packages.js
+++ b/static/js/src/public/store/packages.js
@@ -3,106 +3,15 @@ import debounce from "../../libs/debounce";
 
 /** Store page filters */
 class initPackages {
-  constructor() {
-    this.selectElements();
-    this.togglePlaceholderContainer(true);
-    this.searchCache = window.location.search;
-    this._filters = this.getUrlFilters();
+  static async initialize() {
+    const packageData = await initPackages.fetchPackageList();
 
-    if (
-      this._filters.q.length === 0 &&
-      this._filters.filter.length === 0 &&
-      this._filters.base[0] === "all" &&
-      this._filters.type[0] === "all"
-    ) {
-      this.togglePlaceholderContainer();
-      this.toggleFeaturedContainer(true);
-      this.renderResultsCount(true);
-      this.toggleShowAllPackagesButton(true);
-    }
+    const allPackages = await initPackages.addBundleApps(packageData.packages);
 
-    if (this._filters.q.length > 0) {
-      const queryString = this._filters.q.join(",");
-      this.domEl.searchInputDesktop.el.value = queryString;
-      this.domEl.searchInputMobile.el.value = queryString;
-    }
-
-    this.fetchPackageList()
-      .then((data) => {
-        this.allPackages = data.packages;
-
-        if (!this.allPackages) {
-          return;
-        }
-
-        // Temporary hack to get bundle icons, as the API does not have it
-        this.addBundleApps();
-        if (this._filters.q.length > 0) {
-          setTimeout(() => {
-            this.renderPackages();
-          }, 1000);
-        }
-
-        this.filterPackages();
-        this.handleShowAllPackagesButton();
-        this.handleFilterButtonMobileOpenClick();
-        this.handleFilterClick();
-        this.handlePlatformChange();
-        this.handlePackageTypeChange();
-        this.enableAllActions();
-        this.updateEnabledCategories();
-        this.renderButtonMobileOpen();
-
-        if (
-          this._filters.q.length > 0 ||
-          this._filters.filter.length > 0 ||
-          this._filters.base[0] !== "all" ||
-          this._filters.type[0] !== "all"
-        ) {
-          this.renderPackages();
-          this.renderResultsCount();
-          this.togglePackageContainer(true);
-          this.togglePlaceholderContainer();
-          this.toggleShowAllPackagesButton();
-        }
-      })
-      .catch((e) => console.error(e));
-
-    this.captureTooltipButtonClick();
+    const _class = new initPackages(allPackages);
   }
 
-  addBundleApps() {
-    this.allPackages.forEach((entity, count) => {
-      if (entity.type === "bundle") {
-        fetch(`/${entity.name}/charms.json`)
-          .then((response) => {
-            if (response.ok) {
-              response.json().then((res) => {
-                this.allPackages[count]["apps"] = res.charms;
-              });
-            } else {
-              throw new Error(
-                "There was a problem comunicating with the server."
-              );
-            }
-          })
-          .catch((e) => console.error(e));
-      }
-    });
-  }
-
-  fetchPackageList() {
-    if (this._filters.q) {
-      const queryUrl = this._filters.q.join(",");
-      return fetch(`/packages.json?q=${queryUrl}`).then((result) =>
-        result.json()
-      );
-    } else {
-      return fetch("/packages.json").then((result) => result.json());
-    }
-  }
-
-  getUrlFilters() {
+  static getUrlFilters() {
     const filters = {};
 
     if (window.location.search) {
@@ -130,6 +39,92 @@ class initPackages {
     }
 
     return filters;
+  }
+
+  static async fetchPackageList() {
+    const filters = initPackages.getUrlFilters();
+    if (filters.q.length > 0) {
+      const queryUrl = filters.q.join(",");
+      const result = await fetch(`/packages.json?q=${queryUrl}`);
+      return await result.json();
+    } else {
+      const result = await fetch("/packages.json");
+      return await result.json();
+    }
+  }
+
+  static async getBundleApps(bundleName) {
+    const response = await fetch(`/${bundleName}/charms.json`);
+
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new Error("There was a problem communicating with the server.");
+    }
+  }
+
+  static async addBundleApps(packages) {
+    return Promise.all(
+      packages.map(async (entity) => {
+        if (entity.type === "bundle") {
+          const charms = await initPackages.getBundleApps(entity.name);
+          entity.apps = charms.charms;
+        }
+        return entity;
+      })
+    );
+  }
+
+  constructor(packages) {
+    this.allPackages = packages;
+    this.selectElements();
+    this.togglePlaceholderContainer(true);
+    this.searchCache = window.location.search;
+    this._filters = initPackages.getUrlFilters();
+
+    if (
+      this._filters.q.length === 0 &&
+      this._filters.filter.length === 0 &&
+      this._filters.base[0] === "all" &&
+      this._filters.type[0] === "all"
+    ) {
+      this.togglePlaceholderContainer();
+      this.toggleFeaturedContainer(true);
+      this.renderResultsCount(true);
+      this.toggleShowAllPackagesButton(true);
+    }
+
+    if (this._filters.q.length > 0) {
+      const queryString = this._filters.q.join(",");
+      this.domEl.searchInputDesktop.el.value = queryString;
+      this.domEl.searchInputMobile.el.value = queryString;
+    }
+
+    this.filterPackages();
+    this.handleShowAllPackagesButton();
+    this.handleFilterButtonMobileOpenClick();
+    this.handleFilterClick();
+    this.handlePlatformChange();
+    this.handlePackageTypeChange();
+    this.enableAllActions();
+    this.updateEnabledCategories();
+    this.renderButtonMobileOpen();
+
+    if (
+      this._filters.q.length > 0 ||
+      this._filters.filter.length > 0 ||
+      this._filters.base[0] !== "all" ||
+      this._filters.type[0] !== "all"
+    ) {
+      this.renderPackages();
+      this.renderResultsCount();
+      this.togglePackageContainer(true);
+      this.togglePlaceholderContainer();
+      this.toggleShowAllPackagesButton();
+      handleBundleIcons(this.domEl.packageContainer.el);
+    }
+
+    this.captureTooltipButtonClick();
   }
 
   selectElements() {
@@ -479,7 +474,6 @@ class initPackages {
         this.domEl.packageContainer.el.appendChild(buildPackageCard(entity));
       });
 
-      handleBundleIcons(this.domEl.packageContainer.el);
       this.captureTooltipButtonClick();
     } else {
       throw new Error(
@@ -542,8 +536,9 @@ class initPackages {
 
   renderButtonMobileOpen() {
     if (this.domEl.filterButtonMobileOpen.el) {
-      const filterSpanEl =
-        this.domEl.filterButtonMobileOpen.el.querySelector("span");
+      const filterSpanEl = this.domEl.filterButtonMobileOpen.el.querySelector(
+        "span"
+      );
       if (this._filters.filter.length > 0) {
         filterSpanEl.innerHTML = `Filters (${this._filters.filter.length})`;
       } else {

--- a/static/sass/_charmhub_p-bundle-icons.scss
+++ b/static/sass/_charmhub_p-bundle-icons.scss
@@ -1,20 +1,13 @@
 @use "sass:math";
 
 @mixin charmhub-p-bundle-icons {
-  .p-bundle-icons {
-    $icon-size: 1.75rem;
-    $padding: 0.12rem;
+  $icon-size: 1.5rem;
 
+  .p-bundle-icons {
     align-items: center;
-    background-color: $color-x-light;
-    border: 0.06rem solid $color-mid-light;
-    border-radius: math.div(($padding * 2) + $icon-size, 2);
     color: #333;
-    display: flex;
     font-size: 0.875rem;
-    padding: $padding 0.3rem + $padding $padding $padding;
     position: relative;
-    top: -0.12rem;
     width: fit-content;
 
     &:hover {
@@ -26,21 +19,17 @@
       border-radius: math.div($icon-size, 2);
       display: inline-block;
       height: $icon-size;
-      margin-bottom: 0;
+      margin-bottom: 0.5rem;
+      margin-right: 0.5rem;
       vertical-align: bottom;
       width: $icon-size;
-
-      &:first-child {
-        // Set a background to handle overlapping transparent icons.
-        background-color: $color-x-light;
-        z-index: 1;
-      }
-
-      &:nth-child(2) {
-        margin-inline-end: 0.5rem;
-        margin-left: -1.25rem;
-      }
     }
+  }
+
+  .p-bundle-icons__count {
+    display: inline-block;
+    height: $icon-size;
+    margin-bottom: 0.5rem;
   }
 
   .p-heading-icon--x-small > .p-bundle-icons {

--- a/static/sass/_charmhub_p-bundle-icons.scss
+++ b/static/sass/_charmhub_p-bundle-icons.scss
@@ -4,12 +4,6 @@
   $icon-size: 1.5rem;
 
   .p-bundle-icons {
-    align-items: center;
-    color: #333;
-    font-size: 0.875rem;
-    position: relative;
-    width: fit-content;
-
     &:hover {
       text-decoration: none;
     }
@@ -27,9 +21,14 @@
   }
 
   .p-bundle-icons__count {
+    width: $icon-size;
+    overflow: hidden;
+    color: #333;
+    font-size: 0.875rem;
     display: inline-block;
     height: $icon-size;
     margin-bottom: 0.5rem;
+    vertical-align: middle;
   }
 
   .p-heading-icon--x-small > .p-bundle-icons {

--- a/static/sass/_charmhub_p-bundle-icons.scss
+++ b/static/sass/_charmhub_p-bundle-icons.scss
@@ -4,6 +4,11 @@
   $icon-size: 1.5rem;
 
   .p-bundle-icons {
+    display: grid;
+    grid-gap: 0.5rem;
+    grid-template-columns: repeat(auto-fit, 1.5rem);
+    grid-template-rows: 1.5rem;
+
     &:hover {
       text-decoration: none;
     }
@@ -15,8 +20,6 @@
       display: inline-block;
       font-size: 0.875rem;
       height: $icon-size;
-      margin-bottom: 0.5rem;
-      margin-right: 0.5rem;
       text-align: center;
       vertical-align: bottom;
       width: $icon-size;

--- a/static/sass/_charmhub_p-bundle-icons.scss
+++ b/static/sass/_charmhub_p-bundle-icons.scss
@@ -21,14 +21,14 @@
   }
 
   .p-bundle-icons__count {
-    width: $icon-size;
-    overflow: hidden;
     color: #333;
-    font-size: 0.875rem;
     display: inline-block;
+    font-size: 0.875rem;
     height: $icon-size;
     margin-bottom: 0.5rem;
+    overflow: hidden;
     vertical-align: middle;
+    width: $icon-size;
   }
 
   .p-heading-icon--x-small > .p-bundle-icons {

--- a/static/sass/_charmhub_p-bundle-icons.scss
+++ b/static/sass/_charmhub_p-bundle-icons.scss
@@ -13,16 +13,23 @@
       text-decoration: none;
     }
 
-    img,
     .p-bundle-icon {
       align-items: center;
+      background-size: cover;
       border: 0.06rem solid $color-mid-light;
       border-radius: math.div($icon-size, 2);
+      box-sizing: content-box;
       display: inline-flex;
       font-size: 0.875rem;
       height: $icon-size;
       justify-content: center;
+      overflow: hidden;
       width: $icon-size;
+
+      img {
+        border-radius: 100%;
+        overflow: hidden;
+      }
     }
   }
 

--- a/static/sass/_charmhub_p-bundle-icons.scss
+++ b/static/sass/_charmhub_p-bundle-icons.scss
@@ -15,13 +15,13 @@
 
     img,
     .p-bundle-icon {
+      align-items: center;
       border: 0.06rem solid $color-mid-light;
       border-radius: math.div($icon-size, 2);
-      display: inline-block;
+      display: inline-flex;
       font-size: 0.875rem;
       height: $icon-size;
-      text-align: center;
-      vertical-align: bottom;
+      justify-content: center;
       width: $icon-size;
     }
   }

--- a/static/sass/_charmhub_p-bundle-icons.scss
+++ b/static/sass/_charmhub_p-bundle-icons.scss
@@ -8,13 +8,16 @@
       text-decoration: none;
     }
 
-    img {
+    img,
+    .p-bundle-icon {
       border: 0.06rem solid $color-mid-light;
       border-radius: math.div($icon-size, 2);
       display: inline-block;
+      font-size: 0.875rem;
       height: $icon-size;
       margin-bottom: 0.5rem;
       margin-right: 0.5rem;
+      text-align: center;
       vertical-align: bottom;
       width: $icon-size;
     }

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -36,13 +36,12 @@
     }
 
     animation: shine 3s infinite ease-in-out;
-    background-image:
-      linear-gradient(
-        to bottom right,
-        $color-mid-x-light calc(50% - 2rem),
-        $color-light 50%,
-        $color-mid-x-light calc(50% + 2rem)
-      );
+    background-image: linear-gradient(
+      to bottom right,
+      $color-mid-x-light calc(50% - 2rem),
+      $color-light 50%,
+      $color-mid-x-light calc(50% + 2rem)
+    );
     background-size: 300% 300%;
     clip-path: url("#animation-mask");
   }

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -36,13 +36,12 @@
     }
 
     animation: shine 3s infinite ease-in-out;
-    background-image:
-      linear-gradient(
-        to bottom right,
-        $color-mid-x-light calc(50% - 2rem),
-        $color-light 50%,
-        $color-mid-x-light calc(50% + 2rem)
-      );
+    background-image: linear-gradient(
+      to bottom right,
+      $color-mid-x-light calc(50% - 2rem),
+      $color-light 50%,
+      $color-mid-x-light calc(50% + 2rem)
+    );
     background-size: 300% 300%;
     clip-path: url("#animation-mask");
   }
@@ -54,7 +53,7 @@
     background-color: $color-x-light;
     color: $color-dark !important;
     display: grid;
-    grid-template-rows: auto auto 2.5rem;
+    grid-template-rows: 9rem auto 2.5rem;
 
     // Force obey parent's border-radius
     height: 16rem;

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -54,10 +54,10 @@
     background-color: $color-x-light;
     color: $color-dark !important;
     display: grid;
-    grid-template-rows: 9rem 4rem 2.5rem;
+    grid-template-rows: 9rem 4.5rem 2.5rem;
 
     // Force obey parent's border-radius
-    height: 15.5rem;
+    height: 16rem;
     margin-bottom: $spv--x-large;
     width: 100%;
 

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -54,10 +54,10 @@
     background-color: $color-x-light;
     color: $color-dark !important;
     display: grid;
-    grid-template-rows: 9rem auto 2.5rem;
+    grid-template-rows: 9rem 4rem 2.5rem;
 
     // Force obey parent's border-radius
-    height: 16rem;
+    height: 15.5rem;
     margin-bottom: $spv--x-large;
     width: 100%;
 

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -36,12 +36,13 @@
     }
 
     animation: shine 3s infinite ease-in-out;
-    background-image: linear-gradient(
-      to bottom right,
-      $color-mid-x-light calc(50% - 2rem),
-      $color-light 50%,
-      $color-mid-x-light calc(50% + 2rem)
-    );
+    background-image:
+      linear-gradient(
+        to bottom right,
+        $color-mid-x-light calc(50% - 2rem),
+        $color-light 50%,
+        $color-mid-x-light calc(50% + 2rem)
+      );
     background-size: 300% 300%;
     clip-path: url("#animation-mask");
   }

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -99,6 +99,16 @@
       overflow: hidden;
       padding: 0 $spv--large 0 $spv--large;
       position: relative;
+
+      p {
+        height: 100%;
+
+        .package-card-summary {
+          height: 100%;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+      }
     }
 
     .p-card__footer {

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -54,7 +54,7 @@
     background-color: $color-x-light;
     color: $color-dark !important;
     display: grid;
-    grid-template-rows: 9.5rem 3.9rem;
+    grid-template-rows: auto auto 2.5rem;
 
     // Force obey parent's border-radius
     height: 16rem;
@@ -95,9 +95,9 @@
     }
 
     .p-card__content {
-      max-height: 4.25rem;
+      margin-bottom: 0;
       overflow: hidden;
-      padding: 0 $spv--large $spv--large $spv--large;
+      padding: 0 $spv--large 0 $spv--large;
     }
 
     .p-card__footer {

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -98,6 +98,7 @@
       margin-bottom: 0;
       overflow: hidden;
       padding: 0 $spv--large 0 $spv--large;
+      position: relative;
     }
 
     .p-card__footer {

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -38,10 +38,10 @@
     animation: shine 3s infinite ease-in-out;
     background-image:
       linear-gradient(
-	to bottom right,
-	$color-mid-x-light calc(50% - 2rem),
-	$color-light 50%,
-	$color-mid-x-light calc(50% + 2rem)
+        to bottom right,
+        $color-mid-x-light calc(50% - 2rem),
+        $color-light 50%,
+        $color-mid-x-light calc(50% + 2rem)
       );
     background-size: 300% 300%;
     clip-path: url("#animation-mask");

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -36,12 +36,13 @@
     }
 
     animation: shine 3s infinite ease-in-out;
-    background-image: linear-gradient(
-      to bottom right,
-      $color-mid-x-light calc(50% - 2rem),
-      $color-light 50%,
-      $color-mid-x-light calc(50% + 2rem)
-    );
+    background-image:
+      linear-gradient(
+	to bottom right,
+	$color-mid-x-light calc(50% - 2rem),
+	$color-light 50%,
+	$color-mid-x-light calc(50% + 2rem)
+      );
     background-size: 300% 300%;
     clip-path: url("#animation-mask");
   }

--- a/templates/embeddable-card.html
+++ b/templates/embeddable-card.html
@@ -92,10 +92,10 @@
     </a>
   </div>
   {% if package.type == "bundle" %}
-    <script src="{{ versioned_static('js/dist/store.js') }}" defer></script>
+    <script src="{{ versioned_static('js/dist/store.js') }}"></script>
     <script>
       window.addEventListener("DOMContentLoaded", () => {
-        charmhub.store.initPackages.handleBundleIcons(document.querySelector("body"));
+        charmhub.store.handleBundleIcons(document.querySelector(".p-card--button"));
       });
     </script>
   {% endif %}

--- a/templates/embeddable-card.html
+++ b/templates/embeddable-card.html
@@ -38,49 +38,67 @@
 <body>
 {% if store_design %}
   <div id="{{ package.name }}" style="padding: 2px;">
-    <a href="/{{ package.name }}" class="p-card--button" style="display: block; margin-bottom: 0;">
-      <div class="p-card__header">
-        {% if package.type == "bundle" %}
-          <div class="p-bundle-icons" style="margin-block-end: 6px; margin-block-start: 6px;">
-          {% if package.store_front.bundle.charms %}
-            {% set charms = package.store_front.bundle.charms %}
-              <img src="/{{ charms[0].name }}/icon" alt="" />
-              <img src="/{{ charms[1].name }}/icon" alt="" />
-              {% if charms | length > 2 %}
-              <span class="p-bundle-icons__count u-text--muted">
-                +{{ charms | length - 2 }}
-              </span>
-              {% endif %}
-          {% else %}
-              <img src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" alt="" />
-              <img src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" alt="" />
-          {% endif %}
-          </div>
-        {% else %}
-        <div class="p-card__thumbnail-container">
-          <img src="{% if package.store_front.icons %}{{ package.store_front.icons[0] }}{% else %}https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_64,h_64/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg{% endif %}" alt="{{ package.name }}" class="p-card__thumbnail" loading="lazy" width="40" height="40">
+    <a href="/{{ package.name }}" class="p-card--button" style="margin-bottom: 0;">
+      {% if package.type == "bundle" %}
+        <div class="p-card__header">
+          <h3 class="p-muted-heading">Bundle</h3>
+          <h3 class="p-card__title p-heading--4 u-no-margin--bottom package-card-title">{{ package.store_front["display-name"] }}</h3>
+          <p class="u-text--muted u-no-padding--top package-card-publisher" style="white-space: nowrap;">{{ package.store_front.publisher_name }}</p>
         </div>
-        {% endif %}
-
-        <h3 class="p-card__title p-heading--4 u-no-margin--bottom package-card-title" style="white-space: nowrap;overflow: hidden;text-overflow: ellipsis;">{{ package.store_front["display-name"] }}</h3>
-        <p class="u-text--muted u-no-padding--top package-card-publisher" style="white-space: nowrap;">{{ package.store_front.publisher_name }}</p>
-      </div>
-      <div class="p-card__content" style="height: 5rem; max-height: 5rem;">
-        <p><small class="package-card-summary">{{ package.store_front.metadata.summary|truncate(90) }}</small></p>
-      </div>
-      <div class="p-card__footer" data-js-card-footer="">
-        {% if "kubernetes" in package.store_front["deployable-on"] %}
-          <div class="package-card-icons"><img alt="Kubernetes" src="https://assets.ubuntu.com/v1/f1852c07-Kubernetes.svg" width="24" height="24"></div>
-        {% endif %}
-        {% if "windows" in package.store_front["deployable-on"] %}
-          <div class="package-card-icons"><img alt="Kubernetes" src="https://assets.ubuntu.com/v1/ff17c4fe-Windows.svg" width="24" height="24"></div>
-        {% endif %}
-        {% if "vm" in package.store_front["deployable-on"] %}
-          <div class="package-card-icons"><img alt="VM" src="https://assets.ubuntu.com/v1/a911ecf6-vm-badge.svg" width="24" height="24"></div>
-        {% endif %}
-      </div>
+        <div class="p-card__content">
+          <div class="p-bundle-icons">
+            {% if package.store_front.bundle.charms %}
+              {% set charms = package.store_front.bundle.charms %}
+              {% for charm in charms %}
+                <img src="/{{charm.name}}/icon" alt="" width="24" height="24" />
+              {% endfor %}
+            {% endif %}
+          </div>
+        </div>
+        <div class="p-card__footer" data-js-card-footer>
+          {% if "kubernetes" in package.store_front["deployable-on"] %}
+            <div class="package-card-icons"><img alt="Kubernetes" src="https://assets.ubuntu.com/v1/f1852c07-Kubernetes.svg" width="24" height="24"></div>
+          {% endif %}
+          {% if "windows" in package.store_front["deployable-on"] %}
+            <div class="package-card-icons"><img alt="Kubernetes" src="https://assets.ubuntu.com/v1/ff17c4fe-Windows.svg" width="24" height="24"></div>
+          {% endif %}
+          {% if "vm" in package.store_front["deployable-on"] %}
+            <div class="package-card-icons"><img alt="VM" src="https://assets.ubuntu.com/v1/a911ecf6-vm-badge.svg" width="24" height="24"></div>
+          {% endif %}
+        </div>
+      {% else %}
+        <div class="p-card__header">
+          <div class="p-card__thumbnail-container">
+            <img src="{% if package.store_front.icons %}{{ package.store_front.icons[0] }}{% else %}https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_64,h_64/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg{% endif %}" alt="{{ package.name }}" class="p-card__thumbnail" loading="lazy" width="40" height="40" />
+          </div>
+          <h3 class="p-card__title p-heading--4 u-no-margin--bottom package-card-title">{{ package.store_front["display-name"] }}</h3>
+          <p class="u-text--muted u-no-padding--top package-card-publisher" style="white-space: nowrap;">{{ package.store_front.publisher_name }}</p>
+        </div>
+        <div class="p-card__content">
+          <p><small class="package-card-summary">{{ package.store_front.metadata.summary|truncate(90) }}</small></p>
+        </div>
+        <div class="p-card__footer" data-js-card-footer>
+          {% if "kubernetes" in package.store_front["deployable-on"] %}
+            <div class="package-card-icons"><img alt="Kubernetes" src="https://assets.ubuntu.com/v1/f1852c07-Kubernetes.svg" width="24" height="24"></div>
+          {% endif %}
+          {% if "windows" in package.store_front["deployable-on"] %}
+            <div class="package-card-icons"><img alt="Kubernetes" src="https://assets.ubuntu.com/v1/ff17c4fe-Windows.svg" width="24" height="24"></div>
+          {% endif %}
+          {% if "vm" in package.store_front["deployable-on"] %}
+            <div class="package-card-icons"><img alt="VM" src="https://assets.ubuntu.com/v1/a911ecf6-vm-badge.svg" width="24" height="24"></div>
+          {% endif %}
+        </div>
+      {% endif %}
     </a>
   </div>
+  {% if package.type == "bundle" %}
+    <script src="{{ versioned_static('js/dist/store.js') }}" defer></script>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        charmhub.store.initPackages.handleBundleIcons(document.querySelector("body"));
+      });
+    </script>
+  {% endif %}
 {% else %}
   <div class="p-strip has-suru">
     <div class="row">

--- a/templates/partial/_featured-charms.html
+++ b/templates/partial/_featured-charms.html
@@ -25,7 +25,7 @@
         </p>
       </div>
       <div class="p-card__content">
-        <p><small class="package-card-summary">{{ charm.result.summary|truncate(85) }}</small></p>
+        <p><small class="package-card-summary">{{ charm.result.summary|truncate(60) }}</small></p>
       </div>
 
       <div class="p-card__footer">

--- a/templates/partial/_topics.html
+++ b/templates/partial/_topics.html
@@ -4,7 +4,7 @@
     <div>
       <p>Top related topics</p>
       <div class="u-equal-height" data-js="topics-placeholder-container">
-        {% for _ in range(0, 2) %}
+        {% for _ in range(0, 3) %}
         <a class="p-card--highlighted p-card--href has-top-color">
           <svg width="100%" height="80%" class="p-card--placeholder">
             <defs>

--- a/templates/partial/_topics.html
+++ b/templates/partial/_topics.html
@@ -3,7 +3,7 @@
   <div class="l-fluid-breakout__main">
     <div>
       <p>Top related topics</p>
-      <div class="u-equal-height u-hide" data-js="topics-placeholder-container">
+      <div class="u-equal-height" data-js="topics-placeholder-container">
         {% for _ in range(0, 2) %}
         <a class="p-card--highlighted p-card--href has-top-color">
           <svg width="100%" height="80%" class="p-card--placeholder">

--- a/templates/store.html
+++ b/templates/store.html
@@ -93,7 +93,7 @@
         </div>
 
         <div id="packages" class="l-fluid-section">
-          <div class="l-fluid-breakout__main u-hide" data-js="packages-placeholder-container">
+          <div class="l-fluid-breakout__main" data-js="packages-placeholder-container">
             {% for _ in range(0, 10) %}
               <div class="l-fluid-breakout__item">
                 <a class="p-card--button" style="display: block;">
@@ -187,8 +187,8 @@
 {% block page_scripts %}
   <script src="{{ versioned_static('js/dist/store.js') }}" defer></script>
   <script>
-    window.addEventListener("DOMContentLoaded", () => {
-      new charmhub.store.initPackages();
+    window.addEventListener("DOMContentLoaded", async () => {
+      await new charmhub.store.initPackages.initialize();
       new charmhub.store.initTopics();
     });
   </script>

--- a/templates/store.html
+++ b/templates/store.html
@@ -188,7 +188,7 @@
   <script src="{{ versioned_static('js/dist/store.js') }}" defer></script>
   <script>
     window.addEventListener("DOMContentLoaded", async () => {
-      await new charmhub.store.initPackages.initialize();
+      await charmhub.store.initPackages.initialize();
       new charmhub.store.initTopics();
     });
   </script>

--- a/templates/store.html
+++ b/templates/store.html
@@ -129,17 +129,12 @@
     </div>
   </section>
 
-  <template id="package-card">
+  <template id="package-card-charm">
     <div class="l-fluid-breakout__item" data-js="card-container">
       <a href="" class="p-card--button">
         <div class="p-card__header">
           <div class="p-card__thumbnail-container">
             <img src="" alt="" width="24" height="24" class="p-card__thumbnail">
-          </div>
-          <div class="p-bundle-icons" style="margin-block-end: 6px; margin-block-start: 6px;">
-            <img src="" alt="">
-            <img src="" alt="">
-            <span class="p-bundle-icons__count u-text--muted"></span>
           </div>
           <h3 class="p-card__title p-heading--4 u-no-margin--bottom package-card-title"></h3>
           <p class="u-text--muted u-no-padding--top package-card-publisher" style="white-space: nowrap;"></p>
@@ -153,6 +148,27 @@
       </a>
     </div>
   </template>
+
+  <template id="package-card-bundle">
+    <div class="l-fluid-breakout__item" data-js="card-container">
+      <a href="" class="p-card--button">
+        <div class="p-card__header">
+	  <h3 class="p-muted-heading">Bundle</h3>
+	  <h3 class="p-card__title p-heading--4 u-no-margin--bottom package-card-title"></h3>
+	  <p class="u-text--muted u-no-padding--top package-card-publisher" style="white-space: nowrap;"></p>
+	</div>
+        <div class="p-card__content">
+	  <div class="p-bundle-icons">
+            <img src="" alt="" width="24" height="24" />
+          </div>
+        </div>
+	<div class="p-card__footer" data-js-card-footer>
+	  <div class="package-card-icons"></div>
+	</div>
+      </a>
+    </div>
+</template>
+
   <style>
     .package-card-title {
       text-transform: capitalize;

--- a/templates/store.html
+++ b/templates/store.html
@@ -94,7 +94,7 @@
 
         <div id="packages" class="l-fluid-section">
           <div class="l-fluid-breakout__main" data-js="packages-placeholder-container">
-            {% for _ in range(0, 10) %}
+            {% for _ in range(0, featured_charms|length) %}
               <div class="l-fluid-breakout__item">
                 <a class="p-card--button" style="display: block;">
                   <svg width="100%" height="100%" class="p-card--placeholder">

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -630,9 +630,7 @@ def entity_icon(entity_name):
 
 
 @store.route(
-    '/<regex("'
-    + DETAILS_VIEW_REGEX
-    + '"):entity_name>/icon-no-default'
+    '/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/icon-no-default'
 )
 def entity_icon_missing(entity_name):
     package = None

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -628,6 +628,30 @@ def entity_icon(entity_name):
         f",q_auto,fl_sanitize,w_64,h_64/{icon_url}"
     )
 
+@store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/icon-no-default')
+def entity_icon_missing(entity_name):
+    package = None
+
+    try:
+        package = app.store_api.get_item_details(
+            entity_name,
+            fields=[
+                "result.media",
+            ],
+        )
+    except StoreApiResponseErrorList:
+        pass
+
+    if package and package["result"]["media"]:
+        icon_url = package["result"]["media"][0]["url"]
+
+        return redirect(
+            "https://res.cloudinary.com/canonical/image/fetch/f_auto"
+            f",q_auto,fl_sanitize,w_64,h_64/{icon_url}"
+        )
+
+    abort(404)
+
 
 # This method is a temporary hack to show bundle icons on the
 # homepage, and should be removed once the icons are available via the api

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -628,7 +628,12 @@ def entity_icon(entity_name):
         f",q_auto,fl_sanitize,w_64,h_64/{icon_url}"
     )
 
-@store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/icon-no-default')
+
+@store.route(
+    '/<regex("'
+    + DETAILS_VIEW_REGEX
+    + '"):entity_name>/icon-no-default'
+)
 def entity_icon_missing(entity_name):
     package = None
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -633,7 +633,9 @@ def entity_icon(entity_name):
 # homepage, and should be removed once the icons are available via the api
 @store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/charms.json')
 def get_charms_from_bundle(entity_name):
-    package = get_package(entity_name)
+    package = get_package(
+        entity_name
+    )
 
     if package["type"] != "bundle":
         return "Requested object should be a bundle", 400

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -633,9 +633,7 @@ def entity_icon(entity_name):
 # homepage, and should be removed once the icons are available via the api
 @store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/charms.json')
 def get_charms_from_bundle(entity_name):
-    package = get_package(
-        entity_name
-    )
+    package = get_package(entity_name)
 
     if package["type"] != "bundle":
         return "Requested object should be a bundle", 400

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,6 +21,11 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.16.8.tgz#31560f9f29fdf1868de8cb55049538a1b9732a60"
   integrity sha512-m7OkX0IdKLKPpBlJtF561YJal5y/jyI5fNfWbPxh2D/nbzzGI4qRyrD8xO2jB24u7l+5I2a43scCG2IrfjC50Q==
 
+"@babel/compat-data@^7.17.7", "@babel/compat-data@^7.18.8":
+  version "7.18.8"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.18.8.tgz#2483f565faca607b8535590e84e7de323f27764d"
+  integrity sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==
+
 "@babel/core@7.16.7", "@babel/core@^7.1.0", "@babel/core@^7.12.3", "@babel/core@^7.7.5":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.16.7.tgz#db990f931f6d40cb9b87a0dc7d2adc749f1dcbcf"
@@ -76,6 +81,16 @@
     browserslist "^4.17.5"
     semver "^6.3.0"
 
+"@babel/helper-compilation-targets@^7.17.7":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz#69e64f57b524cde3e5ff6cc5a9f4a387ee5563bf"
+  integrity sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==
+  dependencies:
+    "@babel/compat-data" "^7.18.8"
+    "@babel/helper-validator-option" "^7.18.6"
+    browserslist "^4.20.2"
+    semver "^6.3.0"
+
 "@babel/helper-create-class-features-plugin@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.7.tgz#9c5b34b53a01f2097daf10678d65135c1b9f84ba"
@@ -106,6 +121,18 @@
     "@babel/helper-module-imports" "^7.12.13"
     "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/traverse" "^7.13.0"
+    debug "^4.1.1"
+    lodash.debounce "^4.0.8"
+    resolve "^1.14.2"
+    semver "^6.1.2"
+
+"@babel/helper-define-polyfill-provider@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.2.tgz#bd10d0aca18e8ce012755395b05a79f45eca5073"
+  integrity sha512-r9QJJ+uDWrd+94BSPcP6/de67ygLtvVy6cK4luE6MOuDsZIdoaPBnfSpbO/+LTifjPckbKXRuI9BB/Z2/y3iTg==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.17.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
     debug "^4.1.1"
     lodash.debounce "^4.0.8"
     resolve "^1.14.2"
@@ -162,6 +189,13 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
+"@babel/helper-module-imports@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
+  integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
 "@babel/helper-module-transforms@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz#7665faeb721a01ca5327ddc6bba15a5cb34b6a41"
@@ -187,6 +221,11 @@
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5"
   integrity sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
+
+"@babel/helper-plugin-utils@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz#4b8aea3b069d8cb8a72cdfe28ddf5ceca695ef2f"
+  integrity sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==
 
 "@babel/helper-remap-async-to-generator@^7.16.8":
   version "7.16.8"
@@ -234,10 +273,20 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
   integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
 
+"@babel/helper-validator-identifier@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
+  integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
+
 "@babel/helper-validator-option@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz#b203ce62ce5fe153899b617c08957de860de4d23"
   integrity sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==
+
+"@babel/helper-validator-option@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz#bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8"
+  integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
 
 "@babel/helper-wrap-function@^7.16.8":
   version "7.16.8"
@@ -767,6 +816,18 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
+"@babel/plugin-transform-runtime@7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.18.9.tgz#d9e4b1b25719307bfafbf43065ed7fb3a83adb8f"
+  integrity sha512-wS8uJwBt7/b/mzE13ktsJdmS4JP/j7PQSaADtnb4I2wL0zK51MQ0pmF8/Jy0wUIS96fr+fXT6S/ifiPXnvrlSg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.18.6"
+    "@babel/helper-plugin-utils" "^7.18.9"
+    babel-plugin-polyfill-corejs2 "^0.3.1"
+    babel-plugin-polyfill-corejs3 "^0.5.2"
+    babel-plugin-polyfill-regenerator "^0.3.1"
+    semver "^6.3.0"
+
 "@babel/plugin-transform-shorthand-properties@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz#e8549ae4afcf8382f711794c0c7b6b934c5fbd2a"
@@ -959,6 +1020,14 @@
   integrity sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.18.6":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.9.tgz#7148d64ba133d8d73a41b3172ac4b83a1452205f"
+  integrity sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -1854,6 +1923,15 @@ babel-plugin-polyfill-corejs2@^0.3.0:
     "@babel/helper-define-polyfill-provider" "^0.3.1"
     semver "^6.1.1"
 
+babel-plugin-polyfill-corejs2@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.2.tgz#e4c31d4c89b56f3cf85b92558954c66b54bd972d"
+  integrity sha512-LPnodUl3lS0/4wN3Rb+m+UK8s7lj2jcLRrjho4gLw+OJs+I4bvGXshINesY5xx/apM+biTnQ9reDI8yj+0M5+Q==
+  dependencies:
+    "@babel/compat-data" "^7.17.7"
+    "@babel/helper-define-polyfill-provider" "^0.3.2"
+    semver "^6.1.1"
+
 babel-plugin-polyfill-corejs3@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.1.tgz#d66183bf10976ea677f4149a7fcc4d8df43d4060"
@@ -1862,7 +1940,15 @@ babel-plugin-polyfill-corejs3@^0.5.0:
     "@babel/helper-define-polyfill-provider" "^0.3.1"
     core-js-compat "^3.20.0"
 
-babel-plugin-polyfill-regenerator@^0.3.0:
+babel-plugin-polyfill-corejs3@^0.5.2:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.3.tgz#d7e09c9a899079d71a8b670c6181af56ec19c5c7"
+  integrity sha512-zKsXDh0XjnrUEW0mxIHLfjBfnXSMr5Q/goMe/fxpQnLm07mcOZiIZHBNWCMx60HmdvjxfXcalac0tfFg0wqxyw==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.3.2"
+    core-js-compat "^3.21.0"
+
+babel-plugin-polyfill-regenerator@^0.3.0, babel-plugin-polyfill-regenerator@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.1.tgz#2c0678ea47c75c8cc2fbb1852278d8fb68233990"
   integrity sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==
@@ -2073,6 +2159,16 @@ browserslist@^4.12.0, browserslist@^4.17.5, browserslist@^4.19.1:
     node-releases "^2.0.1"
     picocolors "^1.0.0"
 
+browserslist@^4.20.2, browserslist@^4.21.2:
+  version "4.21.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.2.tgz#59a400757465535954946a400b841ed37e2b4ecf"
+  integrity sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==
+  dependencies:
+    caniuse-lite "^1.0.30001366"
+    electron-to-chromium "^1.4.188"
+    node-releases "^2.0.6"
+    update-browserslist-db "^1.0.4"
+
 browserslist@^4.20.3:
   version "4.20.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.20.3.tgz#eb7572f49ec430e054f56d52ff0ebe9be915f8bf"
@@ -2211,6 +2307,11 @@ caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001335:
   version "1.0.30001341"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz#59590c8ffa8b5939cf4161f00827b8873ad72498"
   integrity sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==
+
+caniuse-lite@^1.0.30001366:
+  version "1.0.30001370"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz#0a30d4f20d38b9e108cc5ae7cc62df9fe66cd5ba"
+  integrity sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -2495,6 +2596,14 @@ core-js-compat@^3.20.0, core-js-compat@^3.20.2:
   integrity sha512-c8M5h0IkNZ+I92QhIpuSijOxGAcj3lgpsWdkCqmUTZNwidujF4r3pi6x1DCN+Vcs5qTS2XWWMfWSuCqyupX8gw==
   dependencies:
     browserslist "^4.19.1"
+    semver "7.0.0"
+
+core-js-compat@^3.21.0:
+  version "3.24.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.24.0.tgz#885958fac38bf3f4464a90f2663b4620f6aee6e3"
+  integrity sha512-F+2E63X3ff/nj8uIrf8Rf24UDGIz7p838+xjEp+Bx3y8OWXj+VTPPZNCtdqovPaS9o7Tka5mCH01Zn5vOd6UQg==
+  dependencies:
+    browserslist "^4.21.2"
     semver "7.0.0"
 
 core-util-is@~1.0.0:
@@ -3098,6 +3207,11 @@ electron-to-chromium@^1.4.17:
   version "1.4.46"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.46.tgz#c88a6fedc766589826db0481602a888864ade1ca"
   integrity sha512-UtV0xUA/dibCKKP2JMxOpDtXR74zABevuUEH4K0tvduFSIoxRVcYmQsbB51kXsFTX8MmOyWMt8tuZAlmDOqkrQ==
+
+electron-to-chromium@^1.4.188:
+  version "1.4.200"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.200.tgz#6e4c5266106688965b4ea7caa11f0dd315586854"
+  integrity sha512-nPyI7oHc8T64oSqRXrAt99gNMpk0SAgPHw/o+hkNKyb5+bcdnFtZcSO9FUJES5cVkVZvo8u4qiZ1gQILl8UXsA==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -5710,6 +5824,11 @@ node-releases@^2.0.3:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.4.tgz#f38252370c43854dc48aa431c766c6c398f40476"
   integrity sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==
 
+node-releases@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
+  integrity sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==
+
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -7754,6 +7873,14 @@ upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
+update-browserslist-db@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz#be06a5eedd62f107b7c19eb5bcefb194411abf38"
+  integrity sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==
+  dependencies:
+    escalade "^3.1.1"
+    picocolors "^1.0.0"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
## Done
- Initial bundle cards
- When the browser resizes the number of charms, adjusts for the space – this is not 100% accurate but is more cautious
- *NOTE FOR UX AND DESIGN* The design in https://app.zeplin.io/project/623c85b9b27d9fa62165f655/screen/624d4b3079f687143e35527e shows 3 rows, but doesn't consider bundles that have double-line names. As such, I've limited the maximum charm rows to 2. Happy to adjust if need be.

## How to QA
- Visit https://charmhub-io-1378.demos.haus/ and use the main listing page to see some bundles. Filter, search, etc.
- A good candidate to search for is "kubeflow"
- "openstack" also has bundles with lot's of icons

## Issue / Card
Fixes #1359 

## Screenshots
![image](https://user-images.githubusercontent.com/479384/180978637-83d7f92c-ca00-4bf5-8174-6fb8882a04ea.png)