### PR TITLE
feat: update docs link to use ReadTheDocs

### DIFF
--- a/templates/details/_side-nav.html
+++ b/templates/details/_side-nav.html
@@ -32,6 +32,11 @@
     </div>
   </nav>
 {% endif %}
+
+{% if doc_url and is_rtd %}
+  <a href="{{ doc_url }}" class="p-button">Read documentation</a>
+{% endif %}
+
 {#{% if package.result.summary %}
   <h4 class="p-heading--5 u-no-margin--bottom">About</h4>
   <p data-js="summary" data-summary="{{ package.result.summary }}">

--- a/tests/mock_data/mock_store_logic.py
+++ b/tests/mock_data/mock_store_logic.py
@@ -497,3 +497,130 @@ sample_charm = {
     },
     "type": "charm",
 }
+
+sample_package_detail = {
+    "channel-map": [
+        {
+            "channel": {
+                "base": {
+                    "architecture": "amd64",
+                    "channel": "22.04",
+                    "name": "ubuntu",
+                },
+                "name": "1.16/stable",
+                "released-at": "2025-01-20T21:44:16.705435+00:00",
+                "risk": "stable",
+                "track": "1.16",
+            },
+            "revision": {
+                "attributes": {"framework": "operator", "language": "python"},
+                "bases": [
+                    {
+                        "architecture": "amd64",
+                        "channel": "22.04",
+                        "name": "ubuntu",
+                    }
+                ],
+                "created-at": "2025-01-17T21:09:54.005947+00:00",
+                "download": {
+                    "hash-sha-256": "xx",
+                    "size": 35749287,
+                    "url": "https://api.charmhub.io/xxx.charm",
+                },
+                "revision": 323,
+                "version": "323",
+            },
+        }
+    ],
+    "default-release": {
+        "channel": {
+            "base": {
+                "architecture": "amd64",
+                "channel": "22.04",
+                "name": "ubuntu",
+            },
+            "name": "1.16/stable",
+            "released-at": "2025-01-20T21:44:16.705435+00:00",
+            "risk": "stable",
+            "track": "1.16",
+        },
+        "resources": [
+            {
+                "created-at": "2024-08-07T10:21:41.554301",
+                "description": "OCI image for Vault",
+                "download": {
+                    "hash-sha-256": "xxxx",
+                    "hash-sha-384": "xxxx",
+                    "hash-sha-512": "xxxx",
+                    "hash-sha3-384": "xxxx",
+                    "size": 501,
+                    "url": "https://xxx",
+                },
+                "filename": "",
+                "name": "vault-image",
+                "revision": 84,
+                "type": "oci-image",
+            }
+        ],
+        "revision": {
+            "actions-yaml": "{}\n",
+            "attributes": {"framework": "operator", "language": "python"},
+            "bases": [
+                {"architecture": "amd64", "channel": "22.04", "name": "ubuntu"}
+            ],
+            "bundle-yaml": "{}\n",
+            "config-yaml": "{}\n",
+            "created-at": "2025-01-17T21:09:54.005947+00:00",
+            "download": {
+                "hash-sha-256": "xxx",
+                "size": 35749287,
+                "url": "https://xxx",
+            },
+            "metadata-yaml": "{}\n",
+            "readme-md": "# Vault",
+            "relations": {
+                "provides": {
+                    "grafana-dashboard": {"interface": "grafana_dashboard"},
+                },
+                "requires": {
+                    "ingress": {"interface": "ingress"},
+                },
+            },
+            "revision": 323,
+            "version": "323",
+        },
+    },
+    "id": "mangoawzhPY46mXnnG8h9MKhY6SUF5Pn",
+    "name": "test",
+    "result": {
+        "bugs-url": "https://github.com/canonical/xxx",
+        "categories": [],
+        "deployable-on": ["kubernetes"],
+        "links": {
+            "contact": ["https://test"],
+            "docs": ["https://discourse.charmhub.io/t/xxx"],
+            "issues": ["https://github.com/canonical/xxx"],
+            "source": ["https://github.com/canonical/xxx"],
+            "website": ["https://charmhub.io/xxx"],
+        },
+        "media": [
+            {
+                "height": None,
+                "type": "icon",
+                "url": "https://api.charmhub.io/xxx",
+                "width": None,
+            }
+        ],
+        "publisher": {
+            "display-name": "Test Publisher",
+            "id": "xxxx",
+            "username": "publisher",
+            "validation": "unproven",
+        },
+        "summary": "A tool for managing secrets",
+        "title": "Test",
+        "unlisted": False,
+        "website": "https://charmhub.io/xxx",
+    },
+    "type": "charm",
+}

--- a/tests/store/test_details_overview.py
+++ b/tests/store/test_details_overview.py
@@ -1,0 +1,29 @@
+from unittest import TestCase
+from unittest.mock import patch
+from webapp.app import app
+from mock_data.mock_store_logic import sample_package_detail
+import copy
+
+
+class TestDetailsOverview(TestCase):
+    def setUp(self):
+        app.testing = True
+        self.client = app.test_client()
+
+    @patch("webapp.store_api.publisher_gateway.get_item_details")
+    def test_details_with_discourse_link(self, mock_find):
+        mock_find.return_value = sample_package_detail
+        response = self.client.get("/test")
+        self.assertNotIn(b"Read documentation", response.data)
+        self.assertEqual(response.status_code, 200)
+
+    @patch("webapp.store_api.publisher_gateway.get_item_details")
+    def test_details_with_readthedocs_link(self, mock_find):
+        data = copy.deepcopy(sample_package_detail)
+        data["result"]["links"]["docs"] = [
+            "https://readthedocs.charmhub.io/t/xxx"
+        ]
+        mock_find.return_value = data
+        response = self.client.get("/test")
+        self.assertIn(b"Read documentation", response.data)
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Done
- if the docs url includes "discourse" url keep the existing behaviour
- else:
     - render the readme file
     -  add "read the doc" link that navigates to the documentation
     - dont render the side navigation

## How to QA
right now there is no charm with readthedoc link. 
- checkout the feature branch
- update the "details_overview" function
     - update the  package["result"]["links"]["docs"] = ["https://canonical-vault-charms.readthedocs-hosted.com/en/latest/"]
 - verify the side navigation isnt rendered, readme is rendered & read the doc button is displayed
 - click on the read the doc button
 - verify it navigates to the correct documentation

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-23959

## Screenshots
<img width="1333" height="1018" alt="Screenshot 2025-07-28 at 9 24 38 PM" src="https://github.com/user-attachments/assets/c09fbcf7-9f72-4c58-b586-2d375b4a6722" />

