### PR TITLE
make sure publisher info is populated when editiing a solution

### DIFF
--- a/templates/publisher/register-solution.html
+++ b/templates/publisher/register-solution.html
@@ -101,8 +101,9 @@
             name="summary"
             rows="4"
             required
+            maxlength="500"
           >{{ form_value(form_data, None, 'summary') | e }}</textarea>
-          <p class="p-form-help-text">A brief description of what your solution does</p>
+          <p class="p-form-help-text">A brief summary of what your solution does (maximum 500 characters)</p>
         </div>
       </div>
     </div>

--- a/templates/solutions/partials/_basic_info_section.html
+++ b/templates/solutions/partials/_basic_info_section.html
@@ -30,8 +30,9 @@
       class="is-dense"
       rows="4"
       required
+      maxlength="500"
     >{{ form_value(form_data, solution, 'summary') | e }}</textarea>
-    <p class="p-form-help-text">A brief summary of what your solution does</p>
+    <p class="p-form-help-text">A brief summary of what your solution does (maximum 500 characters)</p>
   </div>
 </div>
 

--- a/tests/solutions/test_solutions_logic.py
+++ b/tests/solutions/test_solutions_logic.py
@@ -46,7 +46,7 @@ class TestSolutionsLogic(unittest.TestCase):
         ]
         mock_auth_request.return_value = mock_response
 
-        result = get_solution_from_backend("123")
+        result = get_solution_from_backend("123", prefer_authenticated=True)
 
         self.assertEqual(result["creator"]["email"], "creator@example.com")
         mock_auth_request.assert_called_once()
@@ -70,7 +70,34 @@ class TestSolutionsLogic(unittest.TestCase):
         }
         mock_session.get.return_value = mock_response
 
-        result = get_solution_from_backend("123")
+        result = get_solution_from_backend("123", prefer_authenticated=True)
+
+        self.assertEqual(result, {"uuid": "123", "name": "Test Solution"})
+        mock_session.get.assert_called_once()
+
+    @patch(
+        "webapp.solutions.logic.flask_session",
+        {"account": {"username": "testuser"}},
+    )
+    @patch("webapp.solutions.logic.make_authenticated_request")
+    @patch("webapp.solutions.logic.session")
+    def test_get_solution_from_backend_falls_back_when_auth_hash_not_found(
+        self, mock_session, mock_auth_request
+    ):
+        mock_auth_response = MagicMock()
+        mock_auth_response.status_code = 200
+        mock_auth_response.json.return_value = [{"hash": "other"}]
+        mock_auth_request.return_value = mock_auth_response
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "uuid": "123",
+            "name": "Test Solution",
+        }
+        mock_session.get.return_value = mock_response
+
+        result = get_solution_from_backend("123", prefer_authenticated=True)
 
         self.assertEqual(result, {"uuid": "123", "name": "Test Solution"})
         mock_session.get.assert_called_once()

--- a/tests/solutions/test_solutions_logic.py
+++ b/tests/solutions/test_solutions_logic.py
@@ -26,6 +26,32 @@ class TestSolutionsLogic(unittest.TestCase):
         self.assertEqual(result, {"uuid": "123", "name": "Test Solution"})
         mock_session.get.assert_called_once()
 
+    @patch(
+        "webapp.solutions.logic.flask_session",
+        {"account": {"username": "testuser"}},
+    )
+    @patch("webapp.solutions.logic.make_authenticated_request")
+    @patch("webapp.solutions.logic.session")
+    def test_get_solution_from_backend_prefers_authenticated_solution(
+        self, mock_session, mock_auth_request
+    ):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {
+                "hash": "123",
+                "name": "Test Solution",
+                "creator": {"email": "creator@example.com"},
+            }
+        ]
+        mock_auth_request.return_value = mock_response
+
+        result = get_solution_from_backend("123")
+
+        self.assertEqual(result["creator"]["email"], "creator@example.com")
+        mock_auth_request.assert_called_once()
+        mock_session.get.assert_not_called()
+
     @patch("webapp.solutions.logic.session")
     def test_get_solution_from_backend_not_found(self, mock_session):
         mock_response = MagicMock()

--- a/tests/solutions/test_solutions_logic.py
+++ b/tests/solutions/test_solutions_logic.py
@@ -52,6 +52,29 @@ class TestSolutionsLogic(unittest.TestCase):
         mock_auth_request.assert_called_once()
         mock_session.get.assert_not_called()
 
+    @patch(
+        "webapp.solutions.logic.flask_session",
+        {"account": {"username": "testuser"}},
+    )
+    @patch("webapp.solutions.logic.make_authenticated_request")
+    @patch("webapp.solutions.logic.session")
+    def test_get_solution_from_backend_falls_back_to_public_preview(
+        self, mock_session, mock_auth_request
+    ):
+        mock_auth_request.side_effect = Exception("Auth failed")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "uuid": "123",
+            "name": "Test Solution",
+        }
+        mock_session.get.return_value = mock_response
+
+        result = get_solution_from_backend("123")
+
+        self.assertEqual(result, {"uuid": "123", "name": "Test Solution"})
+        mock_session.get.assert_called_once()
+
     @patch("webapp.solutions.logic.session")
     def test_get_solution_from_backend_not_found(self, mock_session):
         mock_response = MagicMock()

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -912,7 +912,7 @@ def submit_register_solution():
 @login_required
 @requires_solutions_access
 def edit_solution_form(hash):
-    solution = get_solution_from_backend(hash)
+    solution = get_solution_from_backend(hash, prefer_authenticated=True)
     if not solution:
         flash("Solution not found.", "negative")
         return redirect("/solutions")
@@ -953,7 +953,7 @@ def cleanup_old_previews():
 @requires_solutions_access
 def submit_edit_solution(hash):
     # Get solution data from backend first
-    solution = get_solution_from_backend(hash)
+    solution = get_solution_from_backend(hash, prefer_authenticated=True)
     if not solution:
         flash("Solution not found.", "negative")
         return redirect("/solutions")

--- a/webapp/solutions/logic.py
+++ b/webapp/solutions/logic.py
@@ -59,17 +59,22 @@ def get_solution_from_backend(uuid):
             username = None
 
         if username:
-            auth_resp = make_authenticated_request(
-                "GET",
-                f"{SOLUTIONS_API_BASE}/publisher/solutions",
-                username,
-                timeout=5,
-            )
-            if auth_resp.status_code == 200:
-                solutions = auth_resp.json()
-                for solution in solutions:
-                    if solution.get("hash") == uuid:
-                        return solution
+            try:
+                auth_resp = make_authenticated_request(
+                    "GET",
+                    f"{SOLUTIONS_API_BASE}/publisher/solutions",
+                    username,
+                    timeout=5,
+                )
+                if auth_resp.status_code == 200:
+                    solutions = auth_resp.json()
+                    for solution in solutions:
+                        if solution.get("hash") == uuid:
+                            return solution
+            except Exception as e:
+                logger.exception(
+                    f"Failed to fetch authenticated solution data: {e}"
+                )
 
         # Then try public preview endpoint for published/bearer-link previews
         resp = session.get(

--- a/webapp/solutions/logic.py
+++ b/webapp/solutions/logic.py
@@ -49,7 +49,7 @@ def make_authenticated_request(method, url, username, **kwargs):
     return response
 
 
-def get_solution_from_backend(uuid):
+def get_solution_from_backend(uuid, prefer_authenticated=False):
     try:
         # First try the authenticated publisher response when available
         # so edit forms receive publisher-only fields such as creator contact details
@@ -58,7 +58,7 @@ def get_solution_from_backend(uuid):
         except RuntimeError:
             username = None
 
-        if username:
+        if prefer_authenticated and username:
             try:
                 auth_resp = make_authenticated_request(
                     "GET",

--- a/webapp/solutions/logic.py
+++ b/webapp/solutions/logic.py
@@ -51,15 +51,13 @@ def make_authenticated_request(method, url, username, **kwargs):
 
 def get_solution_from_backend(uuid):
     try:
-        # public preview endpoint for published solutions
-        resp = session.get(
-            f"{SOLUTIONS_API_BASE}/solutions/preview/{uuid}", timeout=5
-        )
-        if resp.status_code == 200:
-            return resp.json()
+        # First try the authenticated publisher response when available
+        # so edit forms receive publisher-only fields such as creator contact details
+        try:
+            username = flask_session.get("account", {}).get("username")
+        except RuntimeError:
+            username = None
 
-        # fallback for publishers to preview their own draft solutions
-        username = flask_session.get("account", {}).get("username")
         if username:
             auth_resp = make_authenticated_request(
                 "GET",
@@ -72,6 +70,13 @@ def get_solution_from_backend(uuid):
                 for solution in solutions:
                     if solution.get("hash") == uuid:
                         return solution
+
+        # Then try public preview endpoint for published/bearer-link previews
+        resp = session.get(
+            f"{SOLUTIONS_API_BASE}/solutions/preview/{uuid}", timeout=5
+        )
+        if resp.status_code == 200:
+            return resp.json()
     except Exception as e:
         logger.exception(f"Failed to fetch solution from backend: {e}")
     return None


### PR DESCRIPTION
## Done
- Ensures creator info is pre-populated when editing a solution (a bug intorduced with some changes made on the solutions-service repo)
- Adds client-side limits for title, name, summary when registering a solution and when editing an existing solution

## How to QA
- Run this branch locally whilst also running [this branch](https://github.com/canonical/charmhub-solutions-service/pull/49) of solutions service locally
- Try to edit an existing solution (localhost:8045/solutions) and make sure the `Creator` info is pre-populated at the bottom
- Go to [register a new solution](http://localhost:8045/register-solution), try to add title or name > 40 chars and see you are limited, same with a summary > 500 chars

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
