### PR TITLE
feat: integrations tab in details page

### DIFF
--- a/static/js/src/public/details/integrations/components/App/App.tsx
+++ b/static/js/src/public/details/integrations/components/App/App.tsx
@@ -7,7 +7,6 @@ import {
   Col,
   Spinner,
   SearchAndFilter,
-  Chip,
 } from "@canonical/react-components";
 import { InterfaceItem } from "../InterfaceItem";
 import { filterChipsSelector, filterState } from "../../state";

--- a/static/js/src/public/details/integrations/components/App/App.tsx
+++ b/static/js/src/public/details/integrations/components/App/App.tsx
@@ -149,14 +149,6 @@ export const App = () => {
                     }}
                   >
                     {`${interfaceItem.key}`}
-                    {interfaceItem.required === true && (
-                      <Chip
-                        value="Required"
-                        appearance="negative"
-                        className="u-no-margin--bottom"
-                        style={{ marginLeft: "10px" }}
-                      />
-                    )}
                   </a>
                 </li>
               );
@@ -197,40 +189,35 @@ export const App = () => {
             </div>
           </Col>
           <Col size={9} className="p-details-tab__content__body">
-            <Row>
+            <Row className="p-details-tab__integrations-header">
               <Col size={5}>
-                <h2 className="p-heading--3 p-details-tab__content__body__title">
-                  {integrationCount} integration
-                  {integrationCount > 1 ? "s" : ""}
-                </h2>
-                <p className="p-heading--4 p-details-tab__content__body__link">
-                  <a href="https://juju.is/docs/juju/relation">
-                    Learn about integrations&nbsp;&gt;
-                  </a>
-                </p>
+                <Row className="u-flex p-divider p-details-tab__integrations-header-title">
+                  <div className="p-divider__block">
+                    <span>
+                      {integrationCount} integration
+                      {integrationCount > 1 ? "s" : ""}
+                    </span>
+                  </div>
+                  <div className="p-divider__block">
+                    <a href="/interfaces">
+                      All integration interfaces &rsaquo;
+                    </a>
+                  </div>
+                </Row>
               </Col>
               <Col size={4}>
-                <div
-                  style={{
-                    position: "relative",
-                    zIndex: 1,
-                    width: "100%",
-                    minHeight: "3rem",
-                  }}
-                >
-                  <div style={{ position: "absolute", width: "100%" }}>
-                    <SearchAndFilter
-                      // @ts-expect-error: id mismatch (number instead of string) but doesn't matter in reality
-                      filterPanelData={availableFilters}
-                      returnSearchData={(searchData: SearchAndFilterChip[]) => {
-                        setFilterData((prev) =>
-                          prev !== searchData
-                            ? (searchData as IFilterChip[])
-                            : prev
-                        );
-                      }}
-                    />
-                  </div>
+                <div className="p-details-tab__integrations-search">
+                  <SearchAndFilter
+                    // @ts-expect-error: id mismatch (number instead of string) but doesn't matter in reality
+                    filterPanelData={availableFilters}
+                    returnSearchData={(searchData: SearchAndFilterChip[]) => {
+                      setFilterData((prev) =>
+                        prev !== searchData
+                          ? (searchData as IFilterChip[])
+                          : prev
+                      );
+                    }}
+                  />
                 </div>
               </Col>
             </Row>

--- a/static/js/src/public/details/integrations/components/App/App.tsx
+++ b/static/js/src/public/details/integrations/components/App/App.tsx
@@ -190,25 +190,29 @@ export const App = () => {
           <Col size={9} className="p-details-tab__content__body">
             <Row className="p-details-tab__integrations-header">
               <Col size={5}>
-                <Row className="u-flex p-divider p-details-tab__integrations-header-title">
-                  <div className="p-divider__block">
-                    <span>
-                      {integrationCount} integration
-                      {integrationCount > 1 ? "s" : ""}
-                    </span>
-                  </div>
-                  <div className="p-divider__block">
-                    <a href="/interfaces">
-                      All integration interfaces &rsaquo;
-                    </a>
+                <Row className="p-divider p-details-tab__integrations-header-title">
+                  <div className="u-flex">
+                    <div className="p-divider__block">
+                      <span>
+                        {integrationCount} integration
+                        {integrationCount > 1 ? "s" : ""}
+                      </span>
+                    </div>
+                    <div className="p-divider__block">
+                      <a href="/interfaces">
+                        All integration interfaces &rsaquo;
+                      </a>
+                    </div>
                   </div>
                 </Row>
               </Col>
               <Col size={4}>
                 <div className="p-details-tab__integrations-search">
                   <SearchAndFilter
-                    // @ts-expect-error: id mismatch (number instead of string) but doesn't matter in reality
-                    filterPanelData={availableFilters}
+                    filterPanelData={availableFilters.map((filter, index) => ({
+                      ...filter,
+                      id: index,
+                    }))}
                     returnSearchData={(searchData: SearchAndFilterChip[]) => {
                       setFilterData((prev) =>
                         prev !== searchData

--- a/static/js/src/public/details/integrations/components/App/__tests__/App.test.tsx
+++ b/static/js/src/public/details/integrations/components/App/__tests__/App.test.tsx
@@ -117,7 +117,7 @@ describe("App component", () => {
 
     await waitFor(() => {
       const filteredInterfaces = screen.queryAllByText("interface-1");
-      expect(filteredInterfaces).toHaveLength(3);
+      expect(filteredInterfaces).toHaveLength(4);
     });
   });
 

--- a/static/js/src/public/details/integrations/components/InerfaceRow.tsx
+++ b/static/js/src/public/details/integrations/components/InerfaceRow.tsx
@@ -15,10 +15,24 @@ const getDisplayName = (charm: ICharm) => {
   return charm.package.name.replace(/-/g, " ");
 };
 
+const getChannel = (charm: ICharm) => {
+  const { track, risk, name } = charm.package.channel;
+
+  if (track && risk) {
+    return `${track}/${risk}`;
+  }
+
+  if (name && name !== "/") {
+    return name;
+  }
+
+  return "";
+};
+
 export const InerfaceRow = ({ charm }: InerfaceRowProps) => {
   const charmName = getDisplayName(charm);
   const packageLink = `/${charm.package.name}`;
-  const channel = `${charm.package.channel.track}/${charm.package.channel.risk}`;
+  const channel = getChannel(charm);
   const supportsVm = charm.package.platforms.includes("vm");
   const supportsKubernetes =
     charm.package.platforms.includes("kubernetes") ||

--- a/static/js/src/public/details/integrations/components/InerfaceRow.tsx
+++ b/static/js/src/public/details/integrations/components/InerfaceRow.tsx
@@ -40,25 +40,27 @@ export const InerfaceRow = ({ charm }: InerfaceRowProps) => {
 
   return (
     <Row>
-      <Col size={3} className="u-flex">
-        <a href={packageLink}>
-          <img
-            src={
-              charm.package.icon_url ||
-              "https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg"
-            }
-            alt=""
-            width={48}
-            height={48}
-          />
-        </a>
-        <div className="p-integration-row__meta">
-          <a className="p-integration-row__name" href={packageLink}>
-            {charmName}
+      <Col size={3}>
+        <div className="u-flex">
+          <a href={packageLink}>
+            <img
+              src={
+                charm.package.icon_url ||
+                "https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg"
+              }
+              alt=""
+              width={48}
+              height={48}
+            />
           </a>
-          <p className="u-text--muted u-no-margin--bottom">
-            {charm.publisher.display_name}
-          </p>
+          <div className="p-integration-row__meta">
+            <a className="p-integration-row__name" href={packageLink}>
+              {charmName}
+            </a>
+            <p className="u-text--muted u-no-margin--bottom">
+              {charm.publisher.display_name}
+            </p>
+          </div>
         </div>
       </Col>
 

--- a/static/js/src/public/details/integrations/components/InerfaceRow.tsx
+++ b/static/js/src/public/details/integrations/components/InerfaceRow.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+
+import type { ICharm } from "../../../../shared/types";
+import { Col, Row } from "@canonical/react-components";
+
+interface InerfaceRowProps {
+  charm: ICharm;
+}
+
+const getDisplayName = (charm: ICharm) => {
+  if (charm.package.display_name) {
+    return charm.package.display_name;
+  }
+
+  return charm.package.name.replace(/-/g, " ");
+};
+
+export const InerfaceRow = ({ charm }: InerfaceRowProps) => {
+  const charmName = getDisplayName(charm);
+  const packageLink = `/${charm.package.name}`;
+  const channel = `${charm.package.channel.track}/${charm.package.channel.risk}`;
+  const supportsVm = charm.package.platforms.includes("vm");
+  const supportsKubernetes =
+    charm.package.platforms.includes("kubernetes") ||
+    charm.package.platforms.includes("k8s");
+
+  return (
+    <Row>
+      <Col size={3} className="u-flex">
+        <a href={packageLink}>
+          <img
+            src={
+              charm.package.icon_url ||
+              "https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg"
+            }
+            alt=""
+            width={48}
+            height={48}
+          />
+        </a>
+        <div className="p-integration-row__meta">
+          <a className="p-integration-row__name" href={packageLink}>
+            {charmName}
+          </a>
+          <p className="u-text--muted u-no-margin--bottom">
+            {charm.publisher.display_name}
+          </p>
+        </div>
+      </Col>
+
+      <Col size={2}>
+        <p className="u-text--muted u-no-margin--bottom">{channel}</p>
+      </Col>
+
+      <Col size={3}>
+        <p className="p-integration-row__description u-no-margin--bottom">
+          {charm.package.description}
+        </p>
+      </Col>
+
+      <Col size={1}>
+        <div className="u-align--right">
+          {supportsVm && (
+            <img
+              src="https://assets.ubuntu.com/v1/bf61e269-machine-badge.svg"
+              width={24}
+              height={24}
+              alt="Machine"
+            />
+          )}
+          {supportsKubernetes && (
+            <img
+              src="https://assets.ubuntu.com/v1/f1852c07-Kubernetes.svg"
+              width={24}
+              height={24}
+              alt="Kubernetes"
+            />
+          )}
+        </div>
+      </Col>
+    </Row>
+  );
+};
+
+export default InerfaceRow;

--- a/static/js/src/public/details/integrations/components/InterfaceItem.tsx
+++ b/static/js/src/public/details/integrations/components/InterfaceItem.tsx
@@ -8,9 +8,7 @@ import { useQuery } from "react-query";
 import { Row, Col, Spinner, Chip } from "@canonical/react-components";
 
 import { filterChipsSelector, filterState } from "../state";
-
-import { IntegrationCard } from "@canonical/store-components";
-import { Package } from "../../../../publisher-admin/types";
+import { InerfaceRow } from "./InerfaceRow";
 
 interface InterfaceItemProps {
   interfaceType: string;
@@ -29,7 +27,9 @@ const getCharms = async (
     }=${interfaceName}`
   );
   const json = await resp.json();
-  return json.packages.filter((pkg: Package) => pkg.name !== charmName);
+  return (json.packages as ICharm[]).filter(
+    (pkg: ICharm) => pkg.package.name !== charmName
+  );
 };
 
 const filterMap = (charm: ICharm, heading: string) => {
@@ -128,59 +128,61 @@ export const InterfaceItem = ({
   return (
     <>
       <hr />
-      <h3 className="p-heading--4 u-no-margin--bottom" id={interfaceData.key}>
-        <div style={{ display: "flex", alignItems: "center" }}>
-          {interfaceData.key}
-          <span className="u-text--muted">&nbsp;endpoint</span>
-          {interfaceData.required === true && (
-            <Chip
-              value="Required"
-              appearance="negative"
-              className="u-no-margin--bottom"
-              style={{ marginLeft: "10px" }}
-            />
-          )}
-        </div>
-        <div>
-          <a href={`/integrations/${interfaceData.interface}`}>
-            {interfaceData.interface}
-          </a>
-          <span className="u-text--muted">&nbsp;interface</span>
-        </div>
-      </h3>
-      {interfaceData.description && <p>{interfaceData.description}</p>}
-
-      {charms && charms?.length > 0 && (
-        <>
-          <div style={{ paddingTop: "0.5rem" }}>
-            <p className="u-fixed-width u-no-margin--bottom">
-              The <b>{interfaceData.key}</b> endpoint
-              <b>
-                {interfaceType === "requires" ? " requires " : " provides "}
-              </b>
-              an integration over the{" "}
+      <Row>
+        <Col size={5}>
+          <h3
+            className="p-heading--4 u-no-margin--bottom"
+            id={interfaceData.key}
+          >
+            <div style={{ display: "flex", alignItems: "center" }}>
+              {interfaceData.key}
+              <span className="u-text--muted">&nbsp;endpoint</span>
+              {interfaceData.required === true && (
+                <Chip
+                  isReadOnly
+                  value="Required"
+                  appearance="negative"
+                  className="u-no-margin--bottom"
+                  style={{ marginLeft: "10px" }}
+                />
+              )}
+            </div>
+            <div>
               <a href={`/integrations/${interfaceData.interface}`}>
                 {interfaceData.interface}
-              </a>{" "}
-              interface
-            </p>
-            <p>This means it can integrate with:</p>
-          </div>
-          <Row>
-            {charms.map((charm: ICharm) => (
-              <React.Fragment key={charm.package.name}>
-                <Col
-                  size={3}
-                  style={{ marginBottom: "1.5rem" }}
-                  key={charm.package["display_name"]}
-                >
-                  <IntegrationCard data={charm} />
-                </Col>
-              </React.Fragment>
-            ))}
-          </Row>
-        </>
-      )}
+              </a>
+              <span className="u-text--muted">&nbsp;interface</span>
+            </div>
+          </h3>
+        </Col>
+        <Col size={4}>
+          <p className="u-fixed-width u-no-margin--bottom">
+            The <b>{interfaceData.key}</b> endpoint
+            <b>{interfaceType === "requires" ? " requires " : " provides "}</b>
+            an integration over the{" "}
+            <a href={`/integrations/${interfaceData.interface}`}>
+              {interfaceData.interface}
+            </a>{" "}
+            interface
+          </p>
+          <p>This means it can integrate with:</p>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col emptyLarge={2} size={9}>
+          {charms && charms?.length > 0 && (
+            <ul className="p-list--divided">
+              {charms.map((charm: ICharm, idx) => (
+                <li key={charm.package.name} className="p-list__item">
+                  {idx === 0 && <hr />}
+                  <InerfaceRow charm={charm} />
+                </li>
+              ))}
+            </ul>
+          )}
+        </Col>
+      </Row>
       {!charms && (
         <div className="u-fixed-width">
           <Spinner text={`Loading charms for ${interfaceData.interface}`} />

--- a/static/js/src/public/details/integrations/components/InterfaceItem.tsx
+++ b/static/js/src/public/details/integrations/components/InterfaceItem.tsx
@@ -22,7 +22,7 @@ const getCharms = async (
   charmName: string
 ): Promise<ICharm[]> => {
   const resp = await fetch(
-    `/store.json?${
+    `/store.json?extra_fields=default-release.channel.track,default-release.channel.risk&${
       interfaceType === "provides" ? "requires" : "provides"
     }=${interfaceName}`
   );

--- a/static/js/src/public/details/integrations/components/__tests__/InterfaceItem.test.tsx
+++ b/static/js/src/public/details/integrations/components/__tests__/InterfaceItem.test.tsx
@@ -82,7 +82,9 @@ describe("InterfaceItem Component", () => {
     expect(
       screen.getByRole("heading", { name: /test-key/ })
     ).toBeInTheDocument();
-    expect(screen.getByText("This is a test description.")).toBeInTheDocument();
+    expect(
+      screen.getByText("This means it can integrate with:")
+    ).toBeInTheDocument();
     expect(screen.getByText("Required")).toBeInTheDocument();
   });
 
@@ -103,8 +105,12 @@ describe("InterfaceItem Component", () => {
       );
     });
 
-    expect(screen.getByText("test-key")).toBeInTheDocument();
-    expect(screen.getByText("This is a test description.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /test-key/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("This means it can integrate with:")
+    ).toBeInTheDocument();
     expect(screen.queryByText("Required")).not.toBeInTheDocument();
   });
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -228,6 +228,23 @@ $breakpoint-navigation-threshold: 1220px; // keep it in sync with juju.is and br
   }
 }
 
+.p-integration-row__meta{
+  margin-left: 1rem;
+}
+
+.p-integration-row__name {
+  font-weight: 500;
+}
+
+.p-integration-row__description {
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  display: -webkit-box;
+  line-clamp: 2;
+  overflow: hidden;
+}
+
+
 // Override h3 font weight based on design feedback from MS
 .p-heading--3,
 h3 {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -238,8 +238,8 @@ $breakpoint-navigation-threshold: 1220px; // keep it in sync with juju.is and br
 
 .p-integration-row__description {
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
   display: -webkit-box;
+  -webkit-line-clamp: 2;
   line-clamp: 2;
   overflow: hidden;
 }

--- a/webapp/packages/store_packages.py
+++ b/webapp/packages/store_packages.py
@@ -26,9 +26,10 @@ store_packages = Blueprint(
 @store_packages.route("/store.json")
 def get_store_packages():
     args = dict(request.args)
+    extra_fields = [f for f in args.pop("extra_fields", "").split(",") if f]
     res = jsonify(
         get_packages(
-            FIELDS,
+            FIELDS + extra_fields,
             args,
             12,
         )

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -746,7 +746,7 @@ def add_required_fields(metadata_relations, relations):
         {
             **relations[key],
             "key": key,
-            "required": metadata_relations[key].get("required", False),
+            "required": metadata_relations[key].get("optional", False),
         }
         for key in relations.keys()
     ]


### PR DESCRIPTION
Adds integrations tab to the charm details page.
## Deviations:
Some known deviations from the design:
- Mandatory is "Required"
# Q/A
- https://charmhub-io-2351.demos.haus/kafka/integrations 
- [Figma](https://www.figma.com/design/bY5HHkqzvYREdxJFhbl5kM/25.10-Charmhub-solution-focus---Store?node-id=1744-6566&m=dev)