### PR TITLE
chore: add interface links to homepage

### DIFF
--- a/static/js/src/store/components/Banner/Banner.tsx
+++ b/static/js/src/store/components/Banner/Banner.tsx
@@ -13,6 +13,19 @@ function Banner({ searchRef }: Props) {
         <Col size={6} className="col-start-large-4">
           <h1 className="p-heading--2">The Charm Collection</h1>
           <SearchInput searchRef={searchRef} />
+          <h2 className="p-text--small-caps u-text--muted u-no-margin--bottom">
+            developer resources
+          </h2>
+          <Row className="p-divider">
+            <Col size={1} className="p-divider__block">
+              <a href="/integrations">Interfaces</a>
+            </Col>
+            <Col size={3} className="p-divider__block">
+              <a href="https://documentation.ubuntu.com/charmlibs/">
+                Charm development libraries
+              </a>
+            </Col>
+          </Row>
         </Col>
       </Row>
     </Strip>

--- a/static/js/src/store/components/Banner/__tests__/Banner.test.tsx
+++ b/static/js/src/store/components/Banner/__tests__/Banner.test.tsx
@@ -33,6 +33,9 @@ describe("Banner Component", () => {
     expect(
       screen.getByRole("heading", { name: /The Charm Collection/i })
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /Developer Resources/i })
+    ).toBeInTheDocument();
 
     expect(screen.getByPlaceholderText("Search Charmhub")).toBeInTheDocument();
 


### PR DESCRIPTION
Adds interface links to the homepage 

# QA
- Design matches [Figma](https://www.figma.com/design/bY5HHkqzvYREdxJFhbl5kM/25.10-Charmhub-solution-focus---Store?node-id=1749-39690&t=g8IRHDMmGodMUpNt-4)

