### PR TITLE
WD-30030 - Fix dropdowns not working

### DIFF
--- a/static/js/src/base/navigation.ts
+++ b/static/js/src/base/navigation.ts
@@ -82,7 +82,8 @@ if (navAccountContainer) {
     });
 }
 
-initNavDropdowns(".p-navigation__item--dropdown-toggle");
+// To be re-added once the changes from global-nav have been undone (WD-29514)
+// initNavDropdowns(".p-navigation__item--dropdown-toggle");
 
 export {
   toggleDropdown,


### PR DESCRIPTION
## Done

Remove custom navigation code from charmhub, given that it is coming from the newest version of global-nav.
To be re-added once the changes in global-nav are undone (WD-29514).

## How to QA

- Go to Demos and check that the "Community" dropdown works both in Desktop and Mobile views.

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): just temporarily removed an script

## Issue / Card

Fixes #2222 
Fixes [WD-30030](https://warthogs.atlassian.net/browse/WD-30030)


[WD-30030]: https://warthogs.atlassian.net/browse/WD-30030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ