### PR TITLE
add categories to solutions

### DIFF
--- a/static/js/src/solutions/edit-solution.js
+++ b/static/js/src/solutions/edit-solution.js
@@ -2,6 +2,7 @@ import DynamicFormManager from "./modules/DynamicFormManager.js";
 import CharmSearchBox from "./modules/CharmSearchBox.js";
 import initConfirmationModal from "./modules/ConfirmationModal.js";
 import initLocalAutosave from "./modules/LocalAutosave.js";
+import CategorySelector from "./modules/CategorySelector.js";
 
 const CSRF_TOKEN_ENDPOINT = "/api/solutions/csrf-token";
 const CSRF_REFRESH_ACTIONS = [
@@ -84,6 +85,8 @@ document.addEventListener("DOMContentLoaded", function () {
     getMessage: getEditMessage,
     beforeSubmit: refreshCsrfTokenBeforeSubmit,
   });
+
+  const categorySelector = new CategorySelector();
 
   const previewButton = document.getElementById("preview-button");
 
@@ -188,6 +191,10 @@ document.addEventListener("DOMContentLoaded", function () {
       el.classList.remove("is-error");
       hideValidationMessage(el);
     });
+
+    if (!categorySelector.isValid()) {
+      return false;
+    }
 
     const requiredValidationFields = [
       {
@@ -326,4 +333,5 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
   initLocalAutosave(form);
+  categorySelector.enforce();
 });

--- a/static/js/src/solutions/modules/CategorySelector.js
+++ b/static/js/src/solutions/modules/CategorySelector.js
@@ -1,0 +1,102 @@
+const MIN_CATEGORIES = 1;
+const MAX_CATEGORIES = 2;
+
+class CategorySelector {
+  constructor({
+    containerId = "categories-list",
+    sectionId = "categories-section",
+    checkboxSelector = ".category-checkbox",
+    min = MIN_CATEGORIES,
+    max = MAX_CATEGORIES,
+  } = {}) {
+    this.container = document.getElementById(containerId);
+    this.section = document.getElementById(sectionId);
+    this.checkboxSelector = checkboxSelector;
+    this.min = min;
+    this.max = max;
+
+    if (!this.container) {
+      return;
+    }
+
+    this.checkboxes = Array.from(
+      this.container.querySelectorAll(checkboxSelector)
+    );
+
+    this.checkboxes.forEach((checkbox) => {
+      checkbox.addEventListener("change", () => this.handleChange());
+    });
+
+    this.enforce();
+  }
+
+  getCheckedCount() {
+    return this.checkboxes.filter((checkbox) => checkbox.checked).length;
+  }
+
+  handleChange() {
+    this.enforce();
+
+    if (this.getCheckedCount() > 0) {
+      this.clearError();
+    }
+  }
+
+  enforce() {
+    if (!this.checkboxes) {
+      return;
+    }
+
+    const limitReached = this.getCheckedCount() >= this.max;
+
+    this.checkboxes.forEach((checkbox) => {
+      checkbox.disabled = limitReached && !checkbox.checked;
+    });
+  }
+
+  clearError() {
+    if (!this.section) {
+      return;
+    }
+
+    this.section.classList.remove("is-error");
+
+    const message = this.section.querySelector(".p-form-validation__message");
+    if (message) {
+      message.setAttribute("hidden", "");
+    }
+  }
+
+  showError() {
+    if (!this.section) {
+      return;
+    }
+
+    this.section.classList.add("is-error");
+
+    const message = this.section.querySelector(".p-form-validation__message");
+    if (message) {
+      message.removeAttribute("hidden");
+    }
+
+    this.section.scrollIntoView({ behavior: "smooth" });
+  }
+
+  isValid() {
+    if (!this.container || this.checkboxes.length === 0) {
+      return true;
+    }
+
+    const count = this.getCheckedCount();
+
+    if (count < this.min || count > this.max) {
+      this.showError();
+      return false;
+    }
+
+    this.clearError();
+    return true;
+  }
+}
+
+export default CategorySelector;

--- a/static/js/src/solutions/modules/LocalAutosave.js
+++ b/static/js/src/solutions/modules/LocalAutosave.js
@@ -5,6 +5,7 @@ const EXTRA_ARRAY_FIELD_NAMES = [
   "useful_links_url[]",
   "use_cases_description[]",
   "charms[]",
+  "categories",
 ];
 
 function getMultivalueFieldConfigs() {

--- a/templates/solutions/_header.html
+++ b/templates/solutions/_header.html
@@ -31,17 +31,26 @@
     <div class="grid-col-4">
       <div>
         <a href="/solutions" class="u-text--muted p-text--small-caps">&lt; ALL SOLUTIONS</a>
-        <h3 class="u-no-margin--bottom">{{ solution.title }}</h3>
-        <p class="p-heading--6">
-          By
-            {% if solution.publisher.username %}
-              <a href="/publisher/{{ solution.publisher.username | safe }}">
-                {{ solution.publisher.display_name }}
-              </a>
-            {% else %}
-              {{ solution.publisher.name }}
-            {% endif %}
-        </p>
+        <h3 class="u-no-margin--bottom u-sv1">{{ solution.title }}</h3>
+        <ul class="p-inline-list u-no-margin--bottom">
+          <li class="p-inline-list__item">
+            <span class="p-heading--6">
+              By
+                {% if solution.publisher.username %}
+                  <a href="/publisher/{{ solution.publisher.username | safe }}">
+                    {{ solution.publisher.display_name }}
+                  </a>
+                {% else %}
+                  {{ solution.publisher.name }}
+                {% endif %}
+            </span>
+          </li>
+          {% for category in solution.categories %}
+            <li class="p-inline-list__item">
+              <span class="p-chip is-inline u-vertical-align--middle">{{ category.name }}</span>
+            </li>
+          {% endfor %}
+        </ul>
       </div>
     </div>
     <div class="grid-col-2">

--- a/templates/solutions/_header.html
+++ b/templates/solutions/_header.html
@@ -32,23 +32,19 @@
       <div>
         <a href="/solutions" class="u-text--muted p-text--small-caps">&lt; ALL SOLUTIONS</a>
         <h3 class="u-no-margin--bottom u-sv1">{{ solution.title }}</h3>
-        <ul class="p-inline-list u-no-margin--bottom">
+        <ul class="p-inline-list--middot u-no-margin--bottom">
           <li class="p-inline-list__item">
-            <span class="p-heading--6">
-              By
-                {% if solution.publisher.username %}
-                  <a href="/publisher/{{ solution.publisher.username | safe }}">
-                    {{ solution.publisher.display_name }}
-                  </a>
-                {% else %}
-                  {{ solution.publisher.name }}
-                {% endif %}
-            </span>
+            By
+              {% if solution.publisher.username %}
+                <a href="/publisher/{{ solution.publisher.username | safe }}">
+                  {{ solution.publisher.display_name }}
+                </a>
+              {% else %}
+                {{ solution.publisher.name }}
+              {% endif %}
           </li>
           {% for category in solution.categories %}
-            <li class="p-inline-list__item">
-              <span class="p-chip is-inline u-vertical-align--middle">{{ category.name }}</span>
-            </li>
+            <li class="p-inline-list__item">{{ category.name }}</li>
           {% endfor %}
         </ul>
       </div>

--- a/templates/solutions/partials/_basic_info_section.html
+++ b/templates/solutions/partials/_basic_info_section.html
@@ -36,6 +36,34 @@
   </div>
 </div>
 
+{% set selected_categories = form_value(form_data, solution, 'categories') or [] %}
+<div class="p-form__group row">
+  <div class="col-2">
+    <label class="is-required">Categories:</label>
+  </div>
+  <div class="col-8 col-x-large-6">
+    <div class="p-form-validation" id="categories-section">
+      <div id="categories-list" role="group" aria-label="Categories">
+        {% for category in categories %}
+          <label class="p-checkbox">
+            <input
+              type="checkbox"
+              class="p-checkbox__input category-checkbox"
+              name="categories"
+              value="{{ category.slug }}"
+              aria-labelledby="category-{{ category.slug }}"
+              {% if category.slug in selected_categories %}checked{% endif %}
+            >
+            <span class="p-checkbox__label" id="category-{{ category.slug }}">{{ category.name }}</span>
+          </label>
+        {% endfor %}
+      </div>
+      <p class="p-form-validation__message" id="categories-error">Please select between one and two categories</p>
+      <p class="p-form-help-text">Choose a minimum of one and a maximum of two categories for your solution</p>
+    </div>
+  </div>
+</div>
+
 <div class="p-form__group row">
   <div class="col-2">
     <label for="description" class="is-required">Description:</label>

--- a/tests/solutions/test_solutions_logic.py
+++ b/tests/solutions/test_solutions_logic.py
@@ -4,6 +4,8 @@ from webapp.solutions.logic import (
     get_solution_from_backend,
     get_publisher_solutions,
     group_solution_drafts,
+    get_solution_categories,
+    map_category_slugs_to_display,
 )
 
 
@@ -216,4 +218,78 @@ class TestSolutionsLogic(unittest.TestCase):
         self.assertEqual(result_hashes, {"a-pub", "b-pub", "c"})
         attached = next(s for s in result if s["hash"] == "a-pub")
         self.assertEqual(attached["draft_update"]["hash"], "a-draft")
+
+
+class TestSolutionCategories(unittest.TestCase):
+    CONFIG = [{"slug": "cloud", "name": "Cloud"}]
+
+    @patch("webapp.solutions.logic.get_store_categories")
+    def test_get_solution_categories_maps_store_shape(self, mock_store):
+        mock_store.return_value = [
+            {"name": "ai-ml", "display_name": "AI/ML"},
+            {"name": "monitoring", "display_name": "Monitoring"},
+        ]
+
+        result = get_solution_categories()
+
+        self.assertEqual(
+            result,
+            [
+                {"slug": "ai-ml", "name": "AI/ML"},
+                {"slug": "monitoring", "name": "Monitoring"},
+            ],
+        )
+
+    @patch("webapp.solutions.logic.CATEGORIES", CONFIG)
+    @patch("webapp.solutions.logic.get_store_categories")
+    def test_get_solution_categories_falls_back_to_config(self, mock_store):
+        mock_store.return_value = []
+
+        result = get_solution_categories()
+
+        self.assertEqual(result, [{"slug": "cloud", "name": "Cloud"}])
+
+    @patch("webapp.solutions.logic.CATEGORIES", CONFIG)
+    @patch("webapp.solutions.logic.get_store_categories")
+    def test_get_solution_categories_falls_back_on_store_error(
+        self, mock_store
+    ):
+        mock_store.side_effect = Exception("store down")
+
+        result = get_solution_categories()
+
+        self.assertEqual(result, [{"slug": "cloud", "name": "Cloud"}])
+
+    @patch("webapp.solutions.logic.get_store_categories")
+    def test_map_category_slugs_to_display_known_slugs(self, mock_store):
+        mock_store.return_value = [
+            {"name": "ai-ml", "display_name": "AI/ML"},
+            {"name": "monitoring", "display_name": "Monitoring"},
+        ]
+
+        result = map_category_slugs_to_display(["monitoring", "ai-ml"])
+
+        self.assertEqual(
+            result,
+            [
+                {"slug": "monitoring", "name": "Monitoring"},
+                {"slug": "ai-ml", "name": "AI/ML"},
+            ],
+        )
+
+    @patch("webapp.solutions.logic.get_store_categories")
+    def test_map_category_slugs_to_display_unknown_slug_fallback(
+        self, mock_store
+    ):
+        mock_store.return_value = [{"name": "ai-ml", "display_name": "AI/ML"}]
+
+        result = map_category_slugs_to_display(["made-up-slug"])
+
+        self.assertEqual(
+            result, [{"slug": "made-up-slug", "name": "Made Up Slug"}]
+        )
+
+    def test_map_category_slugs_to_display_empty(self):
+        self.assertEqual(map_category_slugs_to_display([]), [])
+        self.assertEqual(map_category_slugs_to_display(None), [])
 

--- a/webapp/publisher/form_processors.py
+++ b/webapp/publisher/form_processors.py
@@ -57,6 +57,11 @@ def extract_maintainers_data():
     return [email.strip() for email in maintainers_emails if email.strip()]
 
 
+def extract_categories_data():
+    categories = request.form.getlist("categories")
+    return [slug.strip() for slug in categories if slug.strip()]
+
+
 def extract_platform_data():
     def clean_list(field_name):
         return [
@@ -80,6 +85,7 @@ def process_solution_form_data():
     form_data["useful_links"] = extract_useful_links_data()
     form_data["use_cases"] = extract_use_cases_data()
     form_data["maintainers"] = extract_maintainers_data()
+    form_data["categories"] = extract_categories_data()
 
     platform_data = extract_platform_data()
     form_data.update(platform_data)

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -30,6 +30,7 @@ from webapp.solutions.logic import (
     update_solution,
     solution_name_exists,
     group_solution_drafts,
+    get_solution_categories,
 )
 from webapp.publisher.form_processors import (
     process_solution_form_data,
@@ -84,6 +85,7 @@ def render_solution_form_with_errors(
     user_teams = get_user_teams_for_solutions(username)
 
     context = create_error_context(errors, solution, user_teams, form_data)
+    context["categories"] = get_solution_categories()
 
     return render_template(template_name, **context), status
 
@@ -929,6 +931,7 @@ def edit_solution_form(hash):
     context = {
         "user_teams": user_teams,
         "solution": solution,
+        "categories": get_solution_categories(),
     }
     return render_template("solutions/edit-solution.html", **context)
 

--- a/webapp/solutions/logic.py
+++ b/webapp/solutions/logic.py
@@ -3,6 +3,9 @@ import logging
 import requests
 from flask import session as flask_session
 from webapp.solutions.auth import login
+from webapp.packages.logic import get_store_categories
+from webapp.store.logic import format_slug
+from webapp.config import CATEGORIES
 
 
 logger = logging.getLogger(__name__)
@@ -12,6 +15,52 @@ session = requests.Session()
 SOLUTIONS_API_BASE = os.getenv(
     "FLASK_SOLUTIONS_API_BASE", "https://solutions.staging.charmhub.io/api"
 )
+
+
+def get_solution_categories():
+    """
+    Return the categories a solution can belong to as
+    ``[{"slug": ..., "name": ...}]``. Categories mirror charm categories
+    and are sourced from the store API so the two always match.
+    """
+    try:
+        store_categories = get_store_categories()
+    except Exception as e:
+        logger.warning(f"Failed to load solution categories: {e}")
+        store_categories = []
+
+    categories = [
+        {
+            "slug": cat.get("slug") or cat["name"],
+            "name": cat.get("display_name") or cat["name"],
+        }
+        for cat in store_categories
+        if cat.get("slug") or cat.get("name")
+    ]
+
+    # fallback to shared category config when store API is unavailable
+    if not categories:
+        categories = [
+            {"slug": cat["slug"], "name": cat["name"]} for cat in CATEGORIES
+        ]
+
+    return categories
+
+
+def map_category_slugs_to_display(slugs):
+    """
+    Map stored category slugs to ``[{"slug": ..., "name": ...}]`` for
+    display. Unknown slugs fall back to a title-cased slug.
+    """
+    if not slugs:
+        return []
+
+    lookup = {cat["slug"]: cat["name"] for cat in get_solution_categories()}
+    return [
+        {"slug": slug, "name": lookup.get(slug) or format_slug(slug)}
+        for slug in slugs
+        if slug
+    ]
 
 
 def get_cached_token(username):

--- a/webapp/solutions/views.py
+++ b/webapp/solutions/views.py
@@ -5,6 +5,7 @@ from webapp.helpers import markdown_to_html
 from webapp.solutions.logic import get_solution_from_backend
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from webapp.solutions.logic import get_published_solution_by_name
+from webapp.solutions.logic import map_category_slugs_to_display
 from webapp.publisher.views import preview_cache
 
 
@@ -59,6 +60,10 @@ def get_charm_data(charm_name):
 def render_solution(solution):
     solution["description_html"] = markdown_to_html(
         solution.get("description", "")
+    )
+
+    solution["categories"] = map_category_slugs_to_display(
+        solution.get("categories")
     )
 
     architecture_explanation = ""
@@ -171,6 +176,8 @@ def solution_preview_draft(preview_key):
     preview_solution["compatibility"] = {
         "juju_versions": form_data.get("juju_versions", []),
     }
+
+    preview_solution["categories"] = form_data.get("categories", [])
 
     charms_list = form_data.get("charms", [])
     preview_solution["charms"] = [


### PR DESCRIPTION
## Done
- Adds categories to solutions - same categories as charms
- Displays categories in solution header
- Allows publisher to choose minimum 1 and maximum 2 categories when editing solution metadata
- Will later be used for filtering on the landing page when we add solutions here

## How to QA
- Run locally against [this branch](https://github.com/canonical/charmhub-solutions-service/pull/54) on the solutions service
- Go to edit an existing solution and see the checkbox input to choose category/ies
- Try to submit without picking any categories - should fail
- Select 2 categories, should disable to rest of the input
- Update the solution and then "Preview" - you should see the newly selected categories

## Testing

- [x] This PR has tests

## Issue / Card

Fixes [WD-37111](https://warthogs.atlassian.net/browse/WD-37111)

## UX Approval

- [x] This PR does require UX approval: quick check to make sure they look okay in solution header
<img width="1449" height="590" alt="image" src="https://github.com/user-attachments/assets/9f0668f5-4f34-4ac7-9a4d-799b4be5c156" />


[WD-37111]: https://warthogs.atlassian.net/browse/WD-37111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ