### PR TITLE
chore: Add logging for login for SSDLC

### DIFF
--- a/tests/publisher/test_publisher_views.py
+++ b/tests/publisher/test_publisher_views.py
@@ -124,7 +124,7 @@ class TestPublisherViews(unittest.TestCase):
         ]
 
         with self.client.session_transaction() as session:
-            session["account"] = {"id": "test-id"}
+            session["account"] = {"id": "test-id", "email": "test@example.com"}
 
         res = self.client.get("/charms")
         self.assertEqual(res.status_code, 200)


### PR DESCRIPTION
## Done
Adds logging for authentication to [satisfy SSDLC requirements](https://library.canonical.com/corporate-policies/information-security-policies/ssdlc/ssdlc---security-event-logging#format-8)

## How to QA
- Run locally
- Go to http://localhost:8045/charms whilst logged out
- Check that in the console you see a warning log with the `datetime`, `event` and `appid`, and a message about failed login
- Login
- Check that in the console you see an info log with the `datetime`, `event` and `appid`, and a message about successful login

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-29139