### PR TITLE
fix 500 error on edit solution

### DIFF
--- a/templates/publisher/register-solution.html
+++ b/templates/publisher/register-solution.html
@@ -217,5 +217,5 @@
 </section>
 
 {% include 'solutions/partials/_confirmation_modal.html' %}
-  {{ vite_import('static/js/src/solutions/register-solution.js') }}
+  {{ vite_import('static/js/src/solutions/register-solution.ts') }}
 {% endblock %}

--- a/templates/solutions/edit-solution.html
+++ b/templates/solutions/edit-solution.html
@@ -147,5 +147,5 @@
     </footer>
   </section>
 </div>
-  {{ vite_import('static/js/src/solutions/edit-solution.js') }}
+  {{ vite_import('static/js/src/solutions/edit-solution.ts') }}
 {% endblock %}

--- a/templates/solutions/partials/_platform_compatibility_section.html
+++ b/templates/solutions/partials/_platform_compatibility_section.html
@@ -55,13 +55,16 @@
   <h4 class="p-heading--4">Platform & Compatibility</h4>
 </div>
 
+{% set deployable_on = solution.get('deployable-on') or [{}] %}
+{% set primary_deployable = deployable_on[0] or {} %}
+
 <div class="p-form__group row">
   <div class="col-2">
     <label class="p-form__label">Platform:</label>
   </div>
   <div class="col-8 col-x-large-6">
     <div class="p-form__control">
-      {% set current_platform = solution.get('deployable-on', [{}])[0].get('platform', 'kubernetes') %}
+      {% set current_platform = primary_deployable.get('platform', 'kubernetes') %}
       <label class="p-radio">
         <input
           type="radio"
@@ -99,8 +102,8 @@
   <div class="col-8 col-x-large-6">
     <div class="p-form-validation" id="platform-version-section">
       <div id="platform-version-list" data-autosave-multivalue-field="platform_version[]" data-autosave-add-button="add-platform-version" data-autosave-item-selector=".platform-version-item" data-autosave-remove-selector=".remove-platform-version">
-        {% if solution['deployable-on'] and solution['deployable-on'][0] and solution['deployable-on'][0].version %}
-          {% for version in solution['deployable-on'][0].version %}
+        {% if primary_deployable.version %}
+          {% for version in primary_deployable.version %}
             <div class="platform-version-item p-form--inline">
               <button type="button" class="p-button--negative has-icon is-small remove-platform-version" aria-label="Remove version"><i class="p-icon--delete is-dark"></i></button>
               <div class="p-form__group">
@@ -132,8 +135,8 @@
   <div class="col-8 col-x-large-6">
     <div id="platform-prerequisites-section">
       <div id="platform-prerequisites-list" data-autosave-multivalue-field="platform_prerequisites[]" data-autosave-add-button="add-platform-prerequisite" data-autosave-item-selector=".platform-prerequisite-item" data-autosave-remove-selector=".remove-platform-prerequisite">
-        {% if solution['deployable-on'] and solution['deployable-on'][0] and solution['deployable-on'][0].prerequisites %}
-          {% for prerequisite in solution['deployable-on'][0].prerequisites %}
+        {% if primary_deployable.prerequisites %}
+          {% for prerequisite in primary_deployable.prerequisites %}
             <div class="platform-prerequisite-item p-form--inline">
               <button type="button" class="p-button--negative has-icon is-small remove-platform-prerequisite" aria-label="Remove prerequisite"><i class="p-icon--delete is-dark"></i></button>
               <div class="p-form__group">

--- a/tests/publisher/test_publisher_views.py
+++ b/tests/publisher/test_publisher_views.py
@@ -204,6 +204,46 @@ class TestPublisherViews(unittest.TestCase):
         self.assertIn(b"Solutions", res.data)
         self.assertIn(b"No published Solutions available", res.data)
 
+    @patch("webapp.publisher.views.get_solution_categories", return_value=[])
+    @patch("webapp.publisher.views.get_user_teams_for_solutions", return_value=[])
+    @patch("webapp.publisher.views.get_solution_from_backend")
+    def test_edit_solution_handles_empty_deployable_on(
+        self,
+        mock_get_solution_from_backend,
+        mock_get_user_teams_for_solutions,
+        mock_get_solution_categories,
+    ):
+        mock_get_solution_from_backend.return_value = {
+            "hash": "test-hash",
+            "name": "test-solution",
+            "title": "Test Solution",
+            "summary": "Test summary",
+            "status": "published",
+            "revision": 1,
+            "deployable-on": [],
+            "compatibility": {},
+            "documentation": {},
+            "media": {},
+            "charms": [],
+            "maintainers": [],
+            "use_cases": [],
+            "useful_links": [],
+            "categories": [],
+        }
+
+        res = self.client.get("/solutions/edit/test-hash")
+
+        self.assertEqual(res.status_code, 200)
+        self.assertIn(b"Edit solution: Test Solution", res.data)
+        self.assertIn(b'name="platform" value="kubernetes"', res.data)
+        mock_get_solution_from_backend.assert_called_once_with(
+            "test-hash", prefer_authenticated=True
+        )
+        mock_get_user_teams_for_solutions.assert_called_once_with(
+            "test-username"
+        )
+        mock_get_solution_categories.assert_called_once()
+
     @patch("webapp.publisher.views.redis_cache.get", return_value=None)
     @patch("webapp.store_api.publisher_gateway.get_account_packages")
     def test_list_page_expired_session_redirects_login(


### PR DESCRIPTION
## Done
- Fixes 500 error on register and edit solution pages due to vite imports
- Fixes `deployable-on` error for empty list (drive-by)

## How to QA
- Go to a solution of yours and click "edit"
- Make sure it works as expected
- Try to register a new solution and make sure the page works

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card

Fixes [WD-38127](https://warthogs.atlassian.net/browse/WD-38127)

## UX Approval

- [x] This PR does not require UX approval


[WD-38127]: https://warthogs.atlassian.net/browse/WD-38127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ