### PR TITLE
increase use cases title char limit

### DIFF
--- a/templates/solutions/partials/_use_cases_section.html
+++ b/templates/solutions/partials/_use_cases_section.html
@@ -8,7 +8,7 @@
             name="use_cases_title[]"
             placeholder="Title: e.g., Log aggregation"
             required
-            maxlength="30"
+            maxlength="60"
           >
         </div>
       </div>
@@ -54,7 +54,7 @@
                       value="{{ use_case.title | e }}"
                       placeholder="Title: e.g., Log aggregation"
                       required
-                      maxlength="30"
+                      maxlength="60"
                     >
                   </div>
                 </div>
@@ -76,7 +76,7 @@
       </div>
       <button type="button" id="add-use-case" class="p-button--base">Add Use Case</button>
       <p class="p-form-validation__message" id="use-case-error">At least one use case is required</p>
-      <p class="p-form-help-text">At least one use case is required (maximum 3). Titles can be up to 30 characters and descriptions up to 500 characters.</p>
+      <p class="p-form-help-text">At least one use case is required (maximum 3). Titles can be up to 60 characters and descriptions up to 500 characters.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done
- Increases use cases title char limit to 60 to allow 2 lines (following customer feedback)

## How to QA
- Check out this branch locally against [this solutions branch](https://github.com/canonical/charmhub-solutions-service/pull/57)
- Go to localhost:8045/solutions and edit one of your solutions
- Go to the use cases section and make sure you can add a title of up to 60 chars
- Update solution

## Testing

- [x] This PR has tests: updates existing

