### PR TITLE
feat: show digest for OCI images in resources tab

### DIFF
--- a/templates/details/resources.html
+++ b/templates/details/resources.html
@@ -70,6 +70,8 @@
           <th>Date</th>
           {% if resource.type == "file" %}
             <th>Size</th>
+          {% else %}
+            <th>Digest</th>
           {% endif %}
         </tr>
       </thead>
@@ -80,6 +82,8 @@
             <td>{{ revision.updated }}</td>
             {% if resource.type == "file" %}
               <td>{{ revision.size }}</td>
+          {% else %}
+            <td>{{ revision.download["hash-sha-256"][:12] }}</td>
             {% endif %}
           </tr>
         {% endfor %}


### PR DESCRIPTION
## Done
- Show digest for OCI images in resources tab. This can be useful to know what the actual resource is since it can be cross reference with the docker registry.
 
## How to QA
- go to `/charm/resources`
- If resource is an oci image, short digest should be displayed.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no new logic

## Issue / Card
Partially addresses #1548, Although this is a larger UX issue