### PR TITLE
add notification to bundle pages

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -5,6 +5,22 @@
     {% include "partial/_kubeflow-beta-banner.html" %}
   {% endif %}
 
+  {% if package.type == "bundle" %}
+    <div class="grid-row">
+      <div class="p-notification--information">
+        <div class="p-notification__content">
+          <h5 class="p-notification__title">We've discontinued the registration of new Bundles</h5>
+          <p class="p-notification__message">New Bundle registrations are no longer accepted. Existing bundles remain functional. We recommend using the Juju Terraform Provider for new deployments.</p>
+        </div>
+        <div class="p-notification__meta">
+          <div class="p-notification__actions">
+            <a class="p-notification__action" href="https://discourse.charmhub.io/t/discontinuing-new-charmhub-bundle-registrations/15344">Learn more</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
   {% call(slot) package_header(package, developer_validation, image) %}
     {% if slot == "additional_info" %}
       {% include "partial/_channel-map.html" %}


### PR DESCRIPTION
## Done
- Adds a Notification to bundle pages to inform of discontinuation

## How to QA
- Go to a bundle page (e.g. https://charmhub-io-2347.demos.haus/cos-lite) and check that the notification is at the top of the page
- Check the notification matches the [design](https://www.figma.com/design/PG7imQsdEBInTocJcQYfIn/26.10---Bundles-discontinuation---Stores?node-id=6-515&t=YywprRGRpdr1Qxwj-1)

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why): UI change

## Issue / Card

Fixes [WD-37010](https://warthogs.atlassian.net/browse/WD-37010)

## Screenshots
<img width="1165" height="652" alt="image" src="https://github.com/user-attachments/assets/e935728f-c826-449e-8bc0-facee437cb6c" />


## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval


[WD-37010]: https://warthogs.atlassian.net/browse/WD-37010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ