### PR TITLE
Fix: rename delete package route

### DIFF
--- a/templates/publisher/list.html
+++ b/templates/publisher/list.html
@@ -338,7 +338,7 @@
       const formData = new FormData();
       formData.set("csrf_token", "{{ csrf_token() }}");
         
-      const response = await fetch(`/${currentPackage}`, {
+      const response = await fetch(`/packages/${currentPackage}`, {
         method: "DELETE",
         body: formData,
       });

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -432,7 +432,7 @@ def register_name_dispute_thank_you():
     )
 
 
-@publisher.route("/<package_name>", methods=["DELETE"])
+@publisher.route("/packages/<package_name>", methods=["DELETE"])
 @login_required
 def delete_package(package_name):
     resp = publisher_api.unregister_package_name(


### PR DESCRIPTION
## Done

- Rename delete package route to avoid conflict with default 404 route.

## How to QA

- Go to https://charmhub-io-1834.demos.haus/non+exisiting+page , get 404 instead of 405
- Make sure unregistering a charm still works


## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): is a  bug fix

## Issue / Card
Fixes [#WD-11678
](https://warthogs.atlassian.net/browse/WD-11678?atlOrigin=eyJpIjoiY2VhNTQ4MmY2NGI5NGM0OTk3ODFiZTRmNTVlN2VmN2IiLCJwIjoiaiJ9)