### PR TITLE
feat: interfaces table

### DIFF
--- a/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
+++ b/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import {
   Strip,
@@ -8,71 +8,75 @@ import {
   MainTable,
   Notification,
   Pagination,
-  StatusLabel,
+  Chip,
+  Select,
+  SearchBox,
 } from "@canonical/react-components";
 
 import type { InterfaceItem } from "../../types";
 
-function pageArray<T>(items: T[], count: number) {
-  const result: T[][] = [];
-
-  for (let i = 0; i < Math.ceil(items.length / count); i++) {
-    const start = i * count;
-    const end = start + count;
-
-    result.push(items.slice(start, end));
-  }
-
-  return result;
-}
-
 function sortInterfaces(a: InterfaceItem, b: InterfaceItem) {
-  if (a.status === "published" && b.status !== "published") {
+  if (a?.status === "published" && b?.status !== "published") {
     return -1;
   }
 
-  if (a.status !== "published" && b.status === "published") {
+  if (a?.status !== "published" && b?.status === "published") {
     return 1;
   }
 
   return 0;
 }
 
+const normalize = (value?: string) => (value || "").trim().toLowerCase();
+
 type Props = {
   interfacesList: Array<InterfaceItem>;
 };
 
-function InterfacesIndex({ interfacesList }: Props) {
-  const ITEMS_PER_PAGE = 10;
+const ITEMS_PER_PAGE = 10;
 
+function InterfacesIndex({ interfacesList }: Props) {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [interfaces, setInterfaces] = useState<Array<InterfaceItem>>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
-  const [currentItems, setCurrentItems] = useState<InterfaceItem[]>([]);
-  const [currentPageNumber, setCurrentPageNumber] = useState(
-    parseInt(searchParams.get("page") || "1")
-  );
-  const [currentPageIndex, setCurrentPageIndex] = useState(
-    currentPageNumber - 1
-  );
+  const searchQuery = searchParams.get("search") || "";
+  const statusFilter = searchParams.get("status") || "";
+  const categoryFilter = searchParams.get("category") || "";
 
-  const pageParam = searchParams.get("page");
+  const parsedPageNumber = Number.parseInt(searchParams.get("page") || "1", 10);
+  const currentPageNumber =
+    Number.isNaN(parsedPageNumber) || parsedPageNumber < 1
+      ? 1
+      : parsedPageNumber;
 
-  useEffect(() => {
-    if (pageParam !== null) {
-      setCurrentPageNumber(parseInt(pageParam));
-      setCurrentPageIndex(parseInt(pageParam) - 1);
-    } else {
-      setCurrentPageNumber(1);
-      setCurrentPageIndex(0);
+  const updateSearchParams = (
+    updates: Record<string, string>,
+    resetPage = true
+  ) => {
+    const params = new URLSearchParams(searchParams);
+
+    Object.entries(updates).forEach(([key, value]) => {
+      if (value) {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+    });
+
+    if (resetPage) {
+      params.delete("page");
     }
-  }, [pageParam]);
+
+    setSearchParams(params);
+  };
 
   useEffect(() => {
     if (interfacesList) {
-      setInterfaces(interfacesList.sort(sortInterfaces));
+      setInterfaces(interfacesList);
+      setError(false);
+      setLoading(false);
       return;
     }
 
@@ -87,7 +91,7 @@ function InterfacesIndex({ interfacesList }: Props) {
         throw response;
       })
       .then((data) => {
-        setInterfaces(data?.interfaces.sort(sortInterfaces));
+        setInterfaces(data?.interfaces || []);
       })
       .catch(() => {
         setError(true);
@@ -97,9 +101,108 @@ function InterfacesIndex({ interfacesList }: Props) {
       });
   }, [interfacesList]);
 
+  const sortedInterfaces = useMemo(
+    () => [...interfaces].sort(sortInterfaces),
+    [interfaces]
+  );
+
+  const statusOptions = useMemo(() => {
+    return Array.from(
+      new Set(
+        sortedInterfaces.map((item) => normalize(item.status)).filter(Boolean)
+      )
+    ).sort();
+  }, [sortedInterfaces]);
+
+  const categoryOptions = useMemo(() => {
+    return Array.from(
+      new Set(
+        sortedInterfaces
+          .flatMap((item) => item.tags || [])
+          .map((tag) => normalize(tag))
+          .filter(Boolean)
+      )
+    ).sort();
+  }, [sortedInterfaces]);
+
+  const statusSelectOptions = useMemo(
+    () => [
+      { value: "", label: "Status" },
+      ...statusOptions.map((status) => ({
+        value: status,
+        label: status.charAt(0).toUpperCase() + status.slice(1),
+      })),
+    ],
+    [statusOptions]
+  );
+
+  const categorySelectOptions = useMemo(
+    () => [
+      { value: "", label: "Category" },
+      ...categoryOptions.map((category) => ({
+        value: category,
+        label: category.charAt(0).toUpperCase() + category.slice(1),
+      })),
+    ],
+    [categoryOptions]
+  );
+
+  const filteredInterfaces = useMemo(() => {
+    const normalizedSearch = normalize(searchQuery);
+    const normalizedStatus = normalize(statusFilter);
+    const normalizedCategory = normalize(categoryFilter);
+
+    return sortedInterfaces.filter((item) => {
+      const itemStatus = normalize(item.status);
+      const itemTags = (item.tags || []).map((tag) => normalize(tag));
+      const searchableText = [
+        item.name,
+        item.summary,
+        item.description,
+        ...(item.tags || []),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+
+      if (normalizedSearch && !searchableText.includes(normalizedSearch)) {
+        return false;
+      }
+
+      if (normalizedStatus && itemStatus !== normalizedStatus) {
+        return false;
+      }
+
+      if (normalizedCategory && !itemTags.includes(normalizedCategory)) {
+        return false;
+      }
+
+      return true;
+    });
+  }, [sortedInterfaces, searchQuery, statusFilter, categoryFilter]);
+
+  const totalPages = Math.max(
+    1,
+    Math.ceil(filteredInterfaces.length / ITEMS_PER_PAGE)
+  );
+  const currentPage = Math.min(currentPageNumber, totalPages);
+  const currentPageIndex = currentPage - 1;
+  const startIndex = currentPageIndex * ITEMS_PER_PAGE;
+  const currentItems = filteredInterfaces.slice(
+    startIndex,
+    startIndex + ITEMS_PER_PAGE
+  );
+
   useEffect(() => {
-    setCurrentItems(pageArray(interfaces, ITEMS_PER_PAGE)[currentPageIndex]);
-  }, [currentPageIndex, interfaces]);
+    if (currentPageNumber > totalPages) {
+      updateSearchParams(
+        {
+          page: totalPages > 1 ? totalPages.toString() : "",
+        },
+        false
+      );
+    }
+  }, [currentPageNumber, totalPages]);
 
   useEffect(() => {
     document.title = "Charmhub | Interface catalogue";
@@ -149,20 +252,62 @@ function InterfacesIndex({ interfacesList }: Props) {
             moments.
           </Notification>
         )}
-        <h2 className="p-heading--4">
-          {currentItems && interfaces.length > ITEMS_PER_PAGE && (
-            <>
-              {ITEMS_PER_PAGE * currentPageIndex + 1} &ndash;{" "}
-              {ITEMS_PER_PAGE * currentPageIndex + currentItems.length} of{" "}
-              {interfaces.length} interfaces
-            </>
-          )}
-        </h2>
+        <Row>
+          <Col size={5}>
+            <SearchBox
+              placeholder="Search interfaces"
+              externallyControlled
+              value={searchQuery}
+              onChange={(value) => {
+                updateSearchParams({ search: value });
+              }}
+              aria-label="Search interfaces"
+            />
+          </Col>
+          <Col
+            emptyLarge={9}
+            size={4}
+            className="p-form--inline"
+            style={{ justifyContent: "flex-end" }}
+          >
+            <Select
+              value={statusFilter}
+              options={statusSelectOptions}
+              onChange={(event) => {
+                updateSearchParams({ status: event.target.value });
+              }}
+              aria-label="Status"
+            />
+            <Select
+              value={categoryFilter}
+              options={categorySelectOptions}
+              onChange={(event) => {
+                updateSearchParams({ category: event.target.value });
+              }}
+              aria-label="Category"
+            />
+          </Col>
+        </Row>
         <MainTable
           headers={[
             {
               content: "Interface name",
               heading: "Interface name",
+            },
+            {
+              content: "Status",
+              heading: "Status",
+              style: {
+                width: "120px",
+              },
+            },
+            {
+              content: "Summary",
+              heading: "Summary",
+            },
+            {
+              content: "Category",
+              heading: "Category",
             },
             {
               content: "Version",
@@ -171,45 +316,117 @@ function InterfacesIndex({ interfacesList }: Props) {
                 width: "80px",
               },
             },
+            {
+              content: "Links",
+              heading: "Links",
+            },
           ]}
-          rows={
-            currentItems &&
-            currentItems.map((item: InterfaceItem) => {
-              return {
-                columns: [
-                  {
-                    content: (
-                      <div
-                        style={{
-                          display: "flex",
-                        }}
-                      >
-                        {item?.status === "published" && (
-                          <Link to={`/integrations/${item?.name}`}>
-                            {item?.name}
-                          </Link>
-                        )}
-                        {item?.status !== "published" && (
-                          <>
-                            <StatusLabel style={{ marginRight: "1rem" }}>
-                              {item?.status}
-                            </StatusLabel>
-                            <Link to={`/integrations/${item?.name}`}>
-                              {item?.name}
-                            </Link>
-                          </>
-                        )}
-                      </div>
-                    ),
-                  },
-                  {
-                    content: item?.version,
-                    className: "u-align--right",
-                  },
-                ],
-              };
-            })
-          }
+          rows={currentItems.map((item: InterfaceItem) => {
+            const interfaceName = item?.name || "";
+            const interfaceStatus = item?.status || "";
+            const libraryLink = item?.links?.library || "";
+            const documentationLink = item?.links?.documentation || "";
+            const normalizedInterfaceStatus = normalize(interfaceStatus);
+            const interfaceStatusLabel = interfaceStatus
+              ? interfaceStatus.charAt(0).toUpperCase() +
+                interfaceStatus.slice(1)
+              : "";
+            const statusAppearance =
+              normalizedInterfaceStatus === "published"
+                ? "positive"
+                : normalizedInterfaceStatus === "draft"
+                  ? "caution"
+                  : normalizedInterfaceStatus === "deprecated"
+                    ? "negative"
+                    : "information";
+
+            return {
+              columns: [
+                {
+                  content: (
+                    <>
+                      {interfaceName && (
+                        <Link to={`/integrations/${interfaceName}`}>
+                          {interfaceName}
+                        </Link>
+                      )}
+                    </>
+                  ),
+                },
+                {
+                  content: (
+                    <>
+                      {interfaceStatus && (
+                        <Chip
+                          value={interfaceStatusLabel}
+                          appearance={statusAppearance}
+                          className="u-no-margin--bottom"
+                          isReadOnly
+                        />
+                      )}
+                    </>
+                  ),
+                },
+                {
+                  content: item?.summary || item?.description || "-",
+                },
+                {
+                  content: (
+                    <>
+                      {item?.tags && item.tags.length > 0 && (
+                        <div style={{ display: "flex", flexWrap: "wrap" }}>
+                          {item.tags.map((tag) => (
+                            <Chip
+                              key={tag}
+                              value={
+                                tag
+                                  ? tag.charAt(0).toUpperCase() + tag.slice(1)
+                                  : ""
+                              }
+                              className="u-no-margin--bottom"
+                              isReadOnly
+                            />
+                          ))}
+                        </div>
+                      )}
+                    </>
+                  ),
+                },
+                {
+                  content: item?.version?.toString() || "",
+                },
+                {
+                  content: (
+                    <>
+                      {libraryLink && (
+                        <>
+                          <a
+                            className="p-link--external"
+                            href={libraryLink}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            Library
+                          </a>
+                          {documentationLink && <br />}
+                        </>
+                      )}
+                      {documentationLink && (
+                        <a
+                          className="p-link--external"
+                          href={documentationLink}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Documentation
+                        </a>
+                      )}
+                    </>
+                  ),
+                },
+              ],
+            };
+          })}
           emptyStateMsg={`${
             loading ? "Fetching interfaces..." : "No interfaces available"
           }`}
@@ -217,22 +434,25 @@ function InterfacesIndex({ interfacesList }: Props) {
         />
         <div className="u-align--right">
           <Pagination
-            currentPage={currentPageNumber}
+            currentPage={currentPage}
             itemsPerPage={ITEMS_PER_PAGE}
             paginate={(pageNumber) => {
-              setCurrentPageNumber(pageNumber);
-              setCurrentPageIndex(pageNumber - 1);
-
-              if (pageNumber > 1) {
-                setSearchParams({ page: pageNumber.toString() });
-              } else {
-                setSearchParams({});
-              }
+              updateSearchParams(
+                { page: pageNumber > 1 ? pageNumber.toString() : "" },
+                false
+              );
             }}
-            totalItems={interfaces.length}
-            scrollToTop
+            totalItems={filteredInterfaces.length}
           />
         </div>
+        <p>
+          {filteredInterfaces.length > ITEMS_PER_PAGE && (
+            <>
+              {startIndex + 1} &ndash; {startIndex + currentItems.length} of{" "}
+              {filteredInterfaces.length} interfaces
+            </>
+          )}
+        </p>
       </Strip>
     </>
   );

--- a/static/js/src/interfaces/components/InterfacesIndex/__tests__/InterfacesIndex.test.tsx
+++ b/static/js/src/interfaces/components/InterfacesIndex/__tests__/InterfacesIndex.test.tsx
@@ -11,22 +11,26 @@ describe("InterfacesIndex", () => {
       name: "interface1",
       description: "Description 1",
       version: "1.0",
-      status: "test",
-      category: "Category 1",
+      status: "published",
+      tags: ["tag1"],
+      links: {
+        library: "https://example.com/library",
+        documentation: "https://example.com/docs",
+      },
     },
     {
       name: "interface2",
       description: "Description 2",
       version: "1.1",
-      status: "beta",
-      category: "Category 2",
+      status: "draft",
+      tags: ["tag2", "tag3"],
     },
     {
       name: "interface3",
       description: "Description 3",
       version: "1.2",
-      status: "beta",
-      category: "Category 3",
+      status: "deprecated",
+      tags: ["tag1", "tag2"],
     },
   ];
 
@@ -100,5 +104,78 @@ describe("InterfacesIndex", () => {
 
     expect(screen.getByText("Next page")).toBeInTheDocument();
     expect(screen.getByText("Previous page")).toBeInTheDocument();
+  });
+
+  test("renders conditional library and documentation links", async () => {
+    render(
+      <Router>
+        <InterfacesIndex interfacesList={interfacesList} />
+      </Router>
+    );
+
+    await waitFor(() => {
+      const libraryLink = screen.getByRole("link", { name: "Library" });
+      const docsLink = screen.getByRole("link", { name: "Documentation" });
+
+      expect(libraryLink).toHaveAttribute(
+        "href",
+        "https://example.com/library"
+      );
+      expect(docsLink).toHaveAttribute("href", "https://example.com/docs");
+    });
+  });
+
+  test("filters interfaces by search query", async () => {
+    render(
+      <Router>
+        <InterfacesIndex interfacesList={interfacesList} />
+      </Router>
+    );
+
+    fireEvent.change(screen.getByLabelText("Search interfaces"), {
+      target: { value: "interface2" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("interface2")).toBeInTheDocument();
+      expect(screen.queryByText("interface1")).not.toBeInTheDocument();
+      expect(screen.queryByText("interface3")).not.toBeInTheDocument();
+    });
+  });
+
+  test("filters interfaces by status", async () => {
+    render(
+      <Router>
+        <InterfacesIndex interfacesList={interfacesList} />
+      </Router>
+    );
+
+    fireEvent.change(screen.getByLabelText("Status"), {
+      target: { value: "draft" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("interface2")).toBeInTheDocument();
+      expect(screen.queryByText("interface1")).not.toBeInTheDocument();
+      expect(screen.queryByText("interface3")).not.toBeInTheDocument();
+    });
+  });
+
+  test("filters interfaces by category", async () => {
+    render(
+      <Router>
+        <InterfacesIndex interfacesList={interfacesList} />
+      </Router>
+    );
+
+    fireEvent.change(screen.getByLabelText("Category"), {
+      target: { value: "tag3" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("interface2")).toBeInTheDocument();
+      expect(screen.queryByText("interface1")).not.toBeInTheDocument();
+      expect(screen.queryByText("interface3")).not.toBeInTheDocument();
+    });
   });
 });

--- a/static/js/src/interfaces/types/index.ts
+++ b/static/js/src/interfaces/types/index.ts
@@ -45,8 +45,13 @@ export type InterfaceData = {
 
 export type InterfaceItem = {
   name: string;
-  description: string;
-  version: string;
-  status: string;
-  category: string;
+  description?: string;
+  summary?: string;
+  version?: string | number;
+  status?: string;
+  tags?: string[];
+  links?: {
+    library?: string;
+    documentation?: string;
+  };
 };

--- a/tests/integrations/test_integrations_logic.py
+++ b/tests/integrations/test_integrations_logic.py
@@ -118,7 +118,7 @@ class TestInterfaces(unittest.TestCase):
         result = self.interfaces.get_interface_from_path(interface_name)
 
         self.repo.get_contents.assert_called_with(
-            "interfaces/test_interface/v3/interface.yaml"
+            "interfaces/test_interface/interface/v3/interface.yaml"
         )
 
         self.assertEqual(result, mock_interface)
@@ -160,7 +160,7 @@ class TestInterfaces(unittest.TestCase):
         result = self.interfaces.get_interface_from_path(interface_name)
 
         self.repo.get_contents.assert_called_with(
-            "interfaces/test_interface/v3/interface.yaml"
+            "interfaces/test_interface/interface/v3/interface.yaml"
         )
 
         self.assertEqual(
@@ -173,3 +173,58 @@ class TestInterfaces(unittest.TestCase):
             self.interfaces.get_interface_name_from_readme(readme),
             "test_interface",
         )
+
+    @patch("webapp.integrations.logic.redis_cache")
+    def test_get_interfaces_normalizes_charmlibs_index(
+        self, mock_redis_cache
+    ):
+        mock_redis_cache.get.return_value = None
+        mock_index = MagicMock()
+        index_content = """
+[
+  {
+    "name": "cos_agent",
+    "version": "2",
+    "lib": "charms.grafana_agent.cos_agent",
+    "lib_url": "https://example.com/library",
+    "docs_url": "https://example.com/docs",
+    "summary": "summary text",
+    "description": "description text",
+    "tags": ["observability"],
+    "status": "published"
+  },
+  {
+    "name": "ingress",
+    "version": "1",
+    "summary": "",
+    "status": "draft"
+  }
+]
+"""
+        mock_index.decoded_content = index_content.encode("utf-8")
+        self.repo.get_contents.return_value = mock_index
+
+        interfaces = self.interfaces.get_interfaces()
+
+        self.assertEqual(len(interfaces), 2)
+        self.assertEqual(interfaces[0]["name"], "cos_agent")
+        self.assertEqual(interfaces[0]["status"], "published")
+        self.assertEqual(interfaces[0]["summary"], "summary text")
+        self.assertEqual(interfaces[0]["tags"], ["observability"])
+        self.assertEqual(
+            interfaces[0]["charm"], "charms.grafana_agent.cos_agent"
+        )
+        self.assertEqual(
+            interfaces[0]["links"]["library"],
+            "https://example.com/library",
+        )
+        self.assertEqual(
+            interfaces[0]["links"]["documentation"],
+            "https://example.com/docs",
+        )
+
+        self.assertEqual(interfaces[1]["tags"], [])
+        self.assertEqual(interfaces[1]["charm"], "")
+        self.assertEqual(interfaces[1]["links"]["library"], "")
+        self.assertEqual(interfaces[1]["links"]["documentation"], "")
+

--- a/webapp/integrations/logic.py
+++ b/webapp/integrations/logic.py
@@ -23,7 +23,7 @@ class Interfaces:
     def repo(self):
         if self._repo is None:
             self._repo = github_client.get_repo(
-                "canonical/charm-relation-interfaces"
+                "canonical/charmlibs"
             )
         return self._repo
 
@@ -34,13 +34,32 @@ class Interfaces:
         if interfaces:
             return interfaces
         try:
-            index = self.repo.get_contents("index.json")
-            if isinstance(index, list):
-                index = index[0]
-            index_content = index.decoded_content.decode("utf-8")
-            interfaces = yaml.load(index_content)
-            redis_cache.set(key, interfaces, ttl=86400)
-            return interfaces
+            index = self.repo.get_contents("interfaces/index.json")
+            interfaces = yaml.load(index.decoded_content.decode("utf-8"))
+
+            normalized_interfaces = []
+            for interface in interfaces or []:
+                normalized_interfaces.append(
+                    {
+                        "name": interface.get("name", ""),
+                        "status": interface.get("status", ""),
+                        "summary": interface.get("summary", ""),
+                        "description": interface.get("description", ""),
+                        "version": interface.get("version", ""),
+                        "tags": interface.get("tags", []),
+                        "charm": interface.get("charm")
+                        or interface.get("lib", ""),
+                        "links": {
+                            "library": interface.get("library")
+                            or interface.get("lib_url", ""),
+                            "documentation": interface.get("documentation")
+                            or interface.get("docs_url", ""),
+                        },
+                    }
+                )
+
+            redis_cache.set(key, normalized_interfaces, ttl=86400)
+            return normalized_interfaces
         except Exception:
             return []
 
@@ -52,7 +71,7 @@ class Interfaces:
             return interface
         try:
             interface_versions = self.repo.get_contents(
-                "interfaces/{}".format(interface_name)
+                "interfaces/{}/interface".format(interface_name)
             )
         except Exception:
             return None
@@ -68,7 +87,7 @@ class Interfaces:
         latest_version = versions.pop()
 
         latest_version_interface = self.repo.get_contents(
-            "interfaces/{}/{}/interface.yaml".format(
+            "interfaces/{}/interface/{}/interface.yaml".format(
                 interface_name, latest_version
             )
         ).decoded_content.decode("utf-8")
@@ -132,7 +151,7 @@ class Interfaces:
     def parse_text(self, interface, version, text):
         base_link = (
             "https://github.com/canonical/"
-            "charm-relation-interfaces/blob/main/interfaces/{}/v{}"
+            "charmlibs/blob/main/interfaces/{}/interface/v{}"
         ).format(interface, version)
         pattern = r"\[.*?\]\(.*?\)"
         matches = re.findall(pattern, text)

--- a/webapp/integrations/logic.py
+++ b/webapp/integrations/logic.py
@@ -47,13 +47,9 @@ class Interfaces:
                         "description": interface.get("description", ""),
                         "version": interface.get("version", ""),
                         "tags": interface.get("tags", []),
-                        "charm": interface.get("charm")
-                        or interface.get("lib", ""),
                         "links": {
-                            "library": interface.get("library")
-                            or interface.get("lib_url", ""),
-                            "documentation": interface.get("documentation")
-                            or interface.get("docs_url", ""),
+                            "library": interface.get("lib_url"),
+                            "documentation": interface.get("docs_url")
                         },
                     }
                 )

--- a/webapp/integrations/views.py
+++ b/webapp/integrations/views.py
@@ -68,7 +68,7 @@ def fetch_interface_details(interface_name):
         return None
 
     readme_path = (
-        f"interfaces/{interface_name}/v{interface['version']}/README.md"
+        f"interfaces/{interface_name}/interface/v{interface['version']}/README.md"
     )
     readme_contentfile = interface_logic.repo.get_contents(readme_path)
     readme = readme_contentfile.decoded_content.decode("utf-8")


### PR DESCRIPTION
Adds the interfaces index table and points to the new interfaces repo.
## Deviations:
Some known deviations from the design:
- Version isn't a dropdown (instead the library/docs link has the top level info containing all versions)
- No charm filter (Adding this requires N+1 queries, and you can go to the /charm-name/integrations tab to get the same info)
- Mandatory is "Required" (Consistent with past label name)
# Q/A
- https://charmhub-io-2352.demos.haus/integrations
- [Figma](https://www.figma.com/design/bY5HHkqzvYREdxJFhbl5kM/25.10-Charmhub-solution-focus---Store?node-id=1744-5226&m=dev)