### PR TITLE
Wd 37114/solutions add char limits

### DIFF
--- a/static/js/src/solutions/edit-solution.js
+++ b/static/js/src/solutions/edit-solution.js
@@ -304,6 +304,7 @@ document.addEventListener("DOMContentLoaded", function () {
     removeSelector: "remove-platform-version",
     itemSelector: ".platform-version-item",
     templateId: "platform-version-template",
+    maxItems: 3,
     onChange: (count) => {
       if (count > 0) {
         clearValidationState("platform-version-section");
@@ -325,6 +326,7 @@ document.addEventListener("DOMContentLoaded", function () {
     removeSelector: "remove-juju-version",
     itemSelector: ".juju-version-item",
     templateId: "juju-version-template",
+    maxItems: 3,
     onChange: (count) => {
       if (count > 0) {
         clearValidationState("juju-versions-section");

--- a/templates/solutions/_header.html
+++ b/templates/solutions/_header.html
@@ -71,9 +71,7 @@
             <span>{{ deployment }}</span>
           {% endif %}
           {% if deployment.get("version") and deployment["version"] | length > 0 %}
-            {% for version in deployment["version"] %}
-              <div class="u-text--muted">Version <strong>{{ version }}</strong></div>
-            {% endfor %}
+            <div class="u-text--muted">Version <strong>{{ deployment["version"] | join(", ") }}</strong></div>
           {% endif %}
           {% if deployment.get("prerequisites") and deployment["prerequisites"] | length > 0 %}
             <div class="u-text--muted">

--- a/templates/solutions/_header.html
+++ b/templates/solutions/_header.html
@@ -30,7 +30,6 @@
 
     <div class="grid-col-4">
       <div>
-        <a href="/solutions" class="u-text--muted p-text--small-caps">&lt; ALL SOLUTIONS</a>
         <h3 class="u-no-margin--bottom u-sv1">{{ solution.title }}</h3>
         <ul class="p-inline-list--middot u-no-margin--bottom">
           <li class="p-inline-list__item">

--- a/templates/solutions/_header.html
+++ b/templates/solutions/_header.html
@@ -30,7 +30,7 @@
 
     <div class="grid-col-4">
       <div>
-        <h3 class="u-no-margin--bottom u-sv1">{{ solution.title }}</h3>
+        <h1 class="u-sv-1">{{ solution.title }}</h1>
         <ul class="p-inline-list--middot u-no-margin--bottom">
           <li class="p-inline-list__item">
             By
@@ -88,7 +88,6 @@
   <div class="grid-row">
     <div class="grid-col-2"></div>
     <div class="grid-col-6 p-section--shallow u-no-padding--bottom">
-      <hr class="p-separator--shallow p-rule--muted u-no-margin--top">
       {% if solution.documentation.get_started %}
         <a class="p-button--positive" href="{{ solution.documentation.get_started }}">View implementation guide</a>
       {% endif %}

--- a/templates/solutions/edit-solution.html
+++ b/templates/solutions/edit-solution.html
@@ -55,7 +55,9 @@
       <div class="p-notification--negative">
         <ul class="p-list p-notification__content u-no-padding--top" role="status">
           {% for e in errors %}
-            <li class="p-list__item p-notification__status">{{ e.message }}</li>
+            <li class="p-list__item p-notification__status">
+              {% if e.field %}<strong>{{ e.field }}:</strong> {% endif %}{{ e.message }}
+            </li>
           {% endfor %}
         </ul>
       </div>

--- a/templates/solutions/partials/_architecture_section.html
+++ b/templates/solutions/partials/_architecture_section.html
@@ -33,7 +33,8 @@
       name="architecture_explanation"
       rows="6"
       required
+      maxlength="2000"
     >{{ form_value(form_data, solution, 'architecture_explanation', 'documentation.architecture_explanation') | e }}</textarea>
-    <p class="p-form-help-text">Explanation of the solution architecture (Markdown supported)</p>
+    <p class="p-form-help-text">Explanation of the solution architecture (Markdown supported, maximum 2000 characters)</p>
   </div>
 </div>

--- a/templates/solutions/partials/_basic_info_section.html
+++ b/templates/solutions/partials/_basic_info_section.html
@@ -75,8 +75,9 @@
       class="is-dense"
       rows="8"
       required
+      maxlength="2000"
     >{{ form_value(form_data, solution, 'description') | e }}</textarea>
-    <p class="p-form-help-text">Detailed description of your solution (Markdown supported)</p>
+    <p class="p-form-help-text">Detailed description of your solution (Markdown supported, maximum 2000 characters)</p>
   </div>
 </div>
 

--- a/templates/solutions/partials/_basic_info_section.html
+++ b/templates/solutions/partials/_basic_info_section.html
@@ -12,10 +12,10 @@
       type="text"
       class="is-dense"
       required
-      maxlength="40"
+      maxlength="30"
       value="{{ form_value(form_data, solution, 'title') | e }}"
     >
-    <p class="p-form-help-text">A human-readable title for your solution (maximum 40 characters)</p>
+    <p class="p-form-help-text">A human-readable title for your solution (maximum 30 characters)</p>
   </div>
 </div>
 

--- a/templates/solutions/partials/_platform_compatibility_section.html
+++ b/templates/solutions/partials/_platform_compatibility_section.html
@@ -119,8 +119,8 @@
         {% endif %}
       </div>
       <button type="button" id="add-platform-version" class="p-button--base">Add Platform Version</button>
-      <p class="p-form-validation__message" id="platform-version-error">At least one platform version is required</p>
-      <p class="p-form-help-text">Add supported platform versions (e.g., Kubernetes versions)</p>
+      <p class="p-form-validation__message" id="platform-version-error">Please add between one and three platform versions</p>
+      <p class="p-form-help-text">Add one to three supported platform versions (e.g., Kubernetes versions)</p>
     </div>
   </div>
 </div>
@@ -183,8 +183,8 @@
         {% endif %}
       </div>
       <button type="button" id="add-juju-version" class="p-button--base">Add Juju Version</button>
-      <p class="p-form-validation__message" id="juju-version-error">At least one Juju version is required</p>
-      <p class="p-form-help-text">Add supported Juju versions (e.g., 3.1, 2.9)</p>
+      <p class="p-form-validation__message" id="juju-version-error">Please add between one and three Juju versions</p>
+      <p class="p-form-help-text">Add one to three supported Juju versions (e.g., 3.1, 2.9)</p>
     </div>
   </div>
 </div>

--- a/templates/solutions/partials/_use_cases_section.html
+++ b/templates/solutions/partials/_use_cases_section.html
@@ -23,6 +23,7 @@
           rows="2"
           placeholder="Description: Describe this use case..."
           required
+          maxlength="500"
         ></textarea>
       </div>
     </div>
@@ -65,6 +66,7 @@
                     rows="2"
                     placeholder="Description: Describe this use case..."
                     required
+                    maxlength="500"
                   >{{ use_case.description | e }}</textarea>
                 </div>
               </div>
@@ -74,7 +76,7 @@
       </div>
       <button type="button" id="add-use-case" class="p-button--base">Add Use Case</button>
       <p class="p-form-validation__message" id="use-case-error">At least one use case is required</p>
-      <p class="p-form-help-text">At least one use case is required (maximum 3). Titles can be up to 30 characters.</p>
+      <p class="p-form-help-text">At least one use case is required (maximum 3). Titles can be up to 30 characters and descriptions up to 500 characters.</p>
     </div>
   </div>
 </div>

--- a/templates/solutions/partials/_use_cases_section.html
+++ b/templates/solutions/partials/_use_cases_section.html
@@ -8,6 +8,7 @@
             name="use_cases_title[]"
             placeholder="Title: e.g., Log aggregation"
             required
+            maxlength="30"
           >
         </div>
       </div>
@@ -52,6 +53,7 @@
                       value="{{ use_case.title | e }}"
                       placeholder="Title: e.g., Log aggregation"
                       required
+                      maxlength="30"
                     >
                   </div>
                 </div>
@@ -72,7 +74,7 @@
       </div>
       <button type="button" id="add-use-case" class="p-button--base">Add Use Case</button>
       <p class="p-form-validation__message" id="use-case-error">At least one use case is required</p>
-      <p class="p-form-help-text">At least one use case is required (maximum 3)</p>
+      <p class="p-form-help-text">At least one use case is required (maximum 3). Titles can be up to 30 characters.</p>
     </div>
   </div>
 </div>

--- a/templates/solutions/partials/_useful_links_section.html
+++ b/templates/solutions/partials/_useful_links_section.html
@@ -10,6 +10,7 @@
           name="useful_links_title[]"
           placeholder="Title: e.g., How to operate"
           required
+          maxlength="30"
         >
       </div>
     </div>
@@ -49,6 +50,7 @@
                     value="{{ link.title | e }}"
                     placeholder="Title: e.g., How to operate"
                     required
+                    maxlength="30"
                   >
                 </div>
               </div>
@@ -68,7 +70,7 @@
         {% endif %}
       </div>
       <button type="button" id="add-useful-link" class="p-button--base">Add Useful Link</button>
-      <p class="p-form-help-text">Add links to documentation, guides, bug reports, discussions, etc. (maximum 3)</p>
+      <p class="p-form-help-text">Add links to documentation, guides, bug reports, discussions, etc. (maximum 3). Link text can be up to 30 characters.</p>
     </div>
   </div>
 </div>

--- a/templates/solutions/solutions_base_layout.html
+++ b/templates/solutions/solutions_base_layout.html
@@ -37,7 +37,7 @@
     <div class="grid-col-2">
     </div>
     <div class="grid-col-6">
-      <hr class="p-separator--shallow p-rule--muted u-no-margin--bottom u-no-margin--top">
+      <hr class="p-separator--shallow p-rule--muted u-no-margin--top">
     </div>
   </div>
   <div class="grid-row">

--- a/templates/solutions/solutions_details.html
+++ b/templates/solutions/solutions_details.html
@@ -1,7 +1,6 @@
 <div>
   {% if solution.description_html %}
     <div class="p-section--shallow u-no-padding--top">
-      <h4 style="font-weight: 500">{{ solution.title }}</h4>
       {{ solution.description_html | safe }}
     </div>
   {% endif %}


### PR DESCRIPTION
## Done
- Adds client-side limits to solutions edit form for:
  - title, description, architecture explanation, use case title + description, useful link text, platform versions and juju versions (see all limits specified [here](https://warthogs.atlassian.net/browse/WD-37114))
- Edits helper text to state the limits
- Removes "All Solutions" link at the top of a details page (discussed and agreed this with Miguel)
- Updates validation errors to show field name so that it is clearer for the user which field they need to check

## How to QA
- Run this branch locally against [this branch of solutions service](https://github.com/canonical/charmhub-solutions-service/pull/56)
- Check all limits as stated in the jira ticket (the browser should block you from being able to input more than the specified number of chars)
- Check that you are limited to adding maximum 3 platform versions and maximum 3 juju versions (make sure the "add" buttons are hidden once you have added 3)
  - Also if you remove one version, the "add" button should be available again
- Force a backend validation error - e.g. add an exclamation mark / invalid char to the title - and click "update solution"
  - You should see an error at the top referring to the problematic field that needs addressed

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card

Fixes [WD-37114](https://warthogs.atlassian.net/browse/WD-37114)

## UX Approval

- [x] This PR does require UX approval


[WD-37114]: https://warthogs.atlassian.net/browse/WD-37114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ