### PR TITLE
fix: release resource type condition

### DIFF
--- a/static/js/src/publisher-admin/utils/__tests__/generateReleaseChannelRows.test.tsx
+++ b/static/js/src/publisher-admin/utils/__tests__/generateReleaseChannelRows.test.tsx
@@ -91,7 +91,7 @@ describe("generateReleaseChannelRows", () => {
 
   test("renders ResourcesCell correctly", () => {
     const resources: Resource[] = [
-      { name: "resource1", type: "oci", revision: 1 },
+      { name: "resource1", type: "oci-image", revision: 1 },
       { name: "resource2", type: "file", revision: null },
     ];
 

--- a/static/js/src/publisher-admin/utils/generateReleaseChannelRows.tsx
+++ b/static/js/src/publisher-admin/utils/generateReleaseChannelRows.tsx
@@ -106,7 +106,7 @@ export function generateReleaseChannelRows(
 
 export function ResourcesCell({ resources }: { resources: Resource[] }) {
   const items = resources.map((resource) => {
-    const type = resource.type === "oci" ? "OCI Image" : "File";
+    const type = resource.type === "oci-image" ? "OCI Image" : "File";
 
     return (
       <>


### PR DESCRIPTION
## Done
Fix condition for resource type

## How to QA
- Go to /releases for a charm with resources (ex `moes-charm`)
- verify OCI-image type is shown correct and isn't showing as file
## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): bug fix
