### PR TITLE
fix: remove unused publisher code

### DIFF
--- a/templates/publisher/list.html
+++ b/templates/publisher/list.html
@@ -280,12 +280,7 @@
 {% endblock %}
 
 {% block page_scripts %}
-<script src="{{ versioned_static('js/dist/list.js') }}" defer></script>
 <script>
-  window.addEventListener("DOMContentLoaded", function () {
-    charmhub.publisher.list.init();
-  });
-
   // De-register charms and bundles
   const unregisterConfirmationModal = document.querySelector(
     "[data-js='unregister-confirmation-modal']"


### PR DESCRIPTION
## Done
- Remove access to non existing file which was causing JS errors when accessing /charms
## How to QA
- go to https://charmhub-io-1995.demos.haus/charms get no console errors about non existing files or `charmhub.publisher is not defined`


## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): is bug fix
