### PR TITLE
Fix docs page

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -355,7 +355,7 @@ def details_docs(entity_name, path=None):
     if not package["store_front"]["docs_topic"]:
         return redirect(url_for(".details_overview", entity_name=entity_name))
     key = (
-        f"{entity_name}:details-docs",
+        f"{entity_name}:details-docs:{path}",
         {"channel": channel_request, "fields": ",".join(sorted(all_fields))},
     )
     context = redis_cache.get(key, expected_type=dict)


### PR DESCRIPTION
## Done
- Fix docs oage showing wrong content
## How to QA
- Go to https://charmhub-io-2195.demos.haus/opensearch/docs/
- click around the how-to guides and other links in the side-bar, check that content displayed matches the slug
## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes #

## Screenshots
