### PR TITLE
modify footer links

### DIFF
--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -108,13 +108,10 @@
       <div class="col-6">
         <ul class="p-inline-list u-no-margin--bottom u-float-right--medium u-float-right--large">
           <li class="p-inline-list__item">
-            <a href="https://chat.charmhub.io/charmhub/channels/juju" class="p-icon--chat">Chat</a>
-          </li>
-          <li class="p-inline-list__item">
             <a href="http://discourse.charmhub.io/" class="p-icon--forum">Discourse</a>
           </li>
           <li class="p-inline-list__item">
-            <a href="https://juju.is/careers" class="p-icon--careers">Careers</a>
+            <a href="https://canonical.com/careers" class="p-icon--careers">Careers</a>
           </li>
           <li class="p-inline-list__item">
             <a href="https://github.com/canonical/operator/" class="p-icon--github">GitHub</a>


### PR DESCRIPTION
## Done
- Updates careers link in footer
- Removes old chat.charmhub.io link

## How to QA
- Go to demo, check the footer links have been updated

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card

Fixes [WD-36463](https://warthogs.atlassian.net/browse/WD-36463)


## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):


[WD-36463]: https://warthogs.atlassian.net/browse/WD-36463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ