### PR TITLE
fix: limit publisher route to only defined ones

### DIFF
--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -32,7 +32,10 @@ def get_account_details():
 
 
 @publisher.route(
-    '/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/<path:path>',
+    '/<regex("'
+    + DETAILS_VIEW_REGEX
+    + '"):entity_name>/'
+    + '<regex("listing|releases|publicise|collaboration|settings"):path>'
 )
 @login_required
 def get_publisher(entity_name, path):


### PR DESCRIPTION
## Done
- currently going to any page with the pattern: https://charmhub.io/foo/bar/ redirects to login, this behavior is faulty and is throwing off google SEO with many false positives

## How to QA
- go to https://charmhub-io-1896.demos.haus/foo/bar/
- get 404 instead of login redirect
- go to actual publisher pages, make sure none of those are broken

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): fixing redirect
