### PR TITLE
Wd 34573/redirect o11y topic

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -13,7 +13,7 @@ topics/operators-corner: https://juju.is/docs
 topics/charm-maturity: https://juju.is/docs
 
 # Observability topic redirects
-topics/canonical-observability-stack/?: https://documentation.ubuntu.com/observability/latest/
+topics/canonical-observability-stack/?: https://documentation.ubuntu.com/observability/
 topics/canonical-observability-stack/tutorials/?: https://documentation.ubuntu.com/observability/latest/tutorial/
 topics/canonical-observability-stack/design-goals/?: https://documentation.ubuntu.com/observability/latest/explanation/architecture/design-goals/
 topics/canonical-observability-stack/juju-topology/?: https://documentation.ubuntu.com/observability/latest/explanation/architecture/juju-topology/

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -11,6 +11,15 @@ kubeflow-charmers-kubeflow-edge: kubeflow-edge
 openstack-charmers-keystone-saml-mellon: keystone-saml-mellon
 topics/operators-corner: https://juju.is/docs
 topics/charm-maturity: https://juju.is/docs
+
+# Observability topic redirects
+topics/canonical-observability-stack/?: https://documentation.ubuntu.com/observability/latest/
+topics/canonical-observability-stack/tutorials/?: https://documentation.ubuntu.com/observability/latest/tutorial/
+topics/canonical-observability-stack/design-goals/?: https://documentation.ubuntu.com/observability/latest/explanation/architecture/design-goals/
+topics/canonical-observability-stack/juju-topology/?: https://documentation.ubuntu.com/observability/latest/explanation/architecture/juju-topology/
+topics/canonical-observability-stack/reference/security/?: https://documentation.ubuntu.com/observability/latest/reference/security-hardening-guide/
+topics/canonical-observability-stack/(?P<path>.*)/?: https://documentation.ubuntu.com/observability/
+
 containers-etcd: etcd
 search\??(?P<search>.*)?/?: /?{search}
 /(?P<charm>[A-Za-z0-9-]*[A-Za-z][A-Za-z0-9-]*)/configure: /{charm}/configurations


### PR DESCRIPTION
## Done
- Adds redirects for Observability topic (as per [this conversation](https://chat.canonical.com/canonical/pl/thzxb535apre7jo4431zh11n9e))

## How to QA
- Go to https://charmhub-io-2314.demos.haus/topics/canonical-observability-stack
  - Check that it redirects to https://documentation.ubuntu.com/observability/
- Check other redirects:
  - [tutorial](https://charmhub-io-2314.demos.haus/topics/canonical-observability-stack/tutorials) > [RTD tutorial](https://documentation.ubuntu.com/observability/latest/tutorial/)
  - [design-goals](https://charmhub-io-2314.demos.haus/topics/canonical-observability-stack/design-goals) > [RTD design-goals](https://documentation.ubuntu.com/observability/latest/explanation/architecture/design-goals/)
  - [topology](https://charmhub-io-2314.demos.haus/topics/canonical-observability-stack/juju-topology) > [RTD topology](https://documentation.ubuntu.com/observability/latest/explanation/architecture/juju-topology/)
  - [security](https://charmhub-io-2314.demos.haus/topics/canonical-observability-stack/reference/security) > [RTD security](https://documentation.ubuntu.com/observability/latest/reference/security-hardening-guide/)

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): adding redirects

## Issue / Card

Fixes [WD-34573](https://warthogs.atlassian.net/browse/WD-34573)

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):


[WD-34573]: https://warthogs.atlassian.net/browse/WD-34573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ