### PR TITLE
render resource description as MD and add upstream source

### DIFF
--- a/templates/details/resources.html
+++ b/templates/details/resources.html
@@ -30,6 +30,10 @@
       </span>
     </h2>
 
+    {% if resource.upstream_source %}
+      <p><strong>Upstream source:</strong> {{ resource.upstream_source }}</p>
+    {% endif %}
+
     <ul class="p-detail-inline-list">
       <li class="p-inline-list__item">
         <i class="p-icon--revisions" style="margin-right: 5px;"></i> Revision: {{ resource.revision }}
@@ -59,7 +63,7 @@
       </li>
     </ul>
 
-    <p>{{ resource.description }}</p>
+    <p>{{ resource.description | markdown | safe }}</p>
 
     <h3 class="p-heading--5">Release history</h3>
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -709,6 +709,16 @@ def details_resource(entity_name, resource_name):
         ].split("@")
         resource["short_digest"] = resource["digest"].split(":")[1][:12]
 
+    # Get upstream-source (if available)
+    metadata_resources = package["store_front"]["metadata"].get(
+        "resources", {}
+    )
+    if resource_name in metadata_resources:
+        upstream = metadata_resources[resource_name].get("upstream-source")
+        resource["upstream_source"] = upstream
+    else:
+        resource["upstream_source"] = None
+
     revisions = device_gateway.get_resource_revisions(
         entity_name, resource_name
     )


### PR DESCRIPTION
## Done
- Fixes resource description so it renders markdown
- Adds `upstream-source` to resources

## How to QA
- Go to some charms with resources and check that markdown is rendered and that there is an `upstream-source` displayed if the resource has one, e.g.:
  - https://charmhub-io-2151.demos.haus/redis-k8s/resources/redis-image
  - https://charmhub-io-2151.demos.haus/traefik-k8s/resources/traefik-image
  - https://charmhub-io-2151.demos.haus/alertmanager-k8s/resources/alertmanager-image

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): adding additional field

## Issue / Card
Fixes [WD-7482](https://warthogs.atlassian.net/browse/WD-7482) and [1706](https://github.com/canonical/charmhub.io/issues/1706)


[WD-7482]: https://warthogs.atlassian.net/browse/WD-7482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ