### PR TITLE
tidy solution preview page

### DIFF
--- a/templates/solutions/_header.html
+++ b/templates/solutions/_header.html
@@ -65,10 +65,12 @@
           {% else %}
             <span>{{ deployment }}</span>
           {% endif %}
-          {% for version in deployment["version"] %}
-            <div class="u-text--muted">Version <strong>{{ version }}</strong></div>
-          {% endfor %}
-          {% if deployment["prerequisites"] %}
+          {% if deployment.get("version") and deployment["version"] | length > 0 %}
+            {% for version in deployment["version"] %}
+              <div class="u-text--muted">Version <strong>{{ version }}</strong></div>
+            {% endfor %}
+          {% endif %}
+          {% if deployment.get("prerequisites") and deployment["prerequisites"] | length > 0 %}
             <div class="u-text--muted">
               {{ deployment["prerequisites"] | join(", ") }}
               <span class="p-tooltip--btm-right" aria-describedby="btm-rgt">
@@ -85,11 +87,15 @@
     <div class="grid-col-2"></div>
     <div class="grid-col-6 p-section--shallow u-no-padding--bottom">
       <hr class="p-separator--shallow p-rule--muted u-no-margin--top">
-      <a class="p-button--positive" href="{{ solution.documentation.get_started }}">View implementation guide</a>
-      <span>
-        <i class="p-icon--revisions"></i>
-        <span class="u-text--muted">Updated {{ solution.last_updated | humanize_date }}</span>
-      </span>
+      {% if solution.documentation.get_started %}
+        <a class="p-button--positive" href="{{ solution.documentation.get_started }}">View implementation guide</a>
+      {% endif %}
+      {% if solution.last_updated %}
+        <span>
+          <i class="p-icon--revisions"></i>
+          <span class="u-text--muted">Updated {{ solution.last_updated | humanize_date }}</span>
+        </span>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/templates/solutions/_side-nav.html
+++ b/templates/solutions/_side-nav.html
@@ -1,74 +1,83 @@
 <div class="p-section">
-  <h4 class="p-muted-heading">Solution details</h4>
-  <ul class="p-list">
-    {% if solution.documentation.main %}
-      <li class="p-list__item u-no-margin--bottom">
-        <a href="{{ solution.documentation.main }}"><i class="p-icon--file-blank"></i>&nbsp;&nbsp;Documentation</a>
-      </li>
+  {% if is_preview and solution.status == "pending_name_review" %}
+      <h4 class="p-muted-heading">Preview Mode</h4>
+      <p class="u-text--muted">This is a preview of your registered solution. Additional details can be added after approval.</p>
+  {% else %}
+    <h4 class="p-muted-heading">Solution details</h4>
+    {% if solution.documentation.main or solution.documentation.source or solution.terraform_modules %}
+      <ul class="p-list">
+        {% if solution.documentation.main %}
+          <li class="p-list__item u-no-margin--bottom">
+            <a href="{{ solution.documentation.main }}"><i class="p-icon--file-blank"></i>&nbsp;&nbsp;Documentation</a>
+          </li>
+        {% endif %}
+        {% if solution.documentation.source %}
+          <li class="p-list__item">
+            <a href="{{ solution.documentation.source }}"><i class="p-icon--github"></i>&nbsp;&nbsp;Source</a>
+          </li>
+        {% endif %}
+        {% if solution.terraform_modules %}
+          <li class="p-list__item">
+            <a href="{{ solution.terraform_modules }}"><i class="p-icon--repository"></i>&nbsp;&nbsp;Terraform modules</a>
+          </li>
+        {% endif %}
+      </ul>
     {% endif %}
-    {% if solution.documentation.source %}
-      <li class="p-list__item">
-        <a href="{{ solution.documentation.source }}"><i class="p-icon--github"></i>&nbsp;&nbsp;Source</a>
-      </li>
-    {% endif %}
-    {% if solution.terraform_modules %}
-      <li class="p-list__item">
-        <a href="{{ solution.terraform_modules }}"><i class="p-icon--repository"></i>&nbsp;&nbsp;Terraform modules</a>
-      </li>
-    {% endif %}
-  </ul>
 
-  {% if solution.compatibility.juju_versions %}
-    <hr class="p-separator--shallow">
-    <h5 class="p-muted-heading u-text--muted">Juju version</h5>
-    <p class="u-no-margin--bottom">{{ solution.compatibility.juju_versions | join(", ") }}</p>
-  {% endif %}
+    {% if solution.compatibility.juju_versions and solution.compatibility.juju_versions | length > 0 %}
+      <hr class="p-separator--shallow">
+      <h5 class="p-muted-heading u-text--muted">Juju version</h5>
+      <p class="u-no-margin--bottom">{{ solution.compatibility.juju_versions | join(", ") }}</p>
+    {% endif %}
 
-  {% if solution.charms %}
-    <hr class="p-separator--shallow">
-    <h5 class="p-muted-heading u-text--muted">Charms used</h5>
-    <div id="charms-list">
-      {% for charm in solution.charms %}
-        <div class="charm-card" style="padding: 0.5rem; margin-bottom: 0.5rem; {% if loop.index > 5 %}display: none;{% endif %}">
-          {% if charm.icon %}
-            <img class="p-card__thumbnail u-vertical-align--middle" src="{{ charm.icon }}" alt="{{ charm.title }}" style="padding-right: 0.5rem;">
-          {% endif %}
-          <span>
-            <a class="u-vertical-align--middle" href="{{ charm.url }}">{{ (charm.title or charm.name) | truncate(28) }}</a>
-          </span>
+    {% if solution.charms and solution.charms | length > 0 %}
+      <hr class="p-separator--shallow">
+      <h5 class="p-muted-heading u-text--muted">Charms used</h5>
+      <div id="charms-list">
+        {% for charm in solution.charms %}
+          <div class="charm-card" style="padding: 0.5rem; margin-bottom: 0.5rem; {% if loop.index > 5 %}display: none;{% endif %}">
+            {% if charm.icon %}
+              <img class="p-card__thumbnail u-vertical-align--middle" src="{{ charm.icon }}" alt="{{ charm.title }}" style="padding-right: 0.5rem;">
+            {% endif %}
+            <span>
+              <a class="u-vertical-align--middle" href="{{ charm.url }}">{{ (charm.title or charm.name) | truncate(28) }}</a>
+            </span>
+          </div>
+        {% endfor %}
+      </div>
+      {% if solution.charms | length > 5 %}
+        <button id="load-more-charms" class="p-button--link">
+          <span class="button-text">See all ({{ solution.charms | length }})</span>
+          <i class="p-icon--spinner u-animation--spin" style="display: none;"></i>
+        </button>
+      {% endif %}
+    {% endif %}
+
+    {% if solution.maintainers and solution.maintainers | length > 0 %}
+      <hr class="p-separator--shallow">
+      <h5 class="p-muted-heading u-text--muted">Maintainers</h5>
+      {% for maintainer in solution.maintainers %}
+        <div style="margin-bottom: 0.5rem;">
+          <a href="mailto:{{ maintainer.email }}"><i class="p-icon--user"></i>&nbsp;&nbsp;{{ maintainer.display_name }}</a>
         </div>
       {% endfor %}
-    </div>
-    {% if solution.charms | length > 5 %}
-      <button id="load-more-charms" class="p-button--link">
-        <span class="button-text">See all ({{ solution.charms | length }})</span>
-        <i class="p-icon--spinner u-animation--spin" style="display: none;"></i>
-      </button>
+    {% endif %}
+
+    {% if solution.documentation.submit_a_bug %}
+      <hr class="p-separator--shallow p-rule--muted">
+      <div>
+        <a href="{{ solution.documentation.submit_a_bug }}"><i class="p-icon--bug"></i>&nbsp;&nbsp;Submit a bug</a>
+      </div>
+    {% endif %}
+
+    {% if solution.documentation.community_discussion %}
+      <hr class="p-separator--shallow p-rule--muted">
+      <div>
+        <p>Share your thoughts on this solution with the community on Discourse.</p>
+        <p><a class="p-button" href="{{ solution.documentation.community_discussion }}">Join the discussion</a></p>
+      </div>
     {% endif %}
   {% endif %}
-
-  {% if solution.maintainers %}
-    <hr class="p-separator--shallow">
-    <h5 class="p-muted-heading u-text--muted">Maintainers</h5>
-    {% for maintainer in solution.maintainers %}
-      <div style="margin-bottom: 0.5rem;">
-        <a href="mailto:{{ maintainer.email }}"><i class="p-icon--user"></i>&nbsp;&nbsp;{{ maintainer.display_name }}</a>
-      </div>
-    {% endfor %}
-  {% endif %}
-
-  <hr class="p-separator--shallow p-rule--muted">
-
-  <div>
-    <a href="{{ solution.documentation.submit_a_bug }}"><i class="p-icon--bug"></i>&nbsp;&nbsp;Submit a bug</a>
-  </div>
-
-  <hr class="p-separator--shallow p-rule--muted">
-
-  <div>
-    <p>Share your thoughts on this solution with the community on Discourse.</p>
-    <p><a class="p-button" href="{{ solution.documentation.community_discussion }}">Join the discussion</a></p>
-  </div>
 
 </div>
 

--- a/templates/solutions/solutions_details.html
+++ b/templates/solutions/solutions_details.html
@@ -1,10 +1,12 @@
 <div>
-  <div class="p-section--shallow u-no-padding--top">
-    <h4 style="font-weight: 500">{{ solution.title }}</h4>
-    {{ solution.description_html | safe }}
-  </div>
+  {% if solution.description_html %}
+    <div class="p-section--shallow u-no-padding--top">
+      <h4 style="font-weight: 500">{{ solution.title }}</h4>
+      {{ solution.description_html | safe }}
+    </div>
+  {% endif %}
 
-  {% if solution.use_cases %}
+  {% if solution.use_cases and solution.use_cases | length > 0 %}
     <hr class="p-separator--shallow">
     <div class="p-section--shallow u-no-padding--top">
       <h4 style="font-weight: 500">Use cases</h4>
@@ -20,20 +22,20 @@
     </div>
   {% endif %}
 
-  {% if solution.media.architecture_diagram or solution.documentation.architecture_explanation %}
+  {% if solution.media.architecture_diagram or (solution.documentation.architecture_explanation and solution.documentation.architecture_explanation != "None" and solution.documentation.architecture_explanation != "") %}
     <hr class="p-separator--shallow">
     <div class="p-section--shallow u-no-padding--top">
       <h4 style="font-weight: 500">Architecture</h4>
       {% if solution.media.architecture_diagram %}
         <img src="{{ solution.media.architecture_diagram }}" alt="{{ solution.title }} architecture diagram" loading="lazy">
       {% endif %}
-      {% if solution.documentation.architecture_explanation and solution.documentation.architecture_explanation != "None" %}
+      {% if solution.documentation.architecture_explanation and solution.documentation.architecture_explanation != "None" and solution.documentation.architecture_explanation != "" %}
         <div class="u-sv1">{{ solution.architecture_explanation_html | safe }}</div>
       {% endif %}
     </div>
   {% endif %}
 
-  {% if solution.charms %}
+  {% if solution.charms and solution.charms | length > 0 %}
     <hr class="p-separator--shallow">
     <div class="p-section--shallow u-no-padding--top">
       <h4 style="font-weight: 500">Charms</h4>
@@ -53,7 +55,7 @@
     </div>
   {% endif %}
 
-  {% if solution.useful_links %}
+  {% if solution.useful_links and solution.useful_links | length > 0 %}
     <hr class="p-separator--shallow">
     <div class="p-section--deep u-no-padding--top">
       <div class="grid-row">


### PR DESCRIPTION
## Done
- Tidies solution preview page to only show fields that have a value
- Makes initial preview minimal

## How to QA
- Check out [solutions service](https://github.com/canonical/charmhub-solutions-service) and run it locally using `docker compose up --build`
- Check out this PR and run it locally
- Go to http://localhost:8045/solutions and register a new solution
- After registering, check the preview and make sure it is very minimal (only basic info)
- On the solutions dashboard (http://localhost:5000), approve the registration of your new solution
- Go back to charmhub and edit the metadata, send for approval, and approve from the dashboard
- Then back in charmhub again, check the preview of the solution and you should only see the fields that you have entered on the solution details preview
- Make edits to the solution and make sure any empty fields do not show up on the preview page

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): visual changes

## Issue / Card
Fixes [WD-27002](https://warthogs.atlassian.net/browse/WD-27002)


[WD-27002]: https://warthogs.atlassian.net/browse/WD-27002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ