### PR TITLE
Wd 36945/make solutions tab public

### DIFF
--- a/static/js/src/solutions/modules/ConfirmationModal.js
+++ b/static/js/src/solutions/modules/ConfirmationModal.js
@@ -12,14 +12,22 @@ function initConfirmationModal(config) {
   }
 
   let formSubmitted = false;
+  let submitter = null;
 
   form.addEventListener("submit", (event) => {
     if (formSubmitted) {
       return;
     }
 
+    submitter = event.submitter;
+
     event.preventDefault();
     event.stopPropagation();
+
+    if (!form.checkValidity()) {
+      form.reportValidity();
+      return;
+    }
 
     if (window.validateSolutionForm && !window.validateSolutionForm()) {
       return;
@@ -45,7 +53,11 @@ function initConfirmationModal(config) {
     confirmButton.disabled = true;
 
     formSubmitted = true;
-    form.submit();
+    if (submitter && form.requestSubmit) {
+      form.requestSubmit(submitter);
+    } else {
+      form.submit();
+    }
   });
 
   const closeModal = () => {

--- a/static/js/src/solutions/modules/ConfirmationModal.js
+++ b/static/js/src/solutions/modules/ConfirmationModal.js
@@ -14,6 +14,16 @@ function initConfirmationModal(config) {
   let formSubmitted = false;
   let submitter = null;
 
+  const submitForm = () => {
+    formSubmitted = true;
+
+    if (form.requestSubmit) {
+      form.requestSubmit(submitter || undefined);
+    } else {
+      form.submit();
+    }
+  };
+
   form.addEventListener("submit", (event) => {
     if (formSubmitted) {
       return;
@@ -37,6 +47,11 @@ function initConfirmationModal(config) {
     const formObject = Object.fromEntries(formData.entries());
     const message = config.getMessage(formObject, form);
 
+    if (!message) {
+      submitForm();
+      return;
+    }
+
     modalMessage.textContent = message;
     modal.classList.remove("u-hide");
     confirmButton.focus();
@@ -52,12 +67,7 @@ function initConfirmationModal(config) {
     confirmButton.appendChild(spinner);
     confirmButton.disabled = true;
 
-    formSubmitted = true;
-    if (submitter && form.requestSubmit) {
-      form.requestSubmit(submitter);
-    } else {
-      form.submit();
-    }
+    submitForm();
   });
 
   const closeModal = () => {

--- a/templates/publisher/list.html
+++ b/templates/publisher/list.html
@@ -21,7 +21,7 @@
         </li>
       </ul>
     {% else %}
-      <h1 class="p-heading--2">{% if g.get('has_solutions', False) %}My charms, bundles and solutions{% else %}My charms and bundles{% endif %}</h1>
+      <h1 class="p-heading--2">My charms, bundles and solutions</h1>
     {% endif %}
   </div>
 </section>
@@ -55,11 +55,9 @@
               <li class="p-tabs__item" role="presentation">
                 <a href="/bundles" class="p-tabs__link" role="tab" aria-controls="bundles" {% if page_type=='bundle' %}aria-selected="true" {% endif %}>Bundles</a>
               </li>
-              {% if g.get('has_solutions', False) %}
               <li class="p-tabs__item" role="presentation">
                 <a href="/solutions" class="p-tabs__link" role="tab" aria-controls="solutions">Solutions</a>
               </li>
-              {% endif %}
             </ul>
           </nav>
         </li>

--- a/templates/publisher/solutions.html
+++ b/templates/publisher/solutions.html
@@ -55,7 +55,7 @@
       <div class="p-strip">
         <div class="row">
           <div class="u-align--right col-4 col-medium-2 col-small-1">
-            <img src="https://assets.ubuntu.com/v1/3234f995-Generic_chamhub_NoDocs.svg" alt="no solutions available" width="121" height="121">
+            <img src="https://assets.ubuntu.com/v1/3234f995-Generic_chamhub_NoDocs.svg" alt="empty state" width="121" height="121">
           </div>
           <div class="u-align--left col-8 col-medium-4 col-small-3">
             <p class="p-heading--4">No published solutions available</p>
@@ -65,7 +65,7 @@
       </div>
     {% else %}
       <div class="u-fixed-width">
-        <h2 class="p-heading--4">My solutions</h2>
+        <h2 class="p-heading--4">Published solutions</h2>
       </div>
       <div class="u-fixed-width">
         <table class="p-table--mobile-card" role="grid">

--- a/templates/publisher/solutions.html
+++ b/templates/publisher/solutions.html
@@ -55,7 +55,7 @@
       <div class="p-strip">
         <div class="row">
           <div class="u-align--right col-4 col-medium-2 col-small-1">
-            <img src="https://assets.ubuntu.com/v1/3234f995-Generic_chamhub_NoDocs.svg" alt="empty state" width="121" height="121">
+            <img src="https://assets.ubuntu.com/v1/3234f995-Generic_chamhub_NoDocs.svg" alt="no solutions available" width="121" height="121">
           </div>
           <div class="u-align--left col-8 col-medium-4 col-small-3">
             <p class="p-heading--4">No published solutions available</p>

--- a/templates/solutions/partials/_architecture_section.html
+++ b/templates/solutions/partials/_architecture_section.html
@@ -25,13 +25,14 @@
 
 <div class="p-form__group row">
   <div class="col-2">
-    <label for="architecture_explanation">Architecture Description:</label>
+    <label for="architecture_explanation" class="is-required">Architecture Explanation:</label>
   </div>
   <div class="col-8 col-x-large-6">
     <textarea class="is-dense"
       id="architecture_explanation"
       name="architecture_explanation"
       rows="6"
+      required
     >{{ form_value(form_data, solution, 'architecture_explanation', 'documentation.architecture_explanation') | e }}</textarea>
     <p class="p-form-help-text">Explanation of the solution architecture (Markdown supported)</p>
   </div>

--- a/templates/solutions/partials/_basic_info_section.html
+++ b/templates/solutions/partials/_basic_info_section.html
@@ -54,16 +54,33 @@
 
 <div class="p-form__group row">
   <div class="col-2">
-    <label for="get_started_url">Get Started URL:</label>
+    <label for="get_started_url" class="is-required">Get Started URL:</label>
   </div>
   <div class="col-8 col-x-large-6">
     <input class="is-dense"
       id="get_started_url"
       name="get_started_url"
       type="url"
+      required
       value="{{ form_value(form_data, solution, 'get_started_url', 'documentation.get_started') | e }}"
     >
     <p class="p-form-help-text">URL to a Getting Started or Implementation Guide</p>
+  </div>
+</div>
+
+<div class="p-form__group row">
+  <div class="col-2">
+    <label for="how_to_operate_url" class="is-required">How to Operate URL:</label>
+  </div>
+  <div class="col-8 col-x-large-6">
+    <input class="is-dense"
+      id="how_to_operate_url"
+      name="how_to_operate_url"
+      type="url"
+      required
+      value="{{ form_value(form_data, solution, 'how_to_operate_url', 'documentation.how_to_operate') | e }}"
+    >
+    <p class="p-form-help-text">URL to documentation explaining how to operate this solution</p>
   </div>
 </div>
 

--- a/templates/solutions/partials/_basic_info_section.html
+++ b/templates/solutions/partials/_basic_info_section.html
@@ -68,21 +68,6 @@
   </div>
 </div>
 
-<div class="p-form__group row">
-  <div class="col-2">
-    <label for="how_to_operate_url" class="is-required">How to Operate URL:</label>
-  </div>
-  <div class="col-8 col-x-large-6">
-    <input class="is-dense"
-      id="how_to_operate_url"
-      name="how_to_operate_url"
-      type="url"
-      required
-      value="{{ form_value(form_data, solution, 'how_to_operate_url', 'documentation.how_to_operate') | e }}"
-    >
-    <p class="p-form-help-text">URL to documentation explaining how to operate this solution</p>
-  </div>
-</div>
 
 <div class="p-form__group row">
   <div class="col-2">

--- a/tests/publisher/test_publisher_views.py
+++ b/tests/publisher/test_publisher_views.py
@@ -143,14 +143,11 @@ class TestPublisherViews(unittest.TestCase):
         self.assertEqual(res.json["success"], False)
         self.assertEqual(res.json["message"], "Package not found")
 
-    @patch("webapp.solutions.logic.publisher_has_solutions_access")
     @patch("webapp.store_api.publisher_gateway.get_account_packages")
     def test_list_page(
         self,
         mock_get_account_packages,
-        mock_has_solutions,
     ):
-        mock_has_solutions.return_value = False
         mock_get_account_packages.return_value = [
             {
                 "contact": "email",
@@ -185,9 +182,19 @@ class TestPublisherViews(unittest.TestCase):
         self.assertIn(b"postgresql", res.data)
         self.assertIn(b"Published charms", res.data)
         self.assertIn(b"Listed", res.data)
+        self.assertIn(b"Solutions", res.data)
         res = self.client.get("/bundles")
         self.assertEqual(res.status_code, 200)
         self.assertNotIn(b"postgresql", res.data)
+
+    @patch("webapp.publisher.views.get_publisher_solutions", return_value=[])
+    def test_solutions_page_empty_state(self, mock_get_publisher_solutions):
+        res = self.client.get("/solutions")
+
+        self.assertEqual(res.status_code, 200)
+        mock_get_publisher_solutions.assert_called_once_with("test-username")
+        self.assertIn(b"Solutions", res.data)
+        self.assertIn(b"No published solutions available", res.data)
 
     @patch("webapp.publisher.views.redis_cache.get", return_value=None)
     @patch("webapp.store_api.publisher_gateway.get_account_packages")

--- a/tests/solutions/test_solutions_logic.py
+++ b/tests/solutions/test_solutions_logic.py
@@ -3,7 +3,6 @@ from unittest.mock import patch, MagicMock
 from webapp.solutions.logic import (
     get_solution_from_backend,
     get_publisher_solutions,
-    publisher_has_solutions_access,
 )
 
 
@@ -147,44 +146,3 @@ class TestSolutionsLogic(unittest.TestCase):
 
         self.assertEqual(result, [])
 
-    @patch("webapp.solutions.logic.make_authenticated_request")
-    def test_publisher_has_solutions_true(self, mock_auth_request):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"user": {"is_publisher": True}}
-        mock_auth_request.return_value = mock_response
-
-        result = publisher_has_solutions_access("testuser")
-
-        self.assertTrue(result)
-        mock_auth_request.assert_called_once()
-
-    @patch("webapp.solutions.logic.make_authenticated_request")
-    def test_publisher_has_solutions_false(self, mock_auth_request):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"user": {"is_publisher": False}}
-        mock_auth_request.return_value = mock_response
-
-        result = publisher_has_solutions_access("testuser")
-
-        self.assertFalse(result)
-        mock_auth_request.assert_called_once()
-
-    @patch("webapp.solutions.logic.make_authenticated_request")
-    def test_publisher_has_solutions_api_failure(self, mock_auth_request):
-        mock_response = MagicMock()
-        mock_response.status_code = 500
-        mock_auth_request.return_value = mock_response
-
-        result = publisher_has_solutions_access("testuser")
-
-        self.assertFalse(result)
-
-    @patch("webapp.solutions.logic.make_authenticated_request")
-    def test_publisher_has_solutions_exception(self, mock_auth_request):
-        mock_auth_request.side_effect = Exception("Network error")
-
-        result = publisher_has_solutions_access("testuser")
-
-        self.assertFalse(result)

--- a/webapp/publisher/form_processors.py
+++ b/webapp/publisher/form_processors.py
@@ -13,6 +13,7 @@ def extract_basic_form_fields():
         "documentation_main",
         "documentation_source",
         "get_started_url",
+        "how_to_operate_url",
         "submit_bug_url",
         "community_discussion_url",
         "architecture_diagram_url",
@@ -75,11 +76,6 @@ def extract_platform_data():
 
 def process_solution_form_data():
     form_data = extract_basic_form_fields()
-
-    if not form_data.get("get_started_url") and form_data.get(
-        "documentation_main"
-    ):
-        form_data["get_started_url"] = form_data["documentation_main"]
 
     form_data["charms"] = extract_charms_data()
     form_data["useful_links"] = extract_useful_links_data()

--- a/webapp/publisher/form_processors.py
+++ b/webapp/publisher/form_processors.py
@@ -13,7 +13,6 @@ def extract_basic_form_fields():
         "documentation_main",
         "documentation_source",
         "get_started_url",
-        "how_to_operate_url",
         "submit_bug_url",
         "community_discussion_url",
         "architecture_diagram_url",

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -9,7 +9,6 @@ from flask import (
     session,
     url_for,
     make_response,
-    g,
 )
 from flask.json import jsonify
 from webapp.config import DETAILS_VIEW_REGEX
@@ -20,7 +19,6 @@ from webapp.store_api import device_gateway, publisher_gateway
 from webapp.utils.emailer import get_emailer
 from webapp.solutions.logic import (
     get_publisher_solutions,
-    publisher_has_solutions_access,
     register_solution,
     get_user_teams_for_solutions,
     get_solution_from_backend,
@@ -31,7 +29,6 @@ from webapp.publisher.form_processors import (
     process_solution_form_data,
     create_error_context,
 )
-import functools
 from datetime import datetime
 import uuid
 
@@ -71,27 +68,6 @@ def paginate_pages(current_page, total_pages):
     pages.append(total_pages)
 
     return pages
-
-
-def requires_solutions_access(func):
-    @functools.wraps(func)
-    def has_solutions_access(*args, **kwargs):
-        username = session["account"]["username"]
-        has_solutions = publisher_has_solutions_access(username)
-        if not has_solutions:
-            flash(
-                "You don't have access to solutions. "
-                "Solutions access is granted based on "
-                "Launchpad team membership.",
-                "negative",
-            )
-            return redirect("/charms")
-
-        g.has_solutions = True
-        response = make_response(func(*args, **kwargs))
-        return response
-
-    return has_solutions_access
 
 
 def render_solution_form_with_errors(
@@ -302,19 +278,12 @@ def list_page():
         "pages": paginate_pages(page, total_pages),
     }
 
-    # Add solutions access check (from staging)
-    username = session["account"]["username"]
-    has_solutions = publisher_has_solutions_access(username)
-    g.has_solutions = has_solutions
-    context["has_solutions"] = has_solutions
-
     return render_template("publisher/list.html", **context)
 
 
 @trace_function
 @publisher.route("/solutions")
 @login_required
-@requires_solutions_access
 def solutions_page():
     username = session["account"]["username"]
 
@@ -790,7 +759,6 @@ def get_releases(entity_name: str):
 
 @publisher.route("/validate-solution-name")
 @login_required
-@requires_solutions_access
 def validate_solution_name():
     name = request.args.get("name", "").strip()
 
@@ -803,7 +771,6 @@ def validate_solution_name():
 
 @publisher.route("/register-solution")
 @login_required
-@requires_solutions_access
 def show_register_solution_form():
     username = session["account"]["username"]
 
@@ -817,7 +784,6 @@ def show_register_solution_form():
 
 @publisher.route("/register-solution", methods=["POST"])
 @login_required
-@requires_solutions_access
 def submit_register_solution():
     username = session["account"]["username"]
 
@@ -910,7 +876,6 @@ def submit_register_solution():
 
 @publisher.route("/solutions/edit/<hash>")
 @login_required
-@requires_solutions_access
 def edit_solution_form(hash):
     solution = get_solution_from_backend(hash, prefer_authenticated=True)
     if not solution:
@@ -950,7 +915,6 @@ def cleanup_old_previews():
 
 @publisher.route("/solutions/edit/<hash>", methods=["POST"])
 @login_required
-@requires_solutions_access
 def submit_edit_solution(hash):
     # Get solution data from backend first
     solution = get_solution_from_backend(hash, prefer_authenticated=True)

--- a/webapp/solutions/logic.py
+++ b/webapp/solutions/logic.py
@@ -129,28 +129,6 @@ def get_publisher_solutions(username):
     return []
 
 
-def publisher_has_solutions_access(username):
-    """
-    Checks if the user logged in has access to any solutions
-    """
-    try:
-        resp = make_authenticated_request(
-            "GET",
-            f"{SOLUTIONS_API_BASE}/me",
-            username,
-            timeout=5,
-        )
-
-        if resp.status_code == 200:
-            user_data = resp.json()
-            has_access = user_data.get("user", {}).get("is_publisher", False)
-            return has_access
-
-    except Exception as e:
-        logger.exception(f"User does not have access to solutions: {e}")
-    return False
-
-
 def register_solution(username, data):
     try:
         resp = make_authenticated_request(

--- a/webapp/solutions/mock_solutions.json
+++ b/webapp/solutions/mock_solutions.json
@@ -44,7 +44,6 @@
       "main": "https://documentation.ubuntu.com/observability/",
       "source": "https://github.com/canonical/observability/",
       "get_started": "https://documentation.ubuntu.com/observability/tutorial/",
-      "how_to_operate": "https://documentation.ubuntu.com/observability/how-to/",
       "architecture_explanation": "this is an explanation of how COS works",
       "submit_a_bug": "https://github.com/canonical/observability-docs/issues/new?title=docs%3A+TYPE+YOUR+QUESTION+HERE&body=*Please%20describe%20the%20question%20or%20issue%20you%27re%20facing%20with%20%22Observability%20Documentation%22.*%0A%0A%0A%0A%0A---%0A*Reported+from%3A+https://charmhub.io*",
       "community_discussion": "https://discourse.charmhub.io/c/charm/observability/62"
@@ -168,7 +167,6 @@
       "main": "https://canonical.com/solutions/telco",
       "source": "https://github.com/canonical/telco/",
       "get_started": "https://documentation.ubuntu.com/telco/tutorial/",
-      "how_to_operate": "https://documentation.ubuntu.com/telco/how-to/",
       "architecture_explanation": "",
       "submit_a_bug": "https://github.com/canonical/telco",
       "community_discussion": "https://discourse.ubuntu.com"
@@ -296,7 +294,6 @@
       "main": "https://charmed-kubeflow.io/docs",
       "source": "https://github.com/canonical/charmed-kubeflow-solutions",
       "get_started": "https://charmed-kubeflow.io/docs/get-started",
-      "how_to_operate": "https://charmed-kubeflow.io/docs/how-to",
       "architecture_explanation": "",
       "submit_a_bug": "https://github.com/canonical/bundle-kubeflow",
       "community_discussion": "https://discourse.charmhub.io/tag/kubeflow"

--- a/webapp/solutions/views.py
+++ b/webapp/solutions/views.py
@@ -150,7 +150,6 @@ def solution_preview_draft(preview_key):
         "main": form_data.get("documentation_main"),
         "source": form_data.get("documentation_source"),
         "get_started": form_data.get("get_started_url"),
-        "how_to_operate": form_data.get("how_to_operate_url"),
         "architecture_explanation": form_data.get("architecture_explanation"),
         "submit_a_bug": form_data.get("submit_bug_url"),
         "community_discussion": form_data.get("community_discussion_url"),


### PR DESCRIPTION
## Done
- Makes solutions tab available to all charmhub publishers
  - this omits the step where publishers need to "request access" - following discussions with the team, we are happy to do this as solutions will be primarily created by internal Canonical users
- Updates mandatory fields (makes architecture explanation and get started url mandatory)
- Removes how_to_operate url - this got mixed up in the `useful_links`, there was never meant to be a `how_to_operate` of its own

## How to QA
- Go to your [charms](https://charmhub-io-2354.demos.haus/charms) page and make sure you see solutions tab by default
  - Or go to [solutions tab](https://charmhub-io-2354.demos.haus/solutions) directly 
  - If you want to check the empty state, you'll have to check out this repo and run it locally with solutions service running locally OR log in with another account that won't have access to solutions
    - Then manually change this line in `webapp/publisher/views.py`:
      - `solutions = get_publisher_solutions(username)` > `solutions = []`
<img width="1437" height="579" alt="image" src="https://github.com/user-attachments/assets/343d1b95-ee92-428e-98bd-a1662f184bbe" />

- To QA new mandatory fields, try to edit one of your solutions
  - Make sure Architecture explanation and Get Started URL are now mandatory and that you can't submit the form without filling them in

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card

Fixes [WD-36945](https://warthogs.atlassian.net/browse/WD-36945)

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):


[WD-36945]: https://warthogs.atlassian.net/browse/WD-36945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ