### PR TITLE
fix: digests not showing for paginated rows

### DIFF
--- a/templates/details/resources.html
+++ b/templates/details/resources.html
@@ -179,6 +179,10 @@
         var fileCell = document.createElement("td");
         fileCell.innerText = release.download.size * 1000 * 1000;
         tableRow.appendChild(fileCell);
+      } else {
+        var digestCell = document.createElement("td");
+        digestCell.innerText = release.download["hash-sha-256"].slice(0, 12);
+        tableRow.appendChild(digestCell);
       }
 
       revisionsTableBody.appendChild(tableRow);


### PR DESCRIPTION
## Done
- Fix hash not showing when clicking "show more" in resources tab
## How to QA
- go to https://charmhub-io-2003.demos.haus/charmhub-io/resources/flask-app-image
- click "show 10 more"
- new rows have digest hash
## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): is a bug fix

