### PR TITLE
add client-side name validation when registering a solution

### DIFF
--- a/static/js/src/solutions/register-solution.js
+++ b/static/js/src/solutions/register-solution.js
@@ -14,4 +14,81 @@ document.addEventListener("DOMContentLoaded", function () {
     formSelector: ".p-form",
     getMessage: getRegistrationMessage,
   });
+
+  const nameInput = document.getElementById("name");
+  const validationContainer = document.getElementById(
+    "solution-name-validation"
+  );
+  const validationMessage = document.getElementById(
+    "solution-name-validation-message"
+  );
+
+  const submitButton = document.querySelector('button[type="submit"]');
+
+  if (!nameInput || !validationContainer || !validationMessage) {
+    return;
+  }
+
+  let validationTimeout = null;
+
+  function showValidationError(message) {
+    validationMessage.textContent = message;
+    validationContainer.classList.add("is-error");
+    nameInput.setAttribute("aria-invalid", "true");
+    nameInput.setAttribute(
+      "aria-describedby",
+      "solution-name-validation-message"
+    );
+
+    if (submitButton) {
+      submitButton.disabled = true;
+    }
+  }
+
+  function hideValidationError() {
+    validationMessage.textContent = "";
+    validationContainer.classList.remove("is-error");
+    nameInput.removeAttribute("aria-invalid");
+    nameInput.removeAttribute("aria-describedby");
+
+    if (submitButton) {
+      submitButton.disabled = false;
+    }
+  }
+
+  async function validateSolutionName(name) {
+    try {
+      const response = await fetch(
+        `/validate-solution-name?name=${encodeURIComponent(name)}`
+      );
+      const data = await response.json();
+      return data.exists;
+    } catch (error) {
+      console.error("Error validating solution name:", error);
+      return false;
+    }
+  }
+
+  nameInput.addEventListener("input", () => {
+    const name = nameInput.value.trim();
+
+    clearTimeout(validationTimeout);
+
+    if (name.length === 0) {
+      hideValidationError();
+      return;
+    }
+
+    validationTimeout = setTimeout(async () => {
+      const exists = await validateSolutionName(name);
+
+      if (exists) {
+        showValidationError(
+          `A solution with the name "${name}" already exists. Please choose a different name.`
+        );
+      } else {
+        hideValidationError();
+      }
+    }, 500);
+  });
 });

--- a/templates/publisher/register-solution.html
+++ b/templates/publisher/register-solution.html
@@ -53,7 +53,7 @@
         <label for="name" class="p-form__label is-required">Name:</label>
       </div>
       <div class="col-8 col-x-large-6">
-        <div class="p-form__control">
+        <div class="p-form__control" id="solution-name-validation">
           <input
             class="p-form__control"
             id="name"
@@ -63,6 +63,7 @@
             maxlength="40"
             value="{{ form_value(form_data, None, 'name') | e }}"
           >
+          <p class="p-form-validation__message" id="solution-name-validation-message" role="alert"></p>
           <p class="p-form-help-text">The slug for the solution URL: it should only contain ASCII lowercase letters, numbers, and hyphens, and must have at least one letter (maximum 40 characters)</p>
         </div>
       </div>

--- a/webapp/solutions/logic.py
+++ b/webapp/solutions/logic.py
@@ -87,6 +87,20 @@ def get_published_solution_by_name(name):
     return None
 
 
+def solution_name_exists(name):
+    try:
+        resp = session.get(
+            f"{SOLUTIONS_API_BASE}/solutions/check-name/{name}", timeout=5
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            return data.get("exists", False)
+    except Exception as e:
+        logger.exception(f"Failed to check if solution name exists: {e}")
+
+    return False
+
+
 def get_publisher_solutions(username):
     try:
         resp = make_authenticated_request(


### PR DESCRIPTION
## Done
- Adds client-side validation to show an error when a user inputs an existing solution name when registering a new solution

## How to QA
- Go to https://charmhub-io-2227.demos.haus/solutions
- Try to register an existing solution name (e.g. test-solution)
- See the form validation error
- You should also see an error if you still try to submit the registration

## Issue / Card
Fixes [WD-28129](https://warthogs.atlassian.net/browse/WD-28129)

[WD-28129]: https://warthogs.atlassian.net/browse/WD-28129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ