### PR TITLE
ensure jinja templates reload in dev mode

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -10,7 +10,7 @@ from canonicalwebteam.flask_base.app import FlaskBase
 
 from webapp.store_api import publisher_gateway
 from webapp.extensions import csrf, vite
-from webapp.config import APP_NAME, VITE_CONFIG
+from webapp.config import APP_NAME, VITE_CONFIG, IS_DEVELOPMENT
 from webapp.handlers import set_handlers
 from webapp.login.views import login
 from webapp.topics.views import topics
@@ -47,6 +47,10 @@ app = FlaskBase(
 app.name = APP_NAME
 app.config["LOGIN_REQUIRED"] = login_required
 app.config.update(VITE_CONFIG)
+
+if IS_DEVELOPMENT:
+    app.config["TEMPLATES_AUTO_RELOAD"] = True
+    app.jinja_options = {**app.jinja_options, "cache_size": 0}
 
 set_handlers(app)
 


### PR DESCRIPTION
## Done
- Currently, changes to jinja templates do not appear without having to restart the server - this fix enables jinja template reloading while in dev mode

## How to QA
- Check out this branch and run `dotrun`
- Make a change to a jinja template, save the file and then reload the browser
- Check that they change propagates

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): no logic change

## Issue / Card

Fixes [WD-36126](https://warthogs.atlassian.net/browse/WD-36126)

## Screenshots

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):


[WD-36126]: https://warthogs.atlassian.net/browse/WD-36126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ