### PR TITLE
fix requires and provides

### DIFF
--- a/webapp/packages/logic.py
+++ b/webapp/packages/logic.py
@@ -60,6 +60,8 @@ def fetch_packages(
     query = query_params.get("q", "")
     package_type = query_params.get("type", None)
     platform = query_params.get("platforms", "")
+    provides = query_params.get("provides", None)
+    requires = query_params.get("requires", None)
 
     args = {
         "category": category,
@@ -67,16 +69,20 @@ def fetch_packages(
         "query": query,
     }
 
+    if provides:
+        args["provides"] = provides.split(",")
+
+    if requires:
+        args["requires"] = requires.split(",")
+
     if package_type and package_type != "all":
         args["type"] = package_type
 
     key = (
         "fetch-packages",
         {
-            "category": category,
-            "q": query,
-            "platform": platform,
-            "type": package_type,
+            **query_params,
+            "fields": tuple(fields),
         },
     )
     result = redis_cache.get(key, expected_type=list)


### PR DESCRIPTION
## Done
- Fix requires and provides missing from arguments 
## How to QA
 
Go to `/kafka/integrations`, not all  charm integrations are the same

(actual problem)
- Hit `store.json?requires=<some-interface>`
- Verify output matches `https://api.snapcraft.io/v2/charms/find?requires=<same interface>`

Ideally, try other api parameters listed [here](https://api.snapcraft.io/docs/charms.html#charm_find)

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes #

## Screenshots
