### PR TITLE
improve error messaging from store-api

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ beautifulsoup4==4.14.3
 bleach==6.2.0
 canonicalwebteam.discourse==7.2.0
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.store-api==8.0.0
+canonicalwebteam.store-api==8.2.0
 canonicalwebteam.docstring-extractor==1.2.0
 canonicalwebteam.flask-vite==0.4.0
 

--- a/templates/publisher/accept-invite.html
+++ b/templates/publisher/accept-invite.html
@@ -24,7 +24,7 @@
     <div class="p-notification--negative u-hide" id="accept-invite-error-notification" aria-live="polite">
       <div class="p-notification__content">
         <h5 class="p-notification__title">Error</h5>
-        <p class="p-notification__message">There has been an error accepting this invite. Please try again or contact your administrator.</p>
+        <p class="p-notification__message">We could not accept this invite. Check that you are signed in with the Ubuntu One account that received the invite, and that the invite link has not expired or already been used.</p>
         <button class="p-notification__close" aria-controls="accept-invite-error-notification">Close this notification</button>
       </div>
     </div>
@@ -99,7 +99,7 @@
       closeAllNotifcations();
 
       if (status !== 200) {
-        const errorMessage = body.message || "There was an unknown error accepting the invite.";
+        const errorMessage = body.message || "We could not accept this invite. Check that you are signed in with the Ubuntu One account that received the invite, and that the invite link has not expired or already been used.";
         const errorParagraph = document.querySelector("#accept-invite-error-notification .p-notification__message");
         errorParagraph.textContent = errorMessage;
         acceptInviteErrorNotification.classList.remove("u-hide");

--- a/tests/publisher/test_publisher_views.py
+++ b/tests/publisher/test_publisher_views.py
@@ -249,7 +249,7 @@ class TestPublisherViews(unittest.TestCase):
             "/accept-invite",
             data={"token": "test-token", "package": "test-package"},
         )
-        self.assertEqual(res.status_code, 500)
+        self.assertEqual(res.status_code, 401)
         self.assertEqual(res.json["message"], "Invite token has expired")
 
     @patch("webapp.store_api.publisher_gateway.accept_invite")
@@ -261,7 +261,7 @@ class TestPublisherViews(unittest.TestCase):
             "/accept-invite",
             data={"token": "test-token", "package": "test-package"},
         )
-        self.assertEqual(res.status_code, 500)
+        self.assertEqual(res.status_code, 400)
         self.assertEqual(res.json["message"], "Invite token has expired")
 
     @patch("webapp.store_api.publisher_gateway.reject_invite")

--- a/tests/publisher/test_publisher_views.py
+++ b/tests/publisher/test_publisher_views.py
@@ -242,12 +242,27 @@ class TestPublisherViews(unittest.TestCase):
     @patch("webapp.store_api.publisher_gateway.accept_invite")
     def test_accept_post_invite_failed(self, mock_accept_invite):
         mock_accept_invite.return_value.status_code = 401
+        mock_accept_invite.return_value.json.return_value = {
+            "error-list": [{"message": "Invite token has expired"}]
+        }
         res = self.client.post(
             "/accept-invite",
             data={"token": "test-token", "package": "test-package"},
         )
         self.assertEqual(res.status_code, 500)
-        self.assertEqual(res.json["message"], "An error occured")
+        self.assertEqual(res.json["message"], "Invite token has expired")
+
+    @patch("webapp.store_api.publisher_gateway.accept_invite")
+    def test_accept_post_invite_error_list(self, mock_accept_invite):
+        mock_accept_invite.side_effect = StoreApiResponseErrorList(
+            "test-error", 400, [{"message": "Invite token has expired"}]
+        )
+        res = self.client.post(
+            "/accept-invite",
+            data={"token": "test-token", "package": "test-package"},
+        )
+        self.assertEqual(res.status_code, 500)
+        self.assertEqual(res.json["message"], "Invite token has expired")
 
     @patch("webapp.store_api.publisher_gateway.reject_invite")
     def test_reject_post_invite(self, mock_reject_invite):

--- a/tests/utils/test_email.py
+++ b/tests/utils/test_email.py
@@ -36,21 +36,26 @@ class TestEmailer(unittest.TestCase):
     @patch("smtplib.SMTP")
     def test_send_email_template_success(self, mock_smtp):
         with patch("webapp.utils.emailer.render_template") as mock_render:
-            mock_render.return_value = "<h1>Hello</h1>"
-            mock_server = MagicMock()
-            mock_smtp.return_value.__enter__.return_value = mock_server
+            with patch("webapp.utils.emailer.Thread") as mock_thread:
+                mock_render.return_value = "<h1>Hello</h1>"
+                mock_server = MagicMock()
+                mock_smtp.return_value.__enter__.return_value = mock_server
 
-            self.emailer.send_email_template(
-                to_email="recipient@test.com",
-                subject="Test Template",
-                template_path="template.html",
-                context={"name": "Test"},
-            )
+                self.emailer.send_email_template(
+                    to_email="recipient@test.com",
+                    subject="Test Template",
+                    template_path="template.html",
+                    context={"name": "Test"},
+                )
 
-            mock_render.assert_called_once_with(
-                "template.html", **{"name": "Test"}
-            )
-            mock_server.send_message.assert_called()
+                target = mock_thread.call_args.kwargs["target"]
+                args = mock_thread.call_args.kwargs["args"]
+                target(*args)
+
+                mock_render.assert_called_once_with(
+                    "template.html", **{"name": "Test"}
+                )
+                mock_server.send_message.assert_called()
 
     def test_validate_config_missing_fields(self):
         incomplete_config = SMTPConfig(

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -342,7 +342,7 @@ def accept_post_invite():
             res["message"] = (
                 errors[0].get("message") if errors else "Unknown error"
             )
-            return make_response(res, 500)
+            return make_response(res, response.status_code)
 
     except StoreApiResponseErrorList as error_list:
         res["success"] = False
@@ -351,9 +351,11 @@ def accept_post_invite():
             for error in error_list.errors
         ]
         res["message"] = " ".join(error_messages)
+        return make_response(res, error_list.status_code)
     except StoreApiResponseError as error:
         res["success"] = False
         res["message"] = str(error)
+        return make_response(res, error.status_code)
     except Exception:
         res["success"] = False
         res["message"] = "An error occured"

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -1,5 +1,9 @@
 from redis_cache.cache_utility import redis_cache
-from canonicalwebteam.exceptions import StoreApiError, StoreApiResponseErrorList
+from canonicalwebteam.exceptions import (
+    StoreApiError,
+    StoreApiResponseError,
+    StoreApiResponseErrorList,
+)
 from flask import (
     Blueprint,
     flash,
@@ -347,6 +351,9 @@ def accept_post_invite():
             for error in error_list.errors
         ]
         res["message"] = " ".join(error_messages)
+    except StoreApiResponseError as error:
+        res["success"] = False
+        res["message"] = str(error)
     except Exception:
         res["success"] = False
         res["message"] = "An error occured"


### PR DESCRIPTION
## Done
- Improves error messaging coming from the API when accepting an invite to a charm

## How to QA
- Follow steps in the [store-api PR](https://github.com/canonical/canonicalwebteam.store-api/pull/194) (there will be errors in this PR until the store-api module is merged and new minor version is published)

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card

Fixes [WD-36930](https://warthogs.atlassian.net/browse/WD-36930)


[WD-36930]: https://warthogs.atlassian.net/browse/WD-36930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ