### PR TITLE
Remove maintenance banner

### DIFF
--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -67,15 +67,6 @@
 
     {% include "partial/_navigation.html" %}
 
-    <div class="p-strip is-shallow">
-      <div class="p-notification--caution u-fixed-width u-no-margin--bottom">
-        <div class="p-notification__content">
-          <h5 class="p-notification__title">Temporary performance degradation</h5>
-          <p class="p-notification__message">We are currently experiencing service degradation and working on resolving this. Thank you for your patience and understanding.</p>
-        </div>
-      </div>
-    </div>
-
     <main id="main-content">
       {% block content %}{% endblock content %}
     </main>


### PR DESCRIPTION
## Done

After implementing mitigations in #2327 and overall improved stability of backend services as well we can remove the maintenance banner.

## How to QA

Open demo, make sure charms load on home page and no banner is visible on top.
https://charmhub-io-2337.demos.haus/

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): visual change


## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval (add context): visual change
