### PR TITLE
Fix crash paths, missing timeouts and small cleanups from code audit

### DIFF
--- a/tests/publisher/test_publisher_views.py
+++ b/tests/publisher/test_publisher_views.py
@@ -232,7 +232,7 @@ class TestPublisherViews(unittest.TestCase):
             data={"token": "test-token", "package": "test-package"},
         )
         self.assertEqual(res.status_code, 500)
-        self.assertEqual(res.json["message"], "An error occured")
+        self.assertEqual(res.json["message"], "An error occurred")
 
     @patch("webapp.store_api.publisher_gateway.reject_invite")
     def test_reject_post_invite(self, mock_reject_invite):

--- a/tests/store/test_package_has_sboms.py
+++ b/tests/store/test_package_has_sboms.py
@@ -1,5 +1,8 @@
 import unittest
 from unittest.mock import patch, Mock
+
+import requests
+
 from webapp.store.views import package_has_sboms
 
 
@@ -160,14 +163,14 @@ class TestPackageHasSboms(unittest.TestCase):
         """Test function returns False when requests.head raises exception."""
         # Setup mocks
         mock_get_endpoint_url.return_value = "https://example.com/sbom/path"
-        mock_head.side_effect = Exception("Network error")
+        mock_head.side_effect = requests.RequestException("Network error")
 
         revisions = ["revision-error"]
         package_id = "error-package"
 
         # Function should handle exceptions gracefully and return False
-        with self.assertRaises(Exception):
-            package_has_sboms(revisions, package_id)
+        result = package_has_sboms(revisions, package_id)
+        self.assertFalse(result)
 
     @patch("webapp.store.views.requests.head")
     @patch("webapp.store.views.device_gateway_sbom.get_endpoint_url")

--- a/tests/store/test_package_has_sboms.py
+++ b/tests/store/test_package_has_sboms.py
@@ -39,7 +39,9 @@ class TestPackageHasSboms(unittest.TestCase):
             f"download/sbom_charm_{package_id}_{revisions[0]}.spdx2.3.json"
         )
         mock_get_endpoint_url.assert_called_once_with(expected_sbom_path)
-        mock_head.assert_called_once_with("https://example.com/sbom/path")
+        mock_head.assert_called_once_with(
+            "https://example.com/sbom/path", timeout=5
+        )
 
     @patch("webapp.store.views.requests.head")
     @patch("webapp.store.views.device_gateway_sbom.get_endpoint_url")
@@ -64,7 +66,9 @@ class TestPackageHasSboms(unittest.TestCase):
             f"download/sbom_charm_{package_id}_{revisions[0]}.spdx2.3.json"
         )
         mock_get_endpoint_url.assert_called_once_with(expected_sbom_path)
-        mock_head.assert_called_once_with("https://example.com/sbom/path")
+        mock_head.assert_called_once_with(
+            "https://example.com/sbom/path", timeout=5
+        )
 
     @patch("webapp.store.views.requests.head")
     @patch("webapp.store.views.device_gateway_sbom.get_endpoint_url")
@@ -89,7 +93,9 @@ class TestPackageHasSboms(unittest.TestCase):
             f"download/sbom_charm_{package_id}_{revisions[0]}.spdx2.3.json"
         )
         mock_get_endpoint_url.assert_called_once_with(expected_sbom_path)
-        mock_head.assert_called_once_with("https://example.com/sbom/path")
+        mock_head.assert_called_once_with(
+            "https://example.com/sbom/path", timeout=5
+        )
 
     @patch("webapp.store.views.requests.head")
     @patch("webapp.store.views.device_gateway_sbom.get_endpoint_url")
@@ -114,7 +120,9 @@ class TestPackageHasSboms(unittest.TestCase):
             f"download/sbom_charm_{package_id}_{revisions[0]}.spdx2.3.json"
         )
         mock_get_endpoint_url.assert_called_once_with(expected_sbom_path)
-        mock_head.assert_called_once_with("https://example.com/sbom/path")
+        mock_head.assert_called_once_with(
+            "https://example.com/sbom/path", timeout=5
+        )
 
     @patch("webapp.store.views.requests.head")
     @patch("webapp.store.views.device_gateway_sbom.get_endpoint_url")
@@ -140,7 +148,9 @@ class TestPackageHasSboms(unittest.TestCase):
             f"download/sbom_charm_{package_id}_first-revision.spdx2.3.json"
         )
         mock_get_endpoint_url.assert_called_once_with(expected_sbom_path)
-        mock_head.assert_called_once_with("https://example.com/sbom/path")
+        mock_head.assert_called_once_with(
+            "https://example.com/sbom/path", timeout=5
+        )
 
     @patch("webapp.store.views.requests.head")
     @patch("webapp.store.views.device_gateway_sbom.get_endpoint_url")

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -218,7 +218,8 @@ def param_redirect_exec(req, make_response, redirect):
     return None
 
 
-def get_csp_as_str(csp={}):
+def get_csp_as_str(csp=None):
+    csp = csp or {}
     csp_str = ""
     for key, values in csp.items():
         csp_value = " ".join(values)

--- a/webapp/packages/logic.py
+++ b/webapp/packages/logic.py
@@ -289,7 +289,10 @@ def get_packages(
 
     total_pages = -(len(packages) // -size)
     total_items = len(packages)
-    page = int(query_params.get("page", 1))
+    try:
+        page = int(query_params.get("page", 1))
+    except (TypeError, ValueError):
+        page = 1
 
     res = paginate(packages, page, size, total_pages)
 

--- a/webapp/packages/logic.py
+++ b/webapp/packages/logic.py
@@ -318,7 +318,7 @@ def get_store_categories() -> List[Dict[str, str]]:
         try:
             all_categories = publisher_gateway.get_categories()
         except StoreApiError:
-            all_categories = []
+            all_categories = {"categories": []}
 
         category_map = {cat["slug"]: cat["name"] for cat in CATEGORIES}
 

--- a/webapp/packages/logic.py
+++ b/webapp/packages/logic.py
@@ -2,7 +2,6 @@ import re
 
 import yaml
 
-from flask import make_response
 from typing import List, Dict, TypedDict, Any, Union
 
 from canonicalwebteam.exceptions import StoreApiError
@@ -121,9 +120,7 @@ def fetch_package(package_name: str, fields: List[str]) -> Package:
         fields=fields,
         api_version=2,
     )
-    response = make_response({"package": package})
-    response.cache_control.max_age = 3600
-    return response.json
+    return {"package": package}
 
 
 @trace_function

--- a/webapp/publisher/form_processors.py
+++ b/webapp/publisher/form_processors.py
@@ -66,7 +66,7 @@ def extract_platform_data():
         ]
 
     return {
-        "platform": request.form.get("platform").strip(),
+        "platform": request.form.get("platform", "").strip(),
         "platform_version": clean_list("platform_version[]"),
         "platform_prerequisites": clean_list("platform_prerequisites[]"),
         "juju_versions": clean_list("juju_versions[]"),

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -722,7 +722,15 @@ def post_create_track(charm_name):
     auto_phasing_percentage = request.form.get("auto-phasing-percentage")
 
     if auto_phasing_percentage is not None:
-        auto_phasing_percentage = float(auto_phasing_percentage)
+        try:
+            auto_phasing_percentage = float(auto_phasing_percentage)
+        except ValueError:
+            return (
+                jsonify(
+                    {"error": "auto-phasing-percentage must be a number."}
+                ),
+                400,
+            )
 
     response = publisher_gateway.create_track(
         session,

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -36,6 +36,7 @@ from datetime import datetime
 import uuid
 
 preview_cache = {}
+PREVIEW_TTL_SECONDS = 300
 
 
 def paginate_pages(current_page, total_pages):
@@ -942,7 +943,7 @@ def cleanup_old_previews():
     expired_keys = [
         key
         for key, (_, timestamp) in preview_cache.items()
-        if (now - timestamp).total_seconds() > 300
+        if (now - timestamp).total_seconds() > PREVIEW_TTL_SECONDS
     ]
     for key in expired_keys:
         del preview_cache[key]

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -364,13 +364,13 @@ def accept_post_invite():
     except StoreApiResponseErrorList as error_list:
         res["success"] = False
         error_messages = [
-            f"{error.get('message', 'An error occured')}"
+            f"{error.get('message', 'An error occurred')}"
             for error in error_list.errors
         ]
         res["message"] = " ".join(error_messages)
     except Exception:
         res["success"] = False
-        res["message"] = "An error occured"
+        res["message"] = "An error occurred"
 
     return make_response(res, 500)
 
@@ -393,19 +393,19 @@ def reject_post_invite():
             return make_response(res, 200)
         else:
             res["success"] = False
-            res["message"] = "An error occured"
+            res["message"] = "An error occurred"
             return make_response(res, 200)
 
     except StoreApiResponseErrorList as error_list:
         res["success"] = False
         error_messages = [
-            f"{error.get('message', 'An error occured')}"
+            f"{error.get('message', 'An error occurred')}"
             for error in error_list.errors
         ]
         res["message"] = " ".join(error_messages)
     except Exception:
         res["success"] = False
-        res["message"] = "An error occured"
+        res["message"] = "An error occurred"
 
     return make_response(res, 500)
 
@@ -429,7 +429,7 @@ def get_collaborators(entity_name):
         response = make_response(res, 200)
     except StoreApiResponseErrorList as error_list:
         error_messages = [
-            f"{error.get('message', 'An error occured')}"
+            f"{error.get('message', 'An error occurred')}"
             for error in error_list.errors
         ]
         res["message"] = " ".join(error_messages)
@@ -456,7 +456,7 @@ def get_pending_invites(entity_name):
         response = make_response(res, 200)
     except StoreApiResponseErrorList as error_list:
         error_messages = [
-            f"{error.get('message', 'An error occured')}"
+            f"{error.get('message', 'An error occurred')}"
             for error in error_list.errors
         ]
         res["message"] = " ".join(error_messages)
@@ -501,7 +501,7 @@ def invite_collaborators(entity_name):
                 "invite_link": invite_link,
             },
             subject=(
-                f"You have been invited to as a collaborator on "
+                f"You have been invited to be a collaborator on "
                 f"{entity_name} in Charmhub"
             ),
         )
@@ -785,7 +785,7 @@ def get_releases(entity_name: str):
 
     except StoreApiResponseErrorList as error_list:
         error_messages = [
-            f"{error.get('message', 'An error occured')}"
+            f"{error.get('message', 'An error occurred')}"
             for error in error_list.errors
         ]
         res["message"] = " ".join(error_messages)

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -516,10 +516,6 @@ def invite_collaborators(entity_name):
             for error in error_list.errors
         ]
         res["message"] = (" ").join(messages)
-    except Exception:
-        res["success"] = False
-        res["message"] = "An error occurred"
-        raise
 
     return make_response(res, 500)
 
@@ -663,10 +659,7 @@ def post_register_name():
                         )
                     )
 
-    if data["type"] == "charm":
-        return redirect("/charms")
-    elif data["type"] == "bundle":
-        return redirect("/bundles")
+    return redirect("/charms")
 
 
 @trace_function

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -403,12 +403,11 @@ def reject_post_invite():
             for error in error_list.errors
         ]
         res["message"] = " ".join(error_messages)
-        response = make_response(res, 500)
     except Exception:
         res["success"] = False
         res["message"] = "An error occured"
 
-    return response
+    return make_response(res, 500)
 
 
 @trace_function

--- a/webapp/search/logic.py
+++ b/webapp/search/logic.py
@@ -1,3 +1,5 @@
+import logging
+
 import requests
 
 from redis_cache.cache_utility import redis_cache
@@ -5,6 +7,8 @@ from webapp.config import SEARCH_FIELDS
 from webapp.packages.logic import parse_package_for_card
 from webapp.observability.utils import trace_function
 from webapp.store_api import publisher_gateway
+
+logger = logging.getLogger(__name__)
 
 DISCOURSE_URL = "https://discourse.charmhub.io"
 DOCS_URL = "https://canonical-juju.readthedocs-hosted.com/"
@@ -57,12 +61,16 @@ def search_topics(
         if cached_page:
             return cached_page
         else:
-            resp = requests.get(
-                f"{DISCOURSE_URL}/search.json",
-                params={"q": query, "page": page},
-                timeout=10,
-            )
-            data = resp.json()
+            try:
+                resp = requests.get(
+                    f"{DISCOURSE_URL}/search.json",
+                    params={"q": query, "page": page},
+                    timeout=10,
+                )
+                data = resp.json()
+            except (requests.RequestException, ValueError):
+                logger.exception("Discourse topic search failed")
+                return []
             topics = data.get("topics", [])
             attach_posts(data, topics)
             topics = [
@@ -93,12 +101,17 @@ def search_topics(
             page += 1
             continue
 
-        resp = requests.get(
-            f"{DISCOURSE_URL}/search.json",
-            params={"q": query, "page": page},
-            timeout=10,
-        )
-        data = resp.json()
+        try:
+            resp = requests.get(
+                f"{DISCOURSE_URL}/search.json",
+                params={"q": query, "page": page},
+                timeout=10,
+            )
+            data = resp.json()
+        except (requests.RequestException, ValueError):
+            # Stop paging and return what we have so far.
+            logger.exception("Discourse topic search failed")
+            break
         topics = data.get("topics", [])
 
         if topics:
@@ -112,17 +125,24 @@ def search_topics(
             if cached_next_topics:
                 next_topics = cached_next_topics
             else:
-                next_resp = requests.get(
-                    f"{DISCOURSE_URL}/search.json",
-                    params={"q": query, "page": page},
-                    timeout=10,
-                )
-                next_topics = [
-                    topic
-                    for topic in next_resp.json().get("topics", [])
-                    if topic["category_id"] != EXCLUDED_DISCOURSE_CATEGORY_ID
-                ]
-                redis_cache.set(key, next_topics, ttl=3600)
+                try:
+                    next_resp = requests.get(
+                        f"{DISCOURSE_URL}/search.json",
+                        params={"q": query, "page": page},
+                        timeout=10,
+                    )
+                    next_topics = [
+                        topic
+                        for topic in next_resp.json().get("topics", [])
+                        if topic["category_id"]
+                        != EXCLUDED_DISCOURSE_CATEGORY_ID
+                    ]
+                    redis_cache.set(key, next_topics, ttl=3600)
+                except (requests.RequestException, ValueError):
+                    # Treat a failed look-ahead as "no next page";
+                    # don't cache the failure.
+                    logger.exception("Discourse topic search failed")
+                    next_topics = []
             if not next_topics or next_topics[0]["id"] == topics[0]["id"]:
                 more_pages = False
         else:
@@ -151,12 +171,16 @@ def search_docs(term: str) -> dict:
     results = redis_cache.get(key, expected_type=list)
     if results:
         return results
-    resp = requests.get(
-        f"{DOCS_URL}/_/api/v3/search/",
-        params={"q": f"project:canonical-juju {term}"},
-        timeout=10,
-    )
-    data = resp.json()
+    try:
+        resp = requests.get(
+            f"{DOCS_URL}/_/api/v3/search/",
+            params={"q": f"project:canonical-juju {term}"},
+            timeout=10,
+        )
+        data = resp.json()
+    except (requests.RequestException, ValueError):
+        logger.exception("ReadTheDocs search failed")
+        return []
 
     results = data.get("results", [])
     redis_cache.set(key, results, ttl=3600)

--- a/webapp/search/logic.py
+++ b/webapp/search/logic.py
@@ -42,7 +42,8 @@ def search_topics(
             return cached_page
         else:
             resp = requests.get(
-                f"{DISCOURSE_URL}/search.json?q={query}&page={page}"
+                f"{DISCOURSE_URL}/search.json?q={query}&page={page}",
+                timeout=10,
             )
             topics = resp.json().get("topics", [])
             for topic in topics:
@@ -80,7 +81,8 @@ def search_topics(
             continue
 
         resp = requests.get(
-            f"{DISCOURSE_URL}/search.json?q={query}&page={page}"
+            f"{DISCOURSE_URL}/search.json?q={query}&page={page}",
+            timeout=10,
         )
         data = resp.json()
         topics = data.get("topics", [])
@@ -106,7 +108,8 @@ def search_topics(
                 next_topics = cached_next_topics
             else:
                 next_resp = requests.get(
-                    f"{DISCOURSE_URL}/search.json?q={query}&page={page}"
+                    f"{DISCOURSE_URL}/search.json?q={query}&page={page}",
+                    timeout=10,
                 )
                 next_topics = [
                     topic
@@ -146,7 +149,7 @@ def search_docs(term: str) -> dict:
         f"{DOCS_URL}/_/api/v3/search/?q=project%3Acanonical-juju+{term}"
     )
 
-    resp = requests.get(search_url)
+    resp = requests.get(search_url, timeout=10)
     data = resp.json()
 
     results = data.get("results", [])

--- a/webapp/search/logic.py
+++ b/webapp/search/logic.py
@@ -9,6 +9,22 @@ from webapp.store_api import publisher_gateway
 DISCOURSE_URL = "https://discourse.charmhub.io"
 DOCS_URL = "https://canonical-juju.readthedocs-hosted.com/"
 
+# Discourse category excluded from search results
+EXCLUDED_DISCOURSE_CATEGORY_ID = 22
+
+
+def attach_posts(data, topics):
+    """
+    Attach the first matching post from a Discourse search
+    response to each topic.
+    """
+    posts_by_topic_id = {}
+    for post in data.get("posts", []):
+        posts_by_topic_id.setdefault(post["topic_id"], post)
+
+    for topic in topics:
+        topic["post"] = posts_by_topic_id.get(topic["id"])
+
 
 @trace_function
 def search_topics(
@@ -46,18 +62,14 @@ def search_topics(
                 params={"q": query, "page": page},
                 timeout=10,
             )
-            topics = resp.json().get("topics", [])
-            for topic in topics:
-                post = next(
-                    (
-                        post
-                        for post in resp.json()["posts"]
-                        if post["topic_id"] == topic["id"]
-                    ),
-                    None,
-                )
-                topic["post"] = post
-            topics = [topic for topic in topics if topic["category_id"] != 22]
+            data = resp.json()
+            topics = data.get("topics", [])
+            attach_posts(data, topics)
+            topics = [
+                topic
+                for topic in topics
+                if topic["category_id"] != EXCLUDED_DISCOURSE_CATEGORY_ID
+            ]
             redis_cache.set(key, topics, ttl=3600)
             return topics
 
@@ -90,16 +102,7 @@ def search_topics(
         topics = data.get("topics", [])
 
         if topics:
-            for topic in topics:
-                post = next(
-                    (
-                        post
-                        for post in data["posts"]
-                        if post["topic_id"] == topic["id"]
-                    ),
-                    None,
-                )
-                topic["post"] = post
+            attach_posts(data, topics)
             redis_cache.set(key, topics, ttl=3600)
             result.extend(topics)
             page += 1
@@ -117,7 +120,7 @@ def search_topics(
                 next_topics = [
                     topic
                     for topic in next_resp.json().get("topics", [])
-                    if topic["category_id"] != 22
+                    if topic["category_id"] != EXCLUDED_DISCOURSE_CATEGORY_ID
                 ]
                 redis_cache.set(key, next_topics, ttl=3600)
             if not next_topics or next_topics[0]["id"] == topics[0]["id"]:

--- a/webapp/search/logic.py
+++ b/webapp/search/logic.py
@@ -42,7 +42,8 @@ def search_topics(
             return cached_page
         else:
             resp = requests.get(
-                f"{DISCOURSE_URL}/search.json?q={query}&page={page}",
+                f"{DISCOURSE_URL}/search.json",
+                params={"q": query, "page": page},
                 timeout=10,
             )
             topics = resp.json().get("topics", [])
@@ -81,7 +82,8 @@ def search_topics(
             continue
 
         resp = requests.get(
-            f"{DISCOURSE_URL}/search.json?q={query}&page={page}",
+            f"{DISCOURSE_URL}/search.json",
+            params={"q": query, "page": page},
             timeout=10,
         )
         data = resp.json()
@@ -108,7 +110,8 @@ def search_topics(
                 next_topics = cached_next_topics
             else:
                 next_resp = requests.get(
-                    f"{DISCOURSE_URL}/search.json?q={query}&page={page}",
+                    f"{DISCOURSE_URL}/search.json",
+                    params={"q": query, "page": page},
                     timeout=10,
                 )
                 next_topics = [
@@ -145,11 +148,11 @@ def search_docs(term: str) -> dict:
     results = redis_cache.get(key, expected_type=list)
     if results:
         return results
-    search_url = (
-        f"{DOCS_URL}/_/api/v3/search/?q=project%3Acanonical-juju+{term}"
+    resp = requests.get(
+        f"{DOCS_URL}/_/api/v3/search/",
+        params={"q": f"project:canonical-juju {term}"},
+        timeout=10,
     )
-
-    resp = requests.get(search_url, timeout=10)
     data = resp.json()
 
     results = data.get("results", [])

--- a/webapp/search/views.py
+++ b/webapp/search/views.py
@@ -35,7 +35,7 @@ def all_search():
 def all_search_json():
     params = request.args
     term = params.get("q")
-    limit = int(params.get("limit", 5))
+    limit = params.get("limit", default=5, type=int)
 
     if not term:
         return {"error": "No search term provided"}
@@ -58,8 +58,8 @@ def all_search_json():
 @search.route("/all-bundles")
 def all_charms() -> dict:
     query = request.args.get("q", "")
-    page = int(request.args.get("page", 1))
-    limit = int(request.args.get("limit", 50))
+    page = request.args.get("page", default=1, type=int)
+    limit = request.args.get("limit", default=50, type=int)
     key = (f"{request.path}", {"q": query, "pg": page})
     cached_page = redis_cache.get(key, expected_type=dict)
     if cached_page:
@@ -82,7 +82,7 @@ def all_charms() -> dict:
 @search.route("/all-docs")
 def all_docs():
     search_term = request.args.get("q")
-    limit = int(request.args.get("limit", 50))
+    limit = request.args.get("limit", default=50, type=int)
 
     docs = search_docs(search_term)[:limit]
 
@@ -93,8 +93,8 @@ def all_docs():
 @search.route("/all-topics")
 def all_topics():
     search_term = request.args.get("q")
-    page = int(request.args.get("page", 1))
-    limit = int(request.args.get("limit", 50))
+    page = request.args.get("page", default=1, type=int)
+    limit = request.args.get("limit", default=50, type=int)
 
     key = ("all-topics", {"q": search_term, "pg": page})
     topics = redis_cache.get(key, expected_type=dict)

--- a/webapp/solutions/auth.py
+++ b/webapp/solutions/auth.py
@@ -21,6 +21,7 @@ def login(username: str) -> str:
     r = requests.post(
         f"{BASE_URL}/login",
         json={"username": username, "timestamp": timestamp, "signature": sig},
+        timeout=10,
     )
 
     r.raise_for_status()

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -237,9 +237,14 @@ def get_sbom(package_id, revision):
     sbom_path = f"download/sbom_charm_{package_id}_{revision}.spdx2.3.json"
     endpoint = device_gateway_sbom.get_endpoint_url(sbom_path)
 
-    res = requests.get(endpoint, timeout=30)
-
-    return jsonify(res.json())
+    try:
+        res = requests.get(endpoint, timeout=30)
+        return jsonify(res.json())
+    except (requests.RequestException, ValueError):
+        logger.exception(
+            "Failed to fetch SBOM for %s revision %s", package_id, revision
+        )
+        return jsonify({"error": "Unable to fetch SBOM"}), 502
 
 
 @trace_function

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -209,7 +209,7 @@ def package_has_sboms(revisions, package_id):
     sbom_path = f"download/sbom_charm_{package_id}_{revisions[0]}.spdx2.3.json"
     endpoint = device_gateway_sbom.get_endpoint_url(sbom_path)
 
-    res = requests.head(endpoint)
+    res = requests.head(endpoint, timeout=5)
 
     # backend returns 302 instead of 200 for a successful request
     # adding the check for 200 in case this is changed without us knowing
@@ -225,7 +225,7 @@ def get_sbom(package_id, revision):
     sbom_path = f"download/sbom_charm_{package_id}_{revision}.spdx2.3.json"
     endpoint = device_gateway_sbom.get_endpoint_url(sbom_path)
 
-    res = requests.get(endpoint)
+    res = requests.get(endpoint, timeout=30)
 
     return jsonify(res.json())
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -1,3 +1,5 @@
+import logging
+
 import humanize
 from canonicalwebteam.discourse import DocParser
 from canonicalwebteam.discourse.exceptions import PathNotFoundError
@@ -23,6 +25,8 @@ from webapp.config import SEARCH_FIELDS
 from webapp.observability.utils import trace_function
 from webapp.store_api import device_gateway, device_gateway_sbom
 
+
+logger = logging.getLogger(__name__)
 
 store = Blueprint(
     "store", __name__, template_folder="/templates", static_folder="/static"
@@ -347,12 +351,21 @@ def details_overview(entity_name):
             context["last_update"] = docs_content["updated"]
             context["topic_path"] = docs_content["topic_path"]
         except Exception as e:
-            if e.response.status_code == 404:
-                navigation = None
-                description = sanitize_html(
-                    logic.get_description(package, parse_to_html=True)
+            # Fall back to the package description whenever the docs
+            # topic cannot be fetched or parsed. A missing topic (404)
+            # is expected; anything else is worth logging.
+            status_code = getattr(
+                getattr(e, "response", None), "status_code", None
+            )
+            if status_code != 404:
+                logger.exception(
+                    "Failed to load docs topic for %s", entity_name
                 )
-                summary = logic.get_summary(package)
+            navigation = None
+            description = sanitize_html(
+                logic.get_description(package, parse_to_html=True)
+            )
+            summary = logic.get_summary(package)
     else:
         navigation = None
         description = sanitize_html(logic.get_description(package, parse_to_html=True))

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -47,7 +47,9 @@ def get_libraries(entity_name):
 
 
 @trace_function
-def get_package_details(entity_name, channel_request=None, fields=[]):
+def get_package_details(entity_name, channel_request=None, fields=None):
+    if fields is None:
+        fields = []
     key = (
         f"package_details:{entity_name}",
         {"channel": channel_request, "fields": ",".join(sorted(fields))},
@@ -170,7 +172,9 @@ FIELDS = [
 
 
 @trace_function
-def get_package(entity_name, channel_request=None, fields=FIELDS, path=None):
+def get_package(entity_name, channel_request=None, fields=None, path=None):
+    if fields is None:
+        fields = FIELDS
     # Get entity info from API
     key = (
         f"package:{entity_name}{':' + path if path else ''}",

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -213,7 +213,15 @@ def package_has_sboms(revisions, package_id):
     sbom_path = f"download/sbom_charm_{package_id}_{revisions[0]}.spdx2.3.json"
     endpoint = device_gateway_sbom.get_endpoint_url(sbom_path)
 
-    res = requests.head(endpoint, timeout=5)
+    try:
+        res = requests.head(endpoint, timeout=5)
+    except requests.RequestException:
+        # SBOM availability is an optional enhancement; don't let a
+        # slow or unreachable SBOM backend break the details page.
+        logger.exception(
+            "Failed to check SBOM availability for %s", package_id
+        )
+        return False
 
     # backend returns 302 instead of 200 for a successful request
     # adding the check for 200 in case this is changed without us knowing

--- a/webapp/store_api.py
+++ b/webapp/store_api.py
@@ -20,11 +20,11 @@ def decorate_all_methods(decorator, cls):
     return WrappedClass
 
 
-TracedPubilsherGW = decorate_all_methods(trace_function, PublisherGW)
+TracedPublisherGW = decorate_all_methods(trace_function, PublisherGW)
 TracedDeviceGW = decorate_all_methods(trace_function, DeviceGW)
 
 
 request_session = requests.Session()
-publisher_gateway = TracedPubilsherGW("charm", request_session)
+publisher_gateway = TracedPublisherGW("charm", request_session)
 device_gateway = TracedDeviceGW("charm", request_session)
 device_gateway_sbom = TracedDeviceGW("sbom", request_session)

--- a/webapp/utils/emailer.py
+++ b/webapp/utils/emailer.py
@@ -106,17 +106,28 @@ class Emailer:
             logger.error(f"Unexpected error sending email: {e}")
             raise EmailerError(f"Failed to send email: {e}")
 
+    def _send_in_background(self, *args):
+        try:
+            self._send(*args)
+        except EmailerError:
+            # _send has already logged the failure; nothing can
+            # observe an exception raised in a detached thread.
+            pass
+
     def send_email(
         self, subject: str, body: str, to_email: Union[str, List[str]]
     ):
-        Thread(target=self._send, args=(subject, body, to_email)).start()
+        Thread(
+            target=self._send_in_background, args=(subject, body, to_email)
+        ).start()
 
     def send_email_template(
         self, to_email: str, subject: str, template_path: str, context: dict
     ):
         body = render_template(template_path, **context)
         Thread(
-            target=self._send, args=(subject, body, to_email, "html")
+            target=self._send_in_background,
+            args=(subject, body, to_email, "html"),
         ).start()
 
 

--- a/webapp/utils/emailer.py
+++ b/webapp/utils/emailer.py
@@ -120,15 +120,6 @@ class Emailer:
         ).start()
 
 
-smtp_config = SMTPConfig(
-    host=os.getenv("SMTP_HOST", None),
-    port=int(os.getenv("SMTP_PORT", 587)),
-    username=os.getenv("SMTP_USER", None),
-    password=os.getenv("SMTP_PASSWORD", None),
-    domain=os.getenv("SMTP_DOMAIN", "canonical.com"),
-)
-
-
 def get_emailer() -> Emailer:
     smtp_config = SMTPConfig(
         host=os.getenv("SMTP_HOST", None),


### PR DESCRIPTION
Low-risk fixes from an architectural/error-handling audit of the webapp. Each commit is self-contained and reviewable on its own.

## Bug fixes

- **`reject_post_invite`**: the generic exception handler never assigned `response`, so `return response` raised `UnboundLocalError` and masked the original failure.
- **`get_store_categories`**: the `StoreApiError` fallback assigned a list that the next line indexed as a dict, guaranteeing a `TypeError` during a store outage instead of degrading gracefully.
- **`details_overview`**: the docs exception handler assumed `e.response` exists and only handled 404s; any other failure (connection error, parse error) crashed the charm details page with `AttributeError`/`UnboundLocalError`. Now falls back to the package description and logs unexpected failures.
- **`process_solution_form_data`**: a missing `platform` form field raised `AttributeError` (`None.strip()`).
- Numeric request params (`?limit=abc`, `?page=abc`, malformed `auto-phasing-percentage`) returned 500s via unhandled `ValueError`; now they fall back to defaults or return a 400.

## Robustness

- Added timeouts to the 7 outbound HTTP calls that had none (Discourse, ReadTheDocs, SBOM backend, solutions login) — `requests` waits forever by default, so a hung upstream pinned a worker indefinitely.
- Search queries to Discourse/ReadTheDocs are now URL-encoded via `params=` (terms with `&`, `#`, `+`, spaces previously corrupted the upstream query, and the corrupted result was cached).
- Email send failures in fire-and-forget threads are logged instead of raised unobservably.

## Cleanups

- `search_topics` parsed the same Discourse response body once per topic (`resp.json()` inside a loop) and joined posts with an O(n·m) scan; now parses once and joins via dict.
- `fetch_package` built a Flask response (with a discarded cache-control header) just to round-trip a dict.
- Removed dead code: unused module-level `smtp_config`, unreachable bundle redirect in `post_register_name`, dead assignments before a re-raise in `invite_collaborators`.
- Mutable default arguments (`fields=[]`, `fields=FIELDS`, `csp={}`) replaced with `None` defaults.
- Named magic numbers (Discourse category 22, preview TTL 300s).
- Typos: "occured" → "occurred" (incl. the test asserting it), invite email subject "invited to as a collaborator" → "invited to be a collaborator", `TracedPubilsherGW` → `TracedPublisherGW`.

## Testing

- `ruff check webapp tests` passes.
- Local test run matches the `main` baseline exactly (remaining failures are pre-existing: Unix-only `fcntl` imports on a Windows dev box, plus the time-flaky `test_param_redirect` cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)