### PR TITLE
remove default-release search field

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -31,8 +31,6 @@ class TestSearchPackage(TestCase):
                         "fields": "result.categories,result.summary,"
                         "result.media,result.title,"
                         "result.publisher.display-name,"
-                        "default-release.revision.revision,"
-                        "default-release.channel,"
                         "result.deployable-on"
                     }
                 ),

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -30,8 +30,6 @@ SEARCH_FIELDS = [
     "result.media",
     "result.title",
     "result.publisher.display-name",
-    "default-release.revision.revision",
-    "default-release.channel",
     "result.deployable-on",
 ]
 


### PR DESCRIPTION
## Done
- as far as I can tell, the information from this field is not being used anywhere, so its removed.
## How to QA
- Find any place where it is used (or get your AI to do it) and get brownie points
