### PR TITLE
fix charm name truncation in side nav

### DIFF
--- a/templates/solutions/_side-nav.html
+++ b/templates/solutions/_side-nav.html
@@ -40,7 +40,7 @@
               <img class="p-card__thumbnail u-vertical-align--middle" src="{{ charm.icon }}" alt="{{ charm.title }}" style="padding-right: 0.5rem;">
             {% endif %}
             <span>
-              <a class="u-vertical-align--middle" href="{{ charm.url }}">{{ (charm.title or charm.name) | truncate(27, True, leeway=0) }}</a>
+              <a class="u-vertical-align--middle" href="{{ charm.url }}" title="{{ charm.title or charm.name }}" aria-label="View {{ charm.title or charm.name }} charm details">{{ (charm.title or charm.name) | truncate(27, True, leeway=0) }}</a>
             </span>
           </div>
         {% endfor %}


### PR DESCRIPTION
## Done
- Fixes truncation of charm names in side nav by adding [these params](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.truncate)

## How to QA
- Go to https://charmhub-io-2242.demos.haus/solutions/test-solution
- In the side nav, expand to show all charms
- Check that `Charmed Operator for MongoDB` is properly truncated (compared to [staging](https://staging.charmhub.io/solutions/test-solution) where it spans onto 2 lines)

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): fixing jinja template

## Issue / Card
Fixes [WD-28134](https://warthogs.atlassian.net/browse/WD-28134)

[WD-28134]: https://warthogs.atlassian.net/browse/WD-28134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ