### PR TITLE
fix: read the docs links parsing, and name registration

### DIFF
--- a/templates/publisher/register-name.html
+++ b/templates/publisher/register-name.html
@@ -55,6 +55,16 @@
     </div>
   {% endif %}
 
+  {% if api_error_message %}
+    <div class="u-fixed-width">
+      <div class="p-notification--negative">
+        <p class="p-notification__content" role="status">
+          <span class="p-notification__status">Unable to register '{{ entity_name }}'.</span> {{ api_error_message }}
+        </p>
+      </div>
+    </div>
+  {% endif %}
+
   <form class="p-form" method="POST">
     <div class="p-form__group row p-form-validation{% if entity_name %} is-error{% endif %}">
       <div class="col-2">
@@ -71,6 +81,7 @@
               {% if invalid_name %}The name should only have ASCII lowercase letters, numbers, and hyphens, and must have at least one letter.{% endif %}
               {% if already_registered %}This name is already taken.{% endif %}
               {% if already_owned %}You already own this name.{% endif %}
+              {% if api_error_message %}{{ api_error_message }}{% endif %}
             </p>
           {% endif %}
         </div>

--- a/tests/publisher/test_publisher_views.py
+++ b/tests/publisher/test_publisher_views.py
@@ -370,6 +370,45 @@ class TestPublisherViews(unittest.TestCase):
         self.assertEqual(res.status_code, 302)
         self.assertIn("already_owned=True", res.headers["Location"])
 
+    @patch("webapp.store_api.publisher_gateway.register_package_name")
+    def test_post_register_name_api_error_relays_message(
+        self, mock_register_package_name
+    ):
+        # Publisher Gateway sometimes wraps more specific failures (e.g.
+        # name already taken by another publisher) under a generic
+        # "api-error" code. Rather than guessing what happened, relay the
+        # API's own message verbatim instead of misreporting it as an
+        # invalid name format error.
+        mock_register_package_name.side_effect = StoreApiResponseErrorList(
+            "test-error",
+            500,
+            [
+                {
+                    "code": "api-error",
+                    "message": "Name 'openbau' is already taken.",
+                }
+            ],
+        )
+        res = self.client.post(
+            "/register-name",
+            data={
+                "name": "openbau",
+                "type": "charm",
+                "private": "private",
+            },
+        )
+        self.assertEqual(res.status_code, 302)
+        self.assertIn(
+            "api_error_message=Name+'openbau'+is+already+taken.",
+            res.headers["Location"],
+        )
+
+        # And the message is rendered on the page as-is.
+        follow_res = self.client.get(res.headers["Location"])
+        self.assertIn(
+            b"Name &#39;openbau&#39; is already taken.", follow_res.data
+        )
+
     def test_register_name_dispute(self):
         res = self.client.get("/register-name-dispute?entity-name=test-name")
         self.assertEqual(res.status_code, 200)

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -625,6 +625,12 @@ def post_register_name():
                 f"Your {data['type']} name has been successfully registered.",
                 "positive",
             )
+            # Invalidate the cached /charms or /bundles list so the
+            # newly registered name shows up immediately on redirect,
+            # instead of waiting for the 10 minute cache TTL to expire.
+            redis_cache.delete(
+                f"account_packages:{session['account']['id']}:{data['type']}"
+            )
     except StoreApiResponseErrorList as api_response_error_list:
         for error in api_response_error_list.errors:
             if error["code"] == "reserved-name":
@@ -710,6 +716,14 @@ def delete_package(package_name):
         session["account-auth"], package_name
     )
     if resp.status_code == 200:
+        # Invalidate the cached /charms and /bundles lists so the
+        # unregistered name disappears immediately on reload, instead
+        # of waiting for the 10 minute cache TTL to expire. We don't
+        # know here whether the package was a charm or bundle, so
+        # clear both.
+        account_id = session["account"]["id"]
+        redis_cache.delete(f"account_packages:{account_id}:charm")
+        redis_cache.delete(f"account_packages:{account_id}:bundle")
         return ("", 200)
     return (
         jsonify({"error": resp.json()["error-list"][0]["message"]}),

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -284,9 +284,11 @@ def list_page():
     context["published"] = [
         {
             **package,
-            "unlisted": package["unlisted"]
-            if "unlisted" in package
-            else get_package_unlisted(package["name"]),
+            "unlisted": (
+                package["unlisted"]
+                if "unlisted" in package
+                else get_package_unlisted(package["name"])
+            ),
         }
         for package in context["published"][start:end]
     ]
@@ -589,12 +591,17 @@ def register_name():
     )
     already_owned = already_owned_str == "True"
 
+    api_error_message = request.args.get(
+        "api_error_message", default="", type=str
+    )
+
     context = {
         "entity_name": entity_name,
         "reserved_name": reserved_name,
         "invalid_name": invalid_name,
         "already_owned": already_owned,
         "already_registered": already_registered,
+        "api_error_message": api_error_message,
     }
     return render_template("publisher/register-name.html", **context)
 
@@ -620,8 +627,6 @@ def post_register_name():
             )
     except StoreApiResponseErrorList as api_response_error_list:
         for error in api_response_error_list.errors:
-            error_message = error.get("message", "").lower()
-
             if error["code"] == "reserved-name":
                 return redirect(
                     url_for(
@@ -646,27 +651,21 @@ def post_register_name():
                         already_owned=True,
                     )
                 )
-            elif error["code"] == "api-error":
-                # Check if the error message indicates the name
-                # is already registered. This is because sometimes
-                # the API returns an api-error code for this case.
-                if "already registered" in error_message:
-                    return redirect(
-                        url_for(
-                            ".register_name",
-                            entity_name=data["name"],
-                            already_registered=True,
-                        )
+            else:
+                # For any other error code (e.g. the generic "api-error"
+                # the API sometimes uses to wrap more specific failures,
+                # such as the name already being taken by another
+                # publisher), relay the API's own message instead of
+                # guessing what went wrong.
+                return redirect(
+                    url_for(
+                        ".register_name",
+                        entity_name=data["name"],
+                        api_error_message=error.get(
+                            "message", "Something went wrong."
+                        ),
                     )
-                else:
-                    # Default to invalid name format error
-                    return redirect(
-                        url_for(
-                            ".register_name",
-                            entity_name=data["name"],
-                            invalid_name=True,
-                        )
-                    )
+                )
 
     if data["type"] == "charm":
         return redirect("/charms")

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 import humanize
 from canonicalwebteam.discourse import DocParser
 from canonicalwebteam.discourse.exceptions import PathNotFoundError
@@ -22,7 +24,6 @@ from webapp.store import logic
 from webapp.config import SEARCH_FIELDS
 from webapp.observability.utils import trace_function
 from webapp.store_api import device_gateway, device_gateway_sbom
-
 
 store = Blueprint(
     "store", __name__, template_folder="/templates", static_folder="/static"
@@ -270,11 +271,11 @@ def details_overview(entity_name):
 
     doc = logic.get_doc_link(package)
 
-    # If the doc link does NOT include "discourse",
-    # it is accepted as a ReadTheDocs link.
-    # Update this logic when a better way to distinguish
-    # ReadTheDocs links becomes available.
-    is_rtd = doc and "discourse" not in doc.lower()
+    # If the doc link does NOT point at the Discourse instance,
+    # it is accepted as a ReadTheDocs (or other externally-hosted) link.
+    is_rtd = (
+        doc and urlparse(doc).netloc != urlparse(discourse_api.base_url).netloc
+    )
 
     docs_topic = package["store_front"].get("docs_topic")
     if is_rtd:
@@ -355,7 +356,9 @@ def details_overview(entity_name):
                 summary = logic.get_summary(package)
     else:
         navigation = None
-        description = sanitize_html(logic.get_description(package, parse_to_html=True))
+        description = sanitize_html(
+            logic.get_description(package, parse_to_html=True)
+        )
         summary = logic.get_summary(package)
 
     revisions = logic.get_revisions(package["channel-map"])
@@ -680,8 +683,7 @@ def download_library(entity_name, library_name):
         library["content"],
         mimetype="text/x-python",
         headers={
-            "Content-disposition": "attachment; "
-            f"filename={library['library-name']}.py"
+            "Content-disposition": f"attachment; filename={library['library-name']}.py"
         },
     )
 


### PR DESCRIPTION
## Done
- Fix name registration UI to surface api-error if error is not known
- Fix docs url fetching to allow external docs (beyond readthedocs)
## How to QA
- go to `/charms`
- try registring existing names, invalid names "1", get different errors
- go to https://charmhub-io-2387.demos.haus/discourse-k8s
- click the edge channel
- see new read documentation button

