### PR TITLE
add save solution draft functionality

### DIFF
--- a/static/js/src/solutions/modules/ConfirmationModal.js
+++ b/static/js/src/solutions/modules/ConfirmationModal.js
@@ -66,17 +66,22 @@ function initConfirmationModal(config) {
     }
 
     submitter = event.submitter;
+    const shouldValidate = !submitter?.formNoValidate;
     hideSubmitError();
 
     event.preventDefault();
     event.stopPropagation();
 
-    if (!form.checkValidity()) {
+    if (shouldValidate && !form.checkValidity()) {
       form.reportValidity();
       return;
     }
 
-    if (window.validateSolutionForm && !window.validateSolutionForm()) {
+    if (
+      shouldValidate &&
+      window.validateSolutionForm &&
+      !window.validateSolutionForm()
+    ) {
       return;
     }
 

--- a/templates/publisher/solutions.html
+++ b/templates/publisher/solutions.html
@@ -66,17 +66,20 @@
     {% else %}
       <div class="u-fixed-width">
         <h2 class="p-heading--4">Published Solutions</h2>
+        <p class="p-form-help-text u-no-max-width">
+          If you save a draft update for an already published solution, use <strong>Edit draft</strong> from this page to continue editing it. The published version remains live until you click <strong>Update solution</strong> from the draft.
+        </p>
       </div>
       <div class="u-fixed-width">
         <table class="p-table--mobile-card" role="grid">
           <thead>
             <tr role="row">
-              <th>Name</th>
-              <th style="width: 15%;">Status</th>
-              <th style="width: 15%;">Visibility</th>
-              <th>Publisher</th>
-              <th>Last Updated</th>
-              <th>Actions</th>
+              <th style="width: 16%;">Name</th>
+              <th style="width: 12%;">Status</th>
+              <th style="width: 8%;">Visibility</th>
+              <th style="width: 15%;">Publisher</th>
+              <th style="width: 12%;">Last Updated</th>
+              <th style="width: 18%;">Actions</th>
             </tr>
           </thead>
           <tbody> 
@@ -96,7 +99,14 @@
                 </div>
               </td>
               <td role="gridcell" aria-label="status">
+                {% if solution.is_draft_update %}
+                  Draft update
+                {% elif solution.draft_update %}
+                  Published<br>
+                  <small class="u-text--muted">Draft update saved</small>
+                {% else %}
                   {{ solution.status | format_solution_status }}
+                {% endif %}
               </td>
               <td role="gridcell" aria-label="visibility">
                 {{ solution.visibility | capitalize }}
@@ -114,9 +124,11 @@
                 {{ solution.last_updated | humanize_date if solution.last_updated else '-' }}
               </td>
               <td role="gridcell" aria-label="actions">
-                <a href="/solutions/preview/{{ solution.hash }}" class="p-button--base is-dense">Preview</a>
-                {% if solution.status in ['draft', 'published', 'pending_metadata_review'] %}
-                  <a href="/solutions/edit/{{ solution.hash }}" class="p-button--base is-dense">Edit</a>
+                <a href="/solutions/preview/{{ solution.draft_update.hash if solution.draft_update else solution.hash }}" class="p-button--base is-dense">{{ 'Preview draft' if solution.draft_update else 'Preview' }}</a>
+                {% if solution.draft_update %}
+                  <a href="/solutions/edit/{{ solution.draft_update.hash }}" class="p-button--base is-dense">Edit draft</a>
+                {% elif solution.status in ['draft', 'published', 'pending_metadata_review'] %}
+                  <a href="/solutions/edit/{{ solution.hash }}" class="p-button--base is-dense">{{ 'Edit draft' if solution.is_draft_update else 'Edit' }}</a>
                 {% endif %}
               </td>
             </tr>

--- a/templates/solutions/edit-solution.html
+++ b/templates/solutions/edit-solution.html
@@ -19,6 +19,14 @@
           </p>
         </div>
       </div>
+    {% elif solution.status == 'draft' and solution.revision > 1 %}
+      <div class="p-notification--caution">
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            You are editing a draft update. The published version remains live until you click <strong>Update solution</strong>. Updates go live immediately and do not require review.
+          </p>
+        </div>
+      </div>
     {% elif solution.status == 'pending_metadata_review' %}
       <div class="p-notification--information">
         <div class="p-notification__content">
@@ -36,7 +44,7 @@
     {% with messages = get_flashed_messages(with_categories=true) %}
       {% if messages %}
         {% for category, message in messages %}
-          <div class="p-notification p-notification--{{ 'negative' if category == 'negative' else 'positive' }}" role="alert">
+          <div class="p-notification p-notification--{{ category }}" role="alert">
             <p class="p-notification__response">{{ message }}</p>
           </div>
         {% endfor %}
@@ -69,6 +77,9 @@
         <button type="button" id="preview-button" class="p-button">
           Preview
         </button>
+        <button type="submit" name="action" value="save_draft" class="p-button" formnovalidate>
+          Save draft
+        </button>
         {% if solution.status == 'draft' and solution.revision == 1 %}
           <button type="submit" name="action" value="submit_for_review" class="p-button--positive">
             Submit metadata for review
@@ -77,13 +88,9 @@
           <button type="submit" name="action" value="submit_for_review" class="p-button--positive">
             Update and resubmit for review
           </button>
-        {% elif solution.status == 'published' %}
+        {% elif solution.status == 'published' or (solution.status == 'draft' and solution.revision > 1) %}
           <button type="submit" name="action" value="update" class="p-button--positive">
             Update solution
-          </button>
-        {% else %}
-          <button type="submit" name="action" value="save_draft" class="p-button--positive">
-            Save draft
           </button>
         {% endif %}
       </div>

--- a/tests/solutions/test_solutions_logic.py
+++ b/tests/solutions/test_solutions_logic.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock
 from webapp.solutions.logic import (
     get_solution_from_backend,
     get_publisher_solutions,
+    group_solution_drafts,
 )
 
 
@@ -36,13 +37,11 @@ class TestSolutionsLogic(unittest.TestCase):
     ):
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.json.return_value = [
-            {
-                "hash": "123",
-                "name": "Test Solution",
-                "creator": {"email": "creator@example.com"},
-            }
-        ]
+        mock_response.json.return_value = {
+            "hash": "123",
+            "name": "Test Solution",
+            "creator": {"email": "creator@example.com"},
+        }
         mock_auth_request.return_value = mock_response
 
         result = get_solution_from_backend("123", prefer_authenticated=True)
@@ -84,8 +83,8 @@ class TestSolutionsLogic(unittest.TestCase):
         self, mock_session, mock_auth_request
     ):
         mock_auth_response = MagicMock()
-        mock_auth_response.status_code = 200
-        mock_auth_response.json.return_value = [{"hash": "other"}]
+        mock_auth_response.status_code = 404
+        mock_auth_response.json.return_value = {"error": "Solution not found"}
         mock_auth_request.return_value = mock_auth_response
 
         mock_response = MagicMock()
@@ -145,4 +144,76 @@ class TestSolutionsLogic(unittest.TestCase):
         result = get_publisher_solutions("testuser")
 
         self.assertEqual(result, [])
+
+    def test_group_solution_drafts_attaches_draft_to_published(self):
+        published = {"name": "sol", "hash": "pub", "status": "published"}
+        draft = {
+            "name": "sol",
+            "hash": "draft",
+            "status": "draft",
+            "revision": 2,
+            "last_updated": "2026-01-01",
+        }
+
+        result = group_solution_drafts([published, draft])
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["hash"], "pub")
+        self.assertEqual(
+            result[0]["draft_update"],
+            {"hash": "draft", "revision": 2, "last_updated": "2026-01-01"},
+        )
+
+    def test_group_solution_drafts_standalone_draft_without_published(self):
+        draft = {
+            "name": "sol",
+            "hash": "draft",
+            "status": "draft",
+            "revision": 2,
+        }
+
+        result = group_solution_drafts([draft])
+
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0]["is_draft_update"])
+
+    def test_group_solution_drafts_rev1_draft_is_untouched(self):
+        draft = {
+            "name": "sol",
+            "hash": "draft",
+            "status": "draft",
+            "revision": 1,
+        }
+
+        result = group_solution_drafts([draft])
+
+        self.assertEqual(len(result), 1)
+        self.assertNotIn("is_draft_update", result[0])
+        self.assertNotIn("draft_update", result[0])
+
+    def test_group_solution_drafts_published_without_draft(self):
+        published = {"name": "sol", "hash": "pub", "status": "published"}
+
+        result = group_solution_drafts([published])
+
+        self.assertEqual(len(result), 1)
+        self.assertNotIn("draft_update", result[0])
+
+    def test_group_solution_drafts_preserves_unrelated_solutions(self):
+        published = {"name": "a", "hash": "a-pub", "status": "published"}
+        draft = {
+            "name": "a",
+            "hash": "a-draft",
+            "status": "draft",
+            "revision": 2,
+        }
+        other = {"name": "b", "hash": "b-pub", "status": "published"}
+        pending = {"name": "c", "hash": "c", "status": "pending_metadata_review"}
+
+        result = group_solution_drafts([published, draft, other, pending])
+
+        result_hashes = {solution["hash"] for solution in result}
+        self.assertEqual(result_hashes, {"a-pub", "b-pub", "c"})
+        attached = next(s for s in result if s["hash"] == "a-pub")
+        self.assertEqual(attached["draft_update"]["hash"], "a-draft")
 

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -25,6 +25,7 @@ from webapp.solutions.logic import (
     get_solution_from_backend,
     update_solution,
     solution_name_exists,
+    group_solution_drafts,
 )
 from webapp.publisher.form_processors import (
     process_solution_form_data,
@@ -298,7 +299,7 @@ def solutions_page():
     username = session["account"]["username"]
 
     # Get solutions data according to launchpad group
-    solutions = get_publisher_solutions(username)
+    solutions = group_solution_drafts(get_publisher_solutions(username))
 
     context = {
         "solutions": solutions,
@@ -903,6 +904,16 @@ def edit_solution_form(hash):
         return redirect("/solutions")
 
     username = session["account"]["username"]
+
+    if solution.get("status") == "published" and solution.get("draft_update"):
+        draft = solution["draft_update"]
+        flash(
+            "A draft update already exists for this solution. "
+            "We've opened that draft so you can continue where you left off.",
+            "information",
+        )
+        return redirect(f"/solutions/edit/{draft['hash']}")
+
     user_teams = get_user_teams_for_solutions(username)
 
     context = {
@@ -963,7 +974,11 @@ def submit_edit_solution(hash):
         return jsonify({"success": True, "preview_key": preview_key})
 
     result = update_solution(
-        username, solution["name"], solution["revision"], form_data
+        username,
+        solution["name"],
+        solution["revision"],
+        form_data,
+        submit=action != "save_draft",
     )
 
     if "error" in result:
@@ -986,7 +1001,12 @@ def submit_edit_solution(hash):
             solution,
         )
 
-    if action == "submit_for_review":
+    if action == "save_draft":
+        flash(
+            f"Your draft for '{form_data['title']}' has been saved.",
+            "positive",
+        )
+    elif action == "submit_for_review":
         flash(
             f"Your solution '{form_data['title']}' "
             "has been submitted for metadata review.",

--- a/webapp/solutions/logic.py
+++ b/webapp/solutions/logic.py
@@ -62,15 +62,12 @@ def get_solution_from_backend(uuid, prefer_authenticated=False):
             try:
                 auth_resp = make_authenticated_request(
                     "GET",
-                    f"{SOLUTIONS_API_BASE}/publisher/solutions",
+                    f"{SOLUTIONS_API_BASE}/publisher/solutions/by-hash/{uuid}",
                     username,
                     timeout=5,
                 )
                 if auth_resp.status_code == 200:
-                    solutions = auth_resp.json()
-                    for solution in solutions:
-                        if solution.get("hash") == uuid:
-                            return solution
+                    return auth_resp.json()
             except Exception as e:
                 logger.exception(
                     f"Failed to fetch authenticated solution data: {e}"
@@ -160,7 +157,10 @@ def register_solution(username, data):
     return {"error": f"API error ({resp.status_code}): {resp.text}"}
 
 
-def update_solution(username, name, revision, data):
+def update_solution(username, name, revision, data, submit=True):
+    if not submit:
+        data = {**data, "submit_for_review": False}
+
     try:
         resp = make_authenticated_request(
             "PATCH",
@@ -213,3 +213,36 @@ def get_user_teams_for_solutions(username):
         logger.exception(f"Failed to fetch user teams for solutions: {e}")
 
     return []
+
+
+def group_solution_drafts(solutions):
+    published_names = {
+        solution["name"]
+        for solution in solutions
+        if solution.get("status") == "published"
+    }
+    drafts_by_name = {
+        solution["name"]: solution
+        for solution in solutions
+        if solution.get("status") == "draft" and solution.get("revision", 1) > 1
+    }
+
+    for solution in solutions:
+        draft = drafts_by_name.get(solution["name"])
+        if solution.get("status") == "published" and draft:
+            solution["draft_update"] = {
+                "hash": draft["hash"],
+                "revision": draft["revision"],
+                "last_updated": draft.get("last_updated"),
+            }
+        elif solution.get("status") == "draft" and solution.get("revision", 1) > 1:
+            solution["is_draft_update"] = True
+
+    return [
+        solution
+        for solution in solutions
+        if not (
+            solution.get("is_draft_update")
+            and solution.get("name") in published_names
+        )
+    ]


### PR DESCRIPTION
## Done
- Adds "Save draft" functionality to solutions so that publishers can save progress and come back later
  - Skips form validation so that publishers can leave fields empty and still save a draft and navigate away from the page
- Matching backend logic in https://github.com/canonical/charmhub-solutions-service/pull/53

## How to QA
- Check out this branch and run it locally with [this branch](https://github.com/canonical/charmhub-solutions-service/pull/53) on solutions service
- Edit an existing solution:
  - Leave some fields blank
  - Make some changes
  - Click "Save draft"
  - Back on the [solutions](https://charmhub-io-2372.demos.haus/solutions) page you should see a new "Edit draft" button where you can continue where you left off
  - Make sure previews work with draft changes included 
- Try to publish the draft - click "Update solution" and make sure you no longer see a "draft" on the [solutions](https://charmhub-io-2372.demos.haus/solutions) page
- Register a new solution name, then approve it on the dashboard (localhost:5000)
- Go back to [solutions](https://charmhub-io-2372.demos.haus/solutions) and edit the new solution
  - Make sure you can save a draft of a non-published solution
  - You should then also be able to edit the non-published solution
- Submit the new solution for review
  - You should also be able to edit a solution that is pending review and resubmit for review

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card

Fixes [WD-37133](https://warthogs.atlassian.net/browse/WD-37133)

## UX Approval

- [x] This PR does not require UX approval


[WD-37133]: https://warthogs.atlassian.net/browse/WD-37133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ