### PR TITLE
fix: remove revoke collaborator exception handler

### DIFF
--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -307,9 +307,6 @@ def revoke_invite(entity_name):
             for error in error_list.errors
         ]
         res["message"] = (" ").join(messages)
-    except Exception:
-        res["success"] = False
-        res["message"] = "An error occurred"
 
     return make_response(res, 500)
 


### PR DESCRIPTION

## Done
- Remove generic exception handler so that errors propagate properly and are recieved on Sentry

## QA
- raise an error in the try block (through `assert 1==2` or similar), see that error isn't caught. If you have sentry set up, you will see the error there.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no change in functionality

## Issue / Card
Fixes [WD-11732](https://warthogs.atlassian.net/browse/WD-11732)



[WD-11732]: https://warthogs.atlassian.net/browse/WD-11732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ