### PR TITLE
group smaller prs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,22 @@
 {
   "extends": [
     "github>canonical-web-and-design/renovate-websites"
+  ],
+
+  "prConcurrentLimit": 3,
+
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "groupName": null
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "groupName": "minor updates"
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "groupName": "patch updates"
+    }
   ]
 }


### PR DESCRIPTION
## Done
- Limited Renovate to at most 3 open PRs at once. Without this renovate might open 20+ prs simultaneously.
- If its a major update: do NOT group major updates together, create separate PRs per dependency.
- Groups all minor updates into one PR.
- Groups all patch updates into one PR.