### PR TITLE
fix: allow crawlers to access index

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -879,7 +879,6 @@ def get_charms_from_bundle(entity_name):
 
 
 @store.route("/")
-def beta_store_index():
+def store_index():
     response = make_response(render_template("store.html"))
-    response.headers["X-Robots-Tag"] = "noindex"
     return response


### PR DESCRIPTION
## Done
- Allow crawlers to index store homepage
## How to QA

- visit https://charmhub-io-1847.demos.haus/ 
- Check `x-robots-tag` header is removed.

## Testing
- [] This PR has tests
- [x] No testing required (explain why): Headers fix

