### PR TITLE
Candid deprecation

### DIFF
--- a/.env
+++ b/.env
@@ -8,6 +8,8 @@ FLASK_SOLUTIONS_API_BASE=http://localhost:5000/api
 FLASK_HMAC_SECRET_KEY=secret-key
 VITE_PORT=5045
 VITE_OUTDIR=static/js/dist/vite
+PUBLISHERGW_URL=https://api.charmhub.io
+FLASK_LOGIN_URL=https://login.ubuntu.com
 
 # OpenTelemetry
 # Uncomment to enable tracing:

--- a/HACKING.md
+++ b/HACKING.md
@@ -6,8 +6,8 @@ To use staging APIs locally you can add the following lines to an `.env.local` f
 
 ```bash
 DEVICEGW_URL=https://api.staging.snapcraft.io/
-PUBLISHER_GATEWAY_API_URL=https://api.staging.charmhub.io/
-CANDID_API_URL=https://api.staging.jujucharms.com/identity/
+PUBLISHERGW_URL=https://api.staging.charmhub.io/
+FLASK_LOGIN_URL=https://login.staging.ubuntu.com
 ```
 
 ## Using Sentry error tracker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 canonicalwebteam.flask-base==3.1.2
 beautifulsoup4==4.14.3
 bleach==6.2.0
-canonicalwebteam.candid==0.9.0
 canonicalwebteam.discourse==7.2.0
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.store-api==7.5.0
+canonicalwebteam.store-api==7.9.0
 canonicalwebteam.docstring-extractor==1.2.0
 canonicalwebteam.flask-vite==0.4.0
 
 Flask-WTF==1.2.2
+Flask-OpenID==1.3.1
 humanize==4.15.0
 mistune==3.2.0
 badgepy==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,9 @@ beautifulsoup4==4.14.3
 bleach==6.2.0
 canonicalwebteam.discourse==7.2.0
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.store-api==7.9.0
+# TODO: Uncomment before merging and remove git path
+# canonicalwebteam.store-api==7.9.0
+git+https://github.com/canonical/canonicalwebteam.store-api@candid-deprication
 canonicalwebteam.docstring-extractor==1.2.0
 canonicalwebteam.flask-vite==0.4.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,7 @@ beautifulsoup4==4.14.3
 bleach==6.2.0
 canonicalwebteam.discourse==7.2.0
 canonicalwebteam.image-template==1.9.0
-# TODO: Uncomment before merging and remove git path
-# canonicalwebteam.store-api==7.9.0
-git+https://github.com/canonical/canonicalwebteam.store-api@candid-deprication
+canonicalwebteam.store-api==8.0.0
 canonicalwebteam.docstring-extractor==1.2.0
 canonicalwebteam.flask-vite==0.4.0
 

--- a/tests/login/test_login.py
+++ b/tests/login/test_login.py
@@ -102,3 +102,19 @@ class TestLoginViews(unittest.TestCase):
             self.assertEqual(response.location, "/charms")
             self.assertEqual(session["account-auth"], "account-auth-token")
             self.assertIn("account", session)
+
+    def test_login_callback_missing_root_macaroon(self):
+        discharge = Macaroon(
+            location=urlparse(login_views.LOGIN_URL).hostname, identifier="discharge"
+        ).serialize()
+
+        with self.app.test_request_context("/login", headers={"User-Agent": "UA"}):
+            session["next_url"] = "/integrations"
+            response = login_views.login_callback(
+                SimpleNamespace(
+                    extensions={"macaroon": SimpleNamespace(discharge=discharge)}
+                )
+            )
+
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(response.location, "/login?next=/integrations")

--- a/tests/login/test_login.py
+++ b/tests/login/test_login.py
@@ -1,108 +1,71 @@
 import unittest
-from flask import session
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import urlparse
 
-from canonicalwebteam.candid import CandidClient
-from webapp.app import app
 import responses
-import requests
+from flask import session
+from pymacaroons import Macaroon
 
-request_session = requests.Session()
-candid = CandidClient(request_session)
+from webapp.app import app
+from webapp.login import views as login_views
 
-CANDID_RESPONSE = {
-    "Info": {
-        "InteractionMethods": {
-            "browser-redirect": {
-                "LoginURL": "https://snapcraft.io/",
-            }
-        }
-    }
-}
 
-MACAROON_RESPONSE = {
-    "macaroon": (
-        '{"i64": "AwoQv6LOwltudUSL__FvssuZfRIBMBoOCgVsb2dpbhIFbG9naW4", '
-        '"s64": "eZlOdzfzQkd9By83AyksW8Rt_cZSbdJWssyZhPRORlg", '
-        '"l": "api.snapcraft.io", '
-        '"c": [{"i": "time-before 2026-09-08T13:27:59.418876Z"}, '
-        '{"i": "time-since 2025-09-08T13:27:59.418876Z"}, '
-        '{"i": "session-id ea67eff4-1dcb-442f-a31e-68412b6fa0cb"}, '
-        '{"i64": "AoZh2j5-nfvsJYAztgZ-Mm8Ehcpi5i4qyEj3HU_MWsRvbfkAIg198sss'
-        "UwTbp6HI3ok250inzlaYddeFx4E3LY5DyTjmYo0Fz5KXZhSrcI1g1Iki-BVAvO3E_"
-        "luKko0KUNkxYYGKn0komrJK1DsMcjBJfBL6hCklJxtCMWGmmgt0DDQspAjjFnBfE"
-        'JbTVaAjk4vY", '
-        '"v64": "r57IO0tZoWHO9XXmYGze0RIIipCQW1RRSYZIRj01VQQld413guTUELM'
-        'pMgGOoXPyGGFdgydIBDDEzUy1ogykimmCvtxa8VuK", '
-        '"l": "https://api.jujucharms.com/identity/"}, '
-        '{"i": "extra {\\"permissions\\": '
-        '[\\"account-register-package\\", \\"account-view-packages\\", '
-        '\\"package-manage\\", \\"package-view\\"]}"}]}'
-    )
-}
+def make_root_macaroon():
+    root = Macaroon(location="api.staging.snapcraft.io", identifier="store-usso")
+    login_host = urlparse(login_views.LOGIN_URL).hostname or login_views.LOGIN_URL
+    root.add_third_party_caveat(login_host, "secret-key", "caveat-id")
+    return root.serialize()
 
 
 class TestLoginViews(unittest.TestCase):
     def setUp(self):
         self.app = app
         app.config["TESTING"] = True
-        self.app.config["WTF_CSRF_ENABLED"] = []
-
         self.client = self.app.test_client()
-        self.api_url = "https://api.charmhub.io/v1/tokens"
-        self.candid_url = "https://api.jujucharms.com/identity/discharge"
+        self.issue_url = login_views.publisher_gateway.get_endpoint_url(
+            "tokens/usso"
+        )
+        self.root_macaroon = make_root_macaroon()
 
     @responses.activate
-    def test_login(self):
+    @patch("webapp.login.views.open_id.try_login")
+    def test_login(self, mock_try_login):
+        mock_try_login.return_value = "ok"
         responses.add(
             responses.POST,
-            self.candid_url,
-            json=CANDID_RESPONSE,
-            status=200,
-        )
-        responses.add(
-            responses.POST,
-            self.api_url,
-            json=MACAROON_RESPONSE,
-            headers={"User-Agent": "Google Chrome"},
+            self.issue_url,
+            json={"macaroon": self.root_macaroon},
             status=200,
         )
 
         with self.client as client:
-            res = client.get(
-                "/login",
-                headers={"User-Agent": "Mozilla/5.0 (X11; Linux x86_64)"},
-            )
-            self.assertEqual(res.status_code, 302)
+            res = client.get("/login")
+            self.assertEqual(res.data, b"ok")
             self.assertIn("account-macaroon", session)
 
     @responses.activate
-    def test_login_next(self):
+    @patch("webapp.login.views.open_id.try_login")
+    def test_login_next(self, mock_try_login):
+        mock_try_login.return_value = "ok"
         responses.add(
             responses.POST,
-            self.candid_url,
-            json=CANDID_RESPONSE,
-            status=200,
-        )
-        responses.add(
-            responses.POST,
-            self.api_url,
-            json=MACAROON_RESPONSE,
-            headers={"User-Agent": "Google Chrome"},
+            self.issue_url,
+            json={"macaroon": self.root_macaroon},
             status=200,
         )
 
         with self.client as client:
-            client.get(
-                "/login?next=/test-page",
-                headers={"User-Agent": "Mozilla/5.0 (X11; Linux x86_64)"},
-            )
+            client.get("/login?next=/test-page")
             self.assertIn("next_url", session)
             self.assertEqual(session["next_url"], "/test-page")
 
     @responses.activate
-    def test_login_api_500(self):
+    @patch("webapp.login.views.open_id.try_login")
+    def test_login_api_500(self, mock_try_login):
+        mock_try_login.return_value = "ok"
         responses.add(
-            responses.Response(method="POST", url=self.api_url, status=500)
+            responses.Response(method="POST", url=self.issue_url, status=500)
         )
 
         response = self.client.get("/login")
@@ -117,3 +80,25 @@ class TestLoginViews(unittest.TestCase):
             self.assertEqual(response.location, "/")
             self.assertEqual(s.get("account-auth"), None)
             self.assertEqual(s.get("account-macaroon"), None)
+
+    @patch("webapp.login.views.publisher_gateway.exchange_usso_macaroons")
+    @patch("webapp.login.views.publisher_gateway.macaroon_info")
+    def test_login_callback(self, mock_macaroon_info, mock_exchange):
+        discharge = Macaroon(
+            location=urlparse(login_views.LOGIN_URL).hostname, identifier="discharge"
+        ).serialize()
+        mock_exchange.return_value = "account-auth-token"
+        mock_macaroon_info.return_value = {"account": {"id": "test-account"}}
+
+        with self.app.test_request_context("/login", headers={"User-Agent": "UA"}):
+            session["account-macaroon"] = self.root_macaroon
+            response = login_views.login_callback(
+                SimpleNamespace(
+                    extensions={"macaroon": SimpleNamespace(discharge=discharge)}
+                )
+            )
+
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(response.location, "/charms")
+            self.assertEqual(session["account-auth"], "account-auth-token")
+            self.assertIn("account", session)

--- a/tests/publisher/test_publisher_views.py
+++ b/tests/publisher/test_publisher_views.py
@@ -1,4 +1,5 @@
 import unittest
+from urllib.parse import parse_qs, urlparse
 from webapp.app import app
 from tests.mock_data.mock_store_logic import sample_charm
 from unittest.mock import patch
@@ -164,10 +165,14 @@ class TestPublisherViews(unittest.TestCase):
             PublisherMacaroonRefreshRequired()
         )
 
-        response = self.client.get("/charms")
+        response = self.client.get("/charms?page=1")
 
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.location, "/login?next=/charms")
+        redirect = urlparse(response.location)
+        self.assertEqual(redirect.path, "/login")
+        self.assertEqual(
+            parse_qs(redirect.query).get("next"), ["/charms?page=1"]
+        )
         with self.client.session_transaction() as session:
             self.assertNotIn("account-auth", session)
             self.assertNotIn("account", session)

--- a/tests/publisher/test_publisher_views.py
+++ b/tests/publisher/test_publisher_views.py
@@ -3,7 +3,10 @@ from webapp.app import app
 from tests.mock_data.mock_store_logic import sample_charm
 from unittest.mock import patch
 
-from canonicalwebteam.exceptions import StoreApiResponseErrorList
+from canonicalwebteam.exceptions import (
+    PublisherMacaroonRefreshRequired,
+    StoreApiResponseErrorList,
+)
 
 
 class TestPublisherViews(unittest.TestCase):
@@ -151,6 +154,23 @@ class TestPublisherViews(unittest.TestCase):
         res = self.client.get("/bundles")
         self.assertEqual(res.status_code, 200)
         self.assertNotIn(b"postgresql", res.data)
+
+    @patch("webapp.publisher.views.redis_cache.get", return_value=None)
+    @patch("webapp.store_api.publisher_gateway.get_account_packages")
+    def test_list_page_expired_session_redirects_login(
+        self, mock_get_account_packages, _
+    ):
+        mock_get_account_packages.side_effect = (
+            PublisherMacaroonRefreshRequired()
+        )
+
+        response = self.client.get("/charms")
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.location, "/login?next=/charms")
+        with self.client.session_transaction() as session:
+            self.assertNotIn("account-auth", session)
+            self.assertNotIn("account", session)
 
     def test_accept_invite(self):
         res = self.client.get("/accept-invite")

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -5,7 +5,6 @@ import webapp.config  # noqa: F401
 from flask import render_template, make_response, request, session
 from dateutil import parser
 
-from canonicalwebteam.candid import CandidClient
 from canonicalwebteam.flask_base.app import FlaskBase
 
 from webapp.store_api import publisher_gateway
@@ -51,7 +50,6 @@ app.config.update(VITE_CONFIG)
 set_handlers(app)
 
 request_session = requests.Session()
-candid = CandidClient(request_session)
 csrf.init_app(app)
 vite.init_app(app)
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -29,7 +29,6 @@ from webapp.packages.store_packages import store_packages
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
 from opentelemetry.trace import Span
-import requests
 
 
 app = FlaskBase(
@@ -49,7 +48,6 @@ app.config.update(VITE_CONFIG)
 
 set_handlers(app)
 
-request_session = requests.Session()
 csrf.init_app(app)
 vite.init_app(app)
 

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -1,7 +1,8 @@
-from flask import render_template, session
+from flask import redirect, render_template, request, session
 from webapp.config import SENTRY_DSN, IS_DEVELOPMENT, VITE_CONFIG
 
 from canonicalwebteam.exceptions import (
+    PublisherMacaroonRefreshRequired,
     StoreApiError,
     StoreApiResourceNotFound,
     StoreApiResponseDecodeError,
@@ -112,6 +113,10 @@ def set_handlers(app):
 
     @app.errorhandler(StoreApiResponseErrorList)
     def handle_store_api_error_list(e):
+        if e.status_code == 401:
+            authentication.empty_session(session)
+            return redirect(f"/login?next={request.path}")
+
         if e.status_code == 404:
             return render_template("404.html", message="Entity not found"), 404
 
@@ -130,11 +135,23 @@ def set_handlers(app):
             status_code,
         )
 
+    @app.errorhandler(PublisherMacaroonRefreshRequired)
+    def handle_macaroon_refresh_required(_):
+        authentication.empty_session(session)
+        return redirect(f"/login?next={request.path}")
+
     @app.errorhandler(StoreApiResponseDecodeError)
     @app.errorhandler(StoreApiResponseError)
     @app.errorhandler(StoreApiConnectionError)
     @app.errorhandler(StoreApiError)
     def handle_store_api_error(e):
+        if (
+            isinstance(e, StoreApiResponseError)
+            and getattr(e, "status_code", None) == 401
+        ):
+            authentication.empty_session(session)
+            return redirect(f"/login?next={request.path}")
+
         status_code = 502
         return (
             render_template(

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -1,4 +1,4 @@
-from flask import redirect, render_template, request, session
+from flask import redirect, render_template, request, session, url_for
 from webapp.config import SENTRY_DSN, IS_DEVELOPMENT, VITE_CONFIG
 
 from canonicalwebteam.exceptions import (
@@ -95,6 +95,10 @@ def set_handlers(app):
     def utility_processor():
         return charmhub_utility_processor()
 
+    def redirect_to_login():
+        next_url = request.full_path if request.query_string else request.path
+        return redirect(url_for("login.publisher_login", next=next_url))
+
     # Error handlers
     # ===
     @app.errorhandler(StoreApiTimeoutError)
@@ -115,7 +119,7 @@ def set_handlers(app):
     def handle_store_api_error_list(e):
         if e.status_code == 401:
             authentication.empty_session(session)
-            return redirect(f"/login?next={request.path}")
+            return redirect_to_login()
 
         if e.status_code == 404:
             return render_template("404.html", message="Entity not found"), 404
@@ -138,7 +142,7 @@ def set_handlers(app):
     @app.errorhandler(PublisherMacaroonRefreshRequired)
     def handle_macaroon_refresh_required(_):
         authentication.empty_session(session)
-        return redirect(f"/login?next={request.path}")
+        return redirect_to_login()
 
     @app.errorhandler(StoreApiResponseDecodeError)
     @app.errorhandler(StoreApiResponseError)
@@ -150,7 +154,7 @@ def set_handlers(app):
             and getattr(e, "status_code", None) == 401
         ):
             authentication.empty_session(session)
-            return redirect(f"/login?next={request.path}")
+            return redirect_to_login()
 
         status_code = 502
         return (

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -1,9 +1,8 @@
 import re
 import json
-from urllib.parse import urlparse, urljoin
+from urllib.parse import urlparse
 
 from bs4 import BeautifulSoup
-from flask import request
 from ruamel.yaml import YAML
 from slugify import slugify
 from datetime import datetime, timedelta

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -1,5 +1,6 @@
 import re
 import json
+from urllib.parse import urlparse, urljoin
 
 from bs4 import BeautifulSoup
 from flask import request
@@ -32,7 +33,18 @@ def is_safe_url(url):
     """
     Return True if the URL is inside the same app
     """
-    return url.startswith(request.url_root) or url.startswith("/")
+    if not url:
+        return False
+
+    cleaned_url = url.strip()
+
+    if cleaned_url.startswith(("/", "\\")) and not cleaned_url.startswith(
+        ("//", "\\\\", "/\\", "\\/")
+    ):
+        parsed = urlparse(cleaned_url)
+        return not parsed.scheme and not parsed.netloc
+
+    return False
 
 
 def get_soup(html_content):
@@ -198,7 +210,7 @@ def param_redirect_exec(req, make_response, redirect):
             for key, value in redirect_data["params"].items():
                 params.append(f"{key}={value}")
             response = make_response(
-                redirect(f'{redirect_data["endpoint"]}?{"&".join(params)}')
+                redirect(f"{redirect_data['endpoint']}?{'&'.join(params)}")
             )
             response.set_cookie(
                 "param_redirect", "", expires=0, secure=True, httponly=True

--- a/webapp/login/macaroon.py
+++ b/webapp/login/macaroon.py
@@ -1,0 +1,41 @@
+from openid.extension import Extension as OpenIDExtension
+
+
+class MacaroonRequest(OpenIDExtension):
+    ns_uri = "http://ns.login.ubuntu.com/2016/openid-macaroon"
+    ns_alias = "macaroon"
+
+    def __init__(self, caveat_id):
+        self.caveat_id = caveat_id
+
+    def getExtensionArgs(self):
+        """
+        Return the arguments to add to the OpenID request query.
+        """
+        return {"caveat_id": self.caveat_id}
+
+
+class MacaroonResponse(OpenIDExtension):
+    ns_uri = "http://ns.login.ubuntu.com/2016/openid-macaroon"
+    ns_alias = "macaroon"
+
+    def getExtensionArgs(self):
+        """
+        Return the arguments to add to the OpenID request query.
+        """
+        return {"discharge": self.discharge}
+
+    def fromSuccessResponse(cls, success_response, signed_only=True):
+        self = cls()
+        if signed_only:
+            args = success_response.getSignedNS(self.ns_uri)
+        else:
+            args = success_response.message.getArgs(self.ns_uri)
+
+        if not args:
+            return None
+
+        self.discharge = args["discharge"]
+        return self
+
+    fromSuccessResponse = classmethod(fromSuccessResponse)

--- a/webapp/login/macaroon.py
+++ b/webapp/login/macaroon.py
@@ -19,10 +19,15 @@ class MacaroonResponse(OpenIDExtension):
     ns_uri = "http://ns.login.ubuntu.com/2016/openid-macaroon"
     ns_alias = "macaroon"
 
+    def __init__(self):
+        self.discharge = None
+
     def getExtensionArgs(self):
         """
         Return the arguments to add to the OpenID request query.
         """
+        if self.discharge is None:
+            return {}
         return {"discharge": self.discharge}
 
     def fromSuccessResponse(cls, success_response, signed_only=True):
@@ -35,7 +40,11 @@ class MacaroonResponse(OpenIDExtension):
         if not args:
             return None
 
-        self.discharge = args["discharge"]
+        discharge = args.get("discharge")
+        if discharge is None:
+            return None
+
+        self.discharge = discharge
         return self
 
     fromSuccessResponse = classmethod(fromSuccessResponse)

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -100,7 +100,9 @@ def login_callback(resp):
     discharge = resp.extensions.get("macaroon")
     discharge_macaroon = getattr(discharge, "discharge", None)
     if not discharge_macaroon:
-        return flask.abort(502, "Ubuntu SSO login did not return macaroon discharge")
+        return flask.abort(
+            502, "Ubuntu SSO login did not return macaroon discharge"
+        )
 
     root_macaroon = flask.session["account-macaroon"]
     bound_discharge = Macaroon.deserialize(root_macaroon).prepare_for_request(

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -1,12 +1,14 @@
 import os
-import requests
+from urllib.parse import urlparse
+
 import flask
+from flask_openid import OpenID
+from pymacaroons import Macaroon
 
-from flask_wtf.csrf import generate_csrf, validate_csrf
-
-from canonicalwebteam.candid import CandidClient
-from webapp.helpers import is_safe_url
 from webapp import authentication
+from webapp.extensions import csrf
+from webapp.helpers import is_safe_url
+from webapp.login.macaroon import MacaroonRequest, MacaroonResponse
 from webapp.observability.utils import trace_function
 from webapp.store_api import publisher_gateway
 
@@ -14,14 +16,52 @@ login = flask.Blueprint(
     "login", __name__, template_folder="/templates", static_folder="/static"
 )
 
-LOGIN_URL = os.getenv("FLASK_LOGIN_URL", "https://login.ubuntu.com")
-LOGIN_LAUNCHPAD_TEAM = os.getenv(
-    "LOGIN_LAUNCHPAD_TEAM", "canonical-webmonkeys"
+PUBLISHER_API_URL = os.getenv("PUBLISHER_GATEWAY_API_URL", "")
+DEFAULT_LOGIN_URL = (
+    "https://login.staging.ubuntu.com"
+    if "staging" in PUBLISHER_API_URL
+    else "https://login.ubuntu.com"
+)
+LOGIN_URL = os.getenv("FLASK_LOGIN_URL", DEFAULT_LOGIN_URL)
+LOGIN_USSO_TTL = int(os.getenv("FLASK_LOGIN_USSO_TTL", "300"))
+
+# Keep staging caveat host and login host aligned, same outcome expected by the
+# snapcraft.io flow where discharge comes back in the macaroon OpenID extension.
+if (
+    "staging" in PUBLISHER_API_URL
+    and urlparse(LOGIN_URL).hostname == "login.ubuntu.com"
+):
+    LOGIN_URL = "https://login.staging.ubuntu.com"
+
+open_id = OpenID(
+    store_factory=lambda: None,
+    safe_roots=[],
+    extension_responses=[MacaroonResponse],
 )
 
 
-request_session = requests.Session()
-candid = CandidClient(request_session)
+def get_caveat_id(root: str):
+    location = urlparse(LOGIN_URL).hostname
+    caveat = next(
+        (
+            c
+            for c in Macaroon.deserialize(root).third_party_caveats()
+            if c.location == location
+        ),
+        None,
+    )
+    if caveat is None:
+        caveat = next(
+            (
+                c
+                for c in Macaroon.deserialize(root).third_party_caveats()
+                if urlparse(f"https://{c.location}").hostname == location
+            ),
+            None,
+        )
+    if caveat is None:
+        raise ValueError("No third-party caveat found on root macaroon")
+    return caveat.caveat_id
 
 
 @trace_function
@@ -32,71 +72,64 @@ def logout():
 
 
 @trace_function
-@login.route("/login")
+@login.route("/login", methods=["GET", "POST"])
+@csrf.exempt
+@open_id.loginhandler
 def publisher_login():
-    user_agent = flask.request.headers.get("User-Agent")
+    if authentication.is_authenticated(flask.session):
+        return flask.redirect("/")
 
-    # Get a bakery v2 macaroon from the publisher API to be discharged
-    # and save it in the session
-    flask.session["account-macaroon"] = publisher_gateway.issue_macaroon(
-        [
+    flask.session["account-macaroon"] = publisher_gateway.issue_usso_macaroon(
+        ttl=LOGIN_USSO_TTL,
+        permissions=[
             "account-register-package",
             "account-view-packages",
             "package-manage",
             "package-view",
         ],
-        description=f"charmhub.io - {user_agent}",
     )
 
-    login_url = candid.get_login_url(
-        macaroon=flask.session["account-macaroon"],
-        callback_url=flask.url_for("login.login_callback", _external=True),
-        state=generate_csrf(),
+    openid_macaroon = MacaroonRequest(
+        caveat_id=get_caveat_id(flask.session["account-macaroon"])
     )
 
-    # Next URL to redirect the user after the login
     next_url = flask.request.args.get("next")
-
     if next_url:
         if not is_safe_url(next_url):
             return flask.abort(400)
         flask.session["next_url"] = next_url
 
-    return flask.redirect(login_url, 302)
-
-
-@trace_function
-@login.route("/login/callback")
-def login_callback():
-    code = flask.request.args["code"]
-    state = flask.request.args["state"]
-
-    # Avoid CSRF attacks
-    validate_csrf(state)
-
-    discharged_token = candid.discharge_token(code)
-    candid_macaroon = candid.discharge_macaroon(
-        flask.session["account-macaroon"], discharged_token
+    return open_id.try_login(
+        LOGIN_URL,
+        ask_for=["email", "nickname", "image"],
+        ask_for_optional=["fullname"],
+        extensions=[openid_macaroon],
     )
 
-    # Store bakery authentication
-    issued_macaroon = candid.get_serialized_bakery_macaroon(
-        flask.session["account-macaroon"], candid_macaroon
+
+@open_id.after_login
+def login_callback(resp):
+    discharge = resp.extensions.get("macaroon")
+    discharge_macaroon = getattr(discharge, "discharge", None)
+    if not discharge_macaroon:
+        return flask.abort(502, "Ubuntu SSO login did not return macaroon discharge")
+
+    root_macaroon = flask.session["account-macaroon"]
+    bound_discharge = Macaroon.deserialize(root_macaroon).prepare_for_request(
+        Macaroon.deserialize(discharge_macaroon)
     )
 
-    flask.session["account-auth"] = publisher_gateway.exchange_macaroons(
-        issued_macaroon
+    user_agent = flask.request.headers.get("User-Agent")
+    client_description = f"charmhub.io - {user_agent}" if user_agent else None
+
+    flask.session["account-auth"] = publisher_gateway.exchange_usso_macaroons(
+        root_macaroon=root_macaroon,
+        discharge_macaroon=bound_discharge.serialize(),
+        client_description=client_description,
     )
 
-    # Set "account", "permissions" and other properties from the API response
     flask.session.update(
         publisher_gateway.macaroon_info(flask.session["account-auth"])
     )
 
-    return flask.redirect(
-        flask.session.pop(
-            "next_url",
-            "/charms",
-        ),
-        302,
-    )
+    return flask.redirect(flask.session.pop("next_url", "/charms"), 302)

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -16,22 +16,10 @@ login = flask.Blueprint(
     "login", __name__, template_folder="/templates", static_folder="/static"
 )
 
-PUBLISHER_API_URL = os.getenv("PUBLISHER_GATEWAY_API_URL", "")
-DEFAULT_LOGIN_URL = (
-    "https://login.staging.ubuntu.com"
-    if "staging" in PUBLISHER_API_URL
-    else "https://login.ubuntu.com"
-)
-LOGIN_URL = os.getenv("FLASK_LOGIN_URL", DEFAULT_LOGIN_URL)
-LOGIN_USSO_TTL = int(os.getenv("FLASK_LOGIN_USSO_TTL", "300"))
+PUBLISHER_API_URL = os.getenv("PUBLISHERGW_URL", "https://api.charmhub.io")
 
-# Keep staging caveat host and login host aligned, same outcome expected by the
-# snapcraft.io flow where discharge comes back in the macaroon OpenID extension.
-if (
-    "staging" in PUBLISHER_API_URL
-    and urlparse(LOGIN_URL).hostname == "login.ubuntu.com"
-):
-    LOGIN_URL = "https://login.staging.ubuntu.com"
+LOGIN_URL = os.getenv("FLASK_LOGIN_URL", "https://login.ubuntu.com")
+LOGIN_USSO_TTL = int(os.getenv("FLASK_LOGIN_USSO_TTL", "300"))
 
 open_id = OpenID(
     store_factory=lambda: None,

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -16,8 +16,6 @@ login = flask.Blueprint(
     "login", __name__, template_folder="/templates", static_folder="/static"
 )
 
-PUBLISHER_API_URL = os.getenv("PUBLISHERGW_URL", "https://api.charmhub.io")
-
 LOGIN_URL = os.getenv("FLASK_LOGIN_URL", "https://login.ubuntu.com")
 LOGIN_USSO_TTL = int(os.getenv("FLASK_LOGIN_USSO_TTL", "300"))
 
@@ -104,7 +102,14 @@ def login_callback(resp):
             502, "Ubuntu SSO login did not return macaroon discharge"
         )
 
-    root_macaroon = flask.session["account-macaroon"]
+    root_macaroon = flask.session.get("account-macaroon")
+    if not root_macaroon:
+        next_url = flask.session.get("next_url", "/charms")
+        authentication.empty_session(flask.session)
+        return flask.redirect(
+            flask.url_for(".publisher_login", next=next_url), 302
+        )
+
     bound_discharge = Macaroon.deserialize(root_macaroon).prepare_for_request(
         Macaroon.deserialize(discharge_macaroon)
     )


### PR DESCRIPTION
## Done
- Authenticate with USSO rather than candid.
- Related [PR ](https://github.com/canonical/canonicalwebteam.store-api/pull/189)on the store-api repo
- Remind me to reference the new store-api version before this is merged :)

## How to QA
- Go to demo, click login, see if login works for you
- try logging out and in again
- maybe leave it in the background for a while and see if session expiry works properly
## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):
