### PR TITLE
chore: init charm

### DIFF
--- a/charm/.gitignore
+++ b/charm/.gitignore
@@ -1,0 +1,9 @@
+venv/
+build/
+*.charm
+.tox/
+.coverage
+__pycache__/
+*.py[cod]
+.idea
+.vscode/

--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -1,0 +1,18 @@
+name: charmhub-io
+
+type: charm
+
+bases:
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+    run-on:
+    - name: ubuntu
+      channel: "22.04"
+
+summary: The charm for the charmhub.io website
+
+description: The charm for the charmhub.io website, built with PaaS app charmer
+
+extensions:
+  - flask-framework

--- a/charm/requirements.txt
+++ b/charm/requirements.txt
@@ -1,0 +1,1 @@
+paas-app-charmer==1.*

--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright 2024 Moe Isk
+# See LICENSE file for licensing details.
+
+"""Flask Charm entrypoint."""
+
+import logging
+import typing
+
+import ops
+
+import paas_app_charmer.flask
+
+logger = logging.getLogger(__name__)
+
+
+class FlaskCharm(paas_app_charmer.flask.Charm):
+    """Flask Charm service."""
+
+    def __init__(self, *args: typing.Any) -> None:
+        """Initialize the instance.
+
+        Args:
+            args: passthrough to CharmBase.
+        """
+        super().__init__(*args)
+
+
+if __name__ == "__main__":
+    ops.main.main(FlaskCharm)


### PR DESCRIPTION
## Done

This PR adds the basic boilerplate for the charm using the PaaS app charm. 

Note: although PaaS charmer requires some libs to be included, we defer fetching them until deployment due to the size being too large and the 