### PR TITLE
Wd 36789/fix save charm listing

### DIFF
--- a/static/js/src/publisher-admin/pages/Listing/Listing.tsx
+++ b/static/js/src/publisher-admin/pages/Listing/Listing.tsx
@@ -92,29 +92,71 @@ function Listing() {
     setErrorMessage("");
     setIsSaving(true);
 
-    const response = await fetch(`/api/packages/${packageName}`, {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        "X-CSRF-Token": window.CSRF_TOKEN,
-      },
-      body: JSON.stringify(formData),
-    });
+    const getLinks = (value: string | undefined) => {
+      const trimmedValue = value?.trim();
 
-    if (!response.ok) {
-      setErrorMessage(response.statusText);
+      return trimmedValue ? [trimmedValue] : [];
+    };
+
+    if (
+      formData.contact?.trim() &&
+      !/^(https?:\/\/|mailto:)/i.test(formData.contact.trim())
+    ) {
+      setErrorMessage(
+        "Contact must start with http://, https://, or mailto:"
+      );
       setShowErrorNotification(true);
       setIsSaving(false);
-      throw new Error(response.statusText);
+      return;
     }
 
-    const data = await response.json();
-
-    if (!data.success) {
-      setErrorMessage(data.message);
+    if (
+      formData.website?.trim() &&
+      !/^https?:\/\//i.test(formData.website.trim())
+    ) {
+      setErrorMessage("Project homepage must start with http:// or https://");
       setShowErrorNotification(true);
       setIsSaving(false);
-      throw new Error(data.message);
+      return;
+    }
+
+    const payload = {
+      title: formData.title || "",
+      summary: formData.summary || "",
+      links: {
+        ...packageData?.links,
+        website: getLinks(formData.website),
+        contact: getLinks(formData.contact),
+      },
+    };
+
+    let response;
+    let data;
+
+    try {
+      response = await fetch(`/api/packages/${packageName}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": window.CSRF_TOKEN,
+        },
+        body: JSON.stringify(payload),
+      });
+      data = await response.json();
+    } catch {
+      setErrorMessage("Unable to save listing data. Please try again.");
+      setShowErrorNotification(true);
+      setIsSaving(false);
+      return;
+    }
+
+    if (!response.ok || !data?.success) {
+      setErrorMessage(
+        data?.message || response.statusText || "Unable to save listing data."
+      );
+      setShowErrorNotification(true);
+      setIsSaving(false);
+      return;
     }
 
     setPackageData(data.data);
@@ -260,6 +302,7 @@ function Listing() {
           maxLength={256}
           value={formData.website}
           placeholder="https://charmhub.io"
+          required={false}
           handleInputChange={handleInputChange}
         />
 
@@ -268,6 +311,7 @@ function Listing() {
           name="contact"
           maxLength={256}
           value={formData.contact}
+          required={false}
           handleInputChange={handleInputChange}
         />
       </section>

--- a/static/js/src/publisher-admin/pages/Listing/Listing.tsx
+++ b/static/js/src/publisher-admin/pages/Listing/Listing.tsx
@@ -102,9 +102,7 @@ function Listing() {
       formData.contact?.trim() &&
       !/^(https?:\/\/|mailto:)/i.test(formData.contact.trim())
     ) {
-      setErrorMessage(
-        "Contact must start with http://, https://, or mailto:"
-      );
+      setErrorMessage("Contact must start with http://, https://, or mailto:");
       setShowErrorNotification(true);
       setIsSaving(false);
       return;

--- a/static/js/src/publisher-admin/pages/Listing/ListingInputField.tsx
+++ b/static/js/src/publisher-admin/pages/Listing/ListingInputField.tsx
@@ -8,6 +8,7 @@ export type ListingInputFieldProps = {
   helpText?: string;
   maxLength?: number;
   placeholder?: string;
+  required?: boolean;
   handleInputChange: (
     e: SyntheticEvent<HTMLInputElement> & {
       target: HTMLInputElement;
@@ -22,6 +23,7 @@ function ListingInputField({
   helpText,
   maxLength,
   placeholder,
+  required = true,
   handleInputChange,
 }: ListingInputFieldProps) {
   return (
@@ -36,7 +38,7 @@ function ListingInputField({
             className="p-form-validation__input"
             id={name}
             name={name}
-            required
+            required={required}
             maxLength={maxLength}
             placeholder={placeholder}
             value={value || ""}

--- a/static/js/src/publisher-admin/pages/Listing/__tests__/Listing.test.tsx
+++ b/static/js/src/publisher-admin/pages/Listing/__tests__/Listing.test.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
+import type { Mock } from "vitest";
 
 import Listing from "../Listing";
 
@@ -21,6 +22,7 @@ const renderComponent = (mockPackageData: Package) => {
 
 beforeEach(() => {
   global.fetch = vi.fn();
+  globalThis.window.CSRF_TOKEN = "test-csrf-token";
 });
 
 afterEach(() => {
@@ -135,5 +137,61 @@ describe("Listing", () => {
 
     expect(saveButton).not.toBeDisabled();
     expect(revertButton).not.toBeDisabled();
+  });
+
+  test("sends optional website and contact as link arrays", async () => {
+    const user = userEvent.setup();
+    (global.fetch as Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: { ...mockPackage, links: { contact: [], website: [] } },
+      }),
+    });
+    renderComponent(mockPackage);
+
+    await user.clear(screen.getByLabelText("Contact:"));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(JSON.parse((global.fetch as Mock).mock.calls[0][1].body)).toEqual({
+      title: mockPackage.title,
+      summary: mockPackage.summary,
+      links: {
+        contact: [],
+        website: [],
+      },
+    });
+  });
+
+  test("shows a readable contact validation error", async () => {
+    const user = userEvent.setup();
+    renderComponent(mockPackage);
+
+    await user.clear(screen.getByLabelText("Contact:"));
+    await user.type(screen.getByLabelText("Contact:"), "plain text");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByText(
+        "Contact must start with http://, https://, or mailto:"
+      )
+    ).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test("shows a readable homepage validation error", async () => {
+    const user = userEvent.setup();
+    renderComponent(mockPackage);
+
+    await user.type(screen.getByLabelText("Project homepage:"), "example.com");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByText(
+        "Project homepage must start with http:// or https://"
+      )
+    ).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/templates/details/_side-nav.html
+++ b/templates/details/_side-nav.html
@@ -78,13 +78,22 @@
   <p><span class="u-text--muted">License</span><br />{{ package.result.license }}</p>
 {% endif %}
 
-{% if package.result.website or package.result.repository or package.result.contact %}
+{% set links = package.result.get("links", {}) %}
+{% set homepage = package.result.get("website") %}
+{% if links.get("website") %}
+  {% set homepage = links.website[0] %}
+{% endif %}
+{% set contact = package.result.get("contact") %}
+{% if links.get("contact") %}
+  {% set contact = links.contact[0] %}
+{% endif %}
+{% if homepage or package.result.repository or contact %}
   {% if _context.has_rendered_content %}<hr class="p-separator--shallow">{% endif %}{% set _context.has_rendered_content = true %}
   <h4 class="p-heading--5 u-no-margin--bottom">Relevant links</h4>
   <ul class="p-list">
-    {% if package.result.website %}
+    {% if homepage %}
       <li class="p-list__item u-no-margin--bottom">
-        <a href="{{ package.result.website }}"><i class="p-icon--home"></i>&nbsp;&nbsp;Homepage</a>
+        <a href="{{ homepage }}"><i class="p-icon--home"></i>&nbsp;&nbsp;Homepage</a>
       </li>
     {% endif %}
     {% if package.result.repository %}
@@ -92,9 +101,9 @@
         <a href="{{ package.result.repository }}"><i class="p-icon--repository"></i>&nbsp;&nbsp;Repository</a>
       </li>
     {% endif %}
-    {% if package.result.contact %}
+    {% if contact %}
       <li class="p-list__item">
-        <a href="{{ package.result.contact }}"><i class="p-icon--contact"></i>&nbsp;&nbsp;Contact</a>
+        <a href="{{ contact }}"><i class="p-icon--contact"></i>&nbsp;&nbsp;Contact</a>
       </li>
     {% endif %}
   </ul>
@@ -145,7 +154,7 @@
   {% if package["result"]["links"]["website"] %}
   <h2 class="p-heading--5 u-no-margin--bottom">Websites</h2>
     <ul class="p-list">
-      {% for contact in package["result"]["links"]["website"] %}
+      {% for website in package["result"]["links"]["website"] %}
       <li><a href="{{ website }}">{{ website }}</a></li>
       {% endfor %}
     </ul>

--- a/tests/publisher/test_publisher_views.py
+++ b/tests/publisher/test_publisher_views.py
@@ -2,7 +2,7 @@ import unittest
 from urllib.parse import parse_qs, urlparse
 from webapp.app import app
 from tests.mock_data.mock_store_logic import sample_charm
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from canonicalwebteam.exceptions import (
     PublisherMacaroonRefreshRequired,
@@ -89,6 +89,35 @@ class TestPublisherViews(unittest.TestCase):
             "/api/packages/test-entity", json={"key": "value"}
         )
         self.assertEqual(res.status_code, 200)
+        public_fields = [
+            "result.media",
+            "default-release",
+            "result.categories",
+            "result.publisher.display-name",
+            "result.title",
+            "result.unlisted",
+            "channel-map",
+            "result.deployable-on",
+            "result.bugs-url",
+            "result.website",
+            "result.summary",
+            "default-release.revision.metadata-yaml",
+            "default-release.revision.readme-md",
+            "result.links",
+        ]
+        public_cache_parts = {
+            "channel": None,
+            "fields": ",".join(sorted(public_fields)),
+        }
+
+        mock_cache_delete.assert_has_calls(
+            [
+                call("package_metadata:test-id:test-entity"),
+                call(("package_details:test-entity", public_cache_parts)),
+                call(("package:test-entity", public_cache_parts)),
+                call(("test-entity:details-overview", public_cache_parts)),
+            ]
+        )
         self.assertEqual(mock_cache_delete.call_count, 4)
 
     @patch("webapp.store_api.publisher_gateway.update_package_metadata")

--- a/tests/publisher/test_publisher_views.py
+++ b/tests/publisher/test_publisher_views.py
@@ -79,13 +79,17 @@ class TestPublisherViews(unittest.TestCase):
             {"success": True, "data": mock_get_package_metadata.return_value},
         )
 
+    @patch("webapp.publisher.views.redis_cache.delete")
     @patch("webapp.store_api.publisher_gateway.update_package_metadata")
-    def test_update_package(self, mock_update_package_metadata):
+    def test_update_package(
+        self, mock_update_package_metadata, mock_cache_delete
+    ):
         mock_update_package_metadata.return_value = {"name": "test-package"}
         res = self.client.patch(
             "/api/packages/test-entity", json={"key": "value"}
         )
         self.assertEqual(res.status_code, 200)
+        self.assertEqual(mock_cache_delete.call_count, 4)
 
     @patch("webapp.store_api.publisher_gateway.update_package_metadata")
     def test_update_package_failure(self, mock_update_package_metadata):

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -1,5 +1,5 @@
 from redis_cache.cache_utility import redis_cache
-from canonicalwebteam.exceptions import StoreApiResponseErrorList
+from canonicalwebteam.exceptions import StoreApiError, StoreApiResponseErrorList
 from flask import (
     Blueprint,
     flash,
@@ -148,6 +148,36 @@ def get_package_metadata(entity_name):
     return package
 
 
+def clear_listing_caches(entity_name):
+    public_fields = [
+        "result.media",
+        "default-release",
+        "result.categories",
+        "result.publisher.display-name",
+        "result.title",
+        "result.unlisted",
+        "channel-map",
+        "result.deployable-on",
+        "result.bugs-url",
+        "result.website",
+        "result.summary",
+        "default-release.revision.metadata-yaml",
+        "default-release.revision.readme-md",
+        "result.links",
+    ]
+    public_cache_parts = {
+        "channel": None,
+        "fields": ",".join(sorted(public_fields)),
+    }
+
+    redis_cache.delete(
+        f"package_metadata:{session['account']['id']}:{entity_name}"
+    )
+    redis_cache.delete((f"package_details:{entity_name}", public_cache_parts))
+    redis_cache.delete((f"package:{entity_name}", public_cache_parts))
+    redis_cache.delete((f"{entity_name}:details-overview", public_cache_parts))
+
+
 @trace_function
 @publisher.route(
     '/<regex("'
@@ -191,6 +221,7 @@ def update_package(entity_name):
         package = publisher_gateway.update_package_metadata(
             session["account-auth"], "charm", entity_name, payload
         )
+        clear_listing_caches(entity_name)
         res["data"] = package
         res["success"] = True
         res["message"] = ""
@@ -203,7 +234,11 @@ def update_package(entity_name):
         if "unauthorized" in error_messages:
             res["message"] = "Package not found"
         else:
-            res["message"] = " ".join(error_messages)
+            res["message"] = " ".join(error_messages) or str(error_list)
+        res["success"] = False
+        response = make_response(res, error_list.status_code)
+    except StoreApiError as error:
+        res["message"] = str(error) or "Unable to update this charm or bundle"
         res["success"] = False
         response = make_response(res, 500)
 


### PR DESCRIPTION
## Done
- Fixes bug where updates to charm listing page were not working due to [new API shape](https://api.charmhub.io/docs/default/#update-package-metadata)
- Users can now update metadata and have made contact and homepage optional
- Added better client-side error messages so that users can understand what the problem is
- Adds cache invalidation for updated fields so that updates appear instantly for consistency

## How to QA
- Go to one of your charms' listing page and try to make some changes
  - Project homepage should start with `http://` or `https://` - try to put an invalid entry and make sure you see an error message
  - Contact field should start with `http://` or `https://` or `mailto:` - try to put an invalid entry and make sure you see an error message
- Make sure you can successfully make updates
- Go to the charm's public page and ensure the changes are reflected here after saving

## Testing

- [x] This PR has tests

## Issue / Card

Fixes [WD-36789](https://warthogs.atlassian.net/browse/WD-36789)

## UX Approval

- [x] This PR does not require UX approval


[WD-36789]: https://warthogs.atlassian.net/browse/WD-36789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ