### PR TITLE
feat: allow specifying channel for badge

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -705,17 +705,28 @@ def details_integrate(entity_name):
 def entity_badge(entity_name):
     package = app.store_api.get_item_details(entity_name, fields=FIELDS)
 
+    channel_request = request.args.get("channel")
+
     if not package["default-release"]:
         abort(404)
+
+    release = package["default-release"]
+
+    if channel_request:
+        for release_channel in package["channel-map"]:
+            channel = release_channel["channel"]
+            if f"{channel['track']}/{channel['risk']}" == channel_request:
+                release = release_channel
+                break
 
     entity_link = request.url_root + entity_name
     right_text = "".join(
         [
-            package["default-release"]["channel"]["track"],
+            release["channel"]["track"],
             "/",
-            package["default-release"]["channel"]["risk"],
+            release["channel"]["risk"],
             " ",
-            package["default-release"]["revision"]["version"],
+            release["revision"]["version"],
         ]
     )
 


### PR DESCRIPTION
## Done
- Optionally allow specfying channel for publicise badge
## How to QA
- go to `https://charmhub-io-1970.demos.haus/postgresql/badge.svg?channel=latest/stable`
- go to `https://charmhub-io-1970.demos.haus/postgresql/badge.svg?channel=14/stable`
- see different channel information.

Fixes  #1473 