### PR TITLE
chore: bump canonical python libs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-canonicalwebteam.flask-base==1.1.0
+canonicalwebteam.flask-base==2.0.0
 beautifulsoup4==4.12.3
 canonicalwebteam.candid==0.9.0
-canonicalwebteam.discourse==5.6.1
+canonicalwebteam.discourse==5.7.2
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.store-api==4.13.2
 canonicalwebteam.docstring-extractor==1.2.0
-canonicalwebteam.store-base==1.0.1
+canonicalwebteam.store-base==1.1.0
 
 Flask-WTF==1.2.1
 humanize==4.9.0


### PR DESCRIPTION
## Done
- Bump canonical python libs. most importantly, bump flask-base to 2.0.0 
## How to QA
- Click around, make sure things arent broken
## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): bump versions
