### PR TITLE
add solutions.json listing endpoint

### DIFF
--- a/tests/solutions/test_solutions_logic.py
+++ b/tests/solutions/test_solutions_logic.py
@@ -1,11 +1,14 @@
 import unittest
 from unittest.mock import patch, MagicMock
 from webapp.solutions.logic import (
+    _solution_listing_item,
     get_solution_from_backend,
     get_publisher_solutions,
     group_solution_drafts,
     get_solution_categories,
+    get_published_solutions,
     map_category_slugs_to_display,
+    SolutionsServiceError,
 )
 
 
@@ -13,6 +16,111 @@ from webapp.solutions.logic import (
     "webapp.solutions.logic.SOLUTIONS_API_BASE", "http://localhost:5000/api"
 )
 class TestSolutionsLogic(unittest.TestCase):
+    @patch("webapp.solutions.logic.redis_cache")
+    @patch("webapp.solutions.logic.session")
+    def test_get_published_solutions(self, mock_session, mock_cache):
+        mock_cache.get.return_value = None
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {
+                "id": 1,
+                "name": "observability",
+                "title": "Canonical Observability Stack",
+                "summary": "Observe applications and infrastructure.",
+                "categories": ["monitoring"],
+                "media": {"icon": "https://example.com/icon.svg"},
+                "deployable-on": [
+                    {"platform": "kubernetes", "version": [">=1.29"]}
+                ],
+                "last_updated": "2026-08-17T10:48:16.021584",
+                "publisher": {"display_name": "Canonical"},
+                "charms": [
+                    {"id": 1, "charm_name": "grafana-k8s"},
+                    {"id": 2, "charm_name": "prometheus-k8s"},
+                ],
+                "maintainers": [{"email": "private@example.com"}],
+            }
+        ]
+        mock_session.get.return_value = mock_response
+
+        result = get_published_solutions()
+
+        self.assertEqual(
+            result,
+            [
+                {
+                    "name": "observability",
+                    "title": "Canonical Observability Stack",
+                    "summary": "Observe applications and infrastructure.",
+                    "icon": "https://example.com/icon.svg",
+                    "categories": ["monitoring"],
+                    "platform": "kubernetes",
+                    "platform_version": [">=1.29"],
+                    "last_updated": "2026-08-17T10:48:16.021584",
+                    "charms": ["grafana-k8s", "prometheus-k8s"],
+                    "publisher": "Canonical",
+                }
+            ],
+        )
+        mock_session.get.assert_called_once_with(
+            "http://localhost:5000/api/solutions", timeout=5
+        )
+        mock_cache.set.assert_called_once_with("published-solutions", result, ttl=60)
+
+    def test_solution_listing_uses_publisher_username_as_fallback(self):
+        result = _solution_listing_item(
+            {
+                "name": "observability",
+                "publisher": {"display_name": "", "username": "canonical"},
+            }
+        )
+
+        self.assertEqual(result["publisher"], "canonical")
+
+    @patch("webapp.solutions.logic.redis_cache")
+    @patch("webapp.solutions.logic.session")
+    def test_get_published_solutions_uses_empty_cached_list(
+        self, mock_session, mock_cache
+    ):
+        mock_cache.get.return_value = []
+
+        result = get_published_solutions()
+
+        self.assertEqual(result, [])
+        mock_session.get.assert_not_called()
+
+    @patch("webapp.solutions.logic.redis_cache")
+    @patch("webapp.solutions.logic.session")
+    def test_get_published_solutions_rejects_service_error(
+        self, mock_session, mock_cache
+    ):
+        mock_cache.get.return_value = None
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        mock_session.get.return_value = mock_response
+
+        with self.assertRaises(SolutionsServiceError):
+            get_published_solutions()
+
+        mock_cache.set.assert_not_called()
+
+    @patch("webapp.solutions.logic.redis_cache")
+    @patch("webapp.solutions.logic.session")
+    def test_get_published_solutions_rejects_invalid_response(
+        self, mock_session, mock_cache
+    ):
+        mock_cache.get.return_value = None
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"solutions": []}
+        mock_session.get.return_value = mock_response
+
+        with self.assertRaises(SolutionsServiceError):
+            get_published_solutions()
+
+        mock_cache.set.assert_not_called()
+
     @patch("webapp.solutions.logic.session")
     def test_get_solution_from_backend_success(self, mock_session):
         mock_response = MagicMock()
@@ -292,4 +400,3 @@ class TestSolutionCategories(unittest.TestCase):
     def test_map_category_slugs_to_display_empty(self):
         self.assertEqual(map_category_slugs_to_display([]), [])
         self.assertEqual(map_category_slugs_to_display(None), [])
-

--- a/tests/solutions/test_solutions_logic.py
+++ b/tests/solutions/test_solutions_logic.py
@@ -98,11 +98,17 @@ class TestSolutionsLogic(unittest.TestCase):
         mock_cache.get.return_value = None
         mock_response = MagicMock()
         mock_response.status_code = 503
+        mock_response.text = "Service unavailable"
         mock_session.get.return_value = mock_response
 
-        with self.assertRaises(SolutionsServiceError):
-            get_published_solutions()
+        with self.assertLogs("webapp.solutions.logic", level="WARNING") as logs:
+            with self.assertRaises(SolutionsServiceError):
+                get_published_solutions()
 
+        self.assertIn(
+            "Solutions service returned status 503: Service unavailable",
+            logs.output[0],
+        )
         mock_cache.set.assert_not_called()
 
     @patch("webapp.solutions.logic.redis_cache")
@@ -116,9 +122,14 @@ class TestSolutionsLogic(unittest.TestCase):
         mock_response.json.return_value = {"solutions": []}
         mock_session.get.return_value = mock_response
 
-        with self.assertRaises(SolutionsServiceError):
-            get_published_solutions()
+        with self.assertLogs("webapp.solutions.logic", level="WARNING") as logs:
+            with self.assertRaises(SolutionsServiceError):
+                get_published_solutions()
 
+        self.assertIn(
+            "Solutions service returned dict instead of a list",
+            logs.output[0],
+        )
         mock_cache.set.assert_not_called()
 
     @patch("webapp.solutions.logic.session")

--- a/tests/solutions/test_solutions_views.py
+++ b/tests/solutions/test_solutions_views.py
@@ -1,0 +1,54 @@
+import unittest
+from unittest.mock import patch
+
+from webapp.app import app
+from webapp.solutions.logic import SolutionsServiceError
+
+
+class TestSolutionsViews(unittest.TestCase):
+    def setUp(self):
+        app.config["SERVER_NAME"] = "localhost.localdomain"
+        self.client = app.test_client()
+
+    @patch("webapp.solutions.views.get_published_solutions")
+    def test_solutions_json(self, mock_get_solutions):
+        mock_get_solutions.return_value = [
+            {
+                "name": "observability",
+                "title": "Canonical Observability Stack",
+            }
+        ]
+
+        response = self.client.get("/solutions.json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.get_json(),
+            {
+                "solutions": [
+                    {
+                        "name": "observability",
+                        "title": "Canonical Observability Stack",
+                    }
+                ],
+                "size": 1,
+            },
+        )
+
+    @patch("webapp.solutions.views.get_published_solutions")
+    def test_solutions_json_empty(self, mock_get_solutions):
+        mock_get_solutions.return_value = []
+
+        response = self.client.get("/solutions.json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), {"solutions": [], "size": 0})
+
+    @patch("webapp.solutions.views.get_published_solutions")
+    def test_solutions_json_service_error(self, mock_get_solutions):
+        mock_get_solutions.side_effect = SolutionsServiceError
+
+        response = self.client.get("/solutions.json")
+
+        self.assertEqual(response.status_code, 502)
+        self.assertEqual(response.get_json(), {"error": "Failed to fetch solutions"})

--- a/webapp/solutions/logic.py
+++ b/webapp/solutions/logic.py
@@ -57,12 +57,21 @@ def get_published_solutions():
     try:
         response = session.get(f"{SOLUTIONS_API_BASE}/solutions", timeout=5)
         if response.status_code != 200:
+            logger.warning(
+                "Solutions service returned status %s: %s",
+                response.status_code,
+                response.text,
+            )
             raise SolutionsServiceError(
                 f"Solutions service returned {response.status_code}"
             )
 
         solutions = response.json()
         if not isinstance(solutions, list):
+            logger.warning(
+                "Solutions service returned %s instead of a list",
+                type(solutions).__name__,
+            )
             raise SolutionsServiceError("Solutions service returned invalid data")
 
         listing = [

--- a/webapp/solutions/logic.py
+++ b/webapp/solutions/logic.py
@@ -2,6 +2,7 @@ import os
 import logging
 import requests
 from flask import session as flask_session
+from redis_cache.cache_utility import redis_cache
 from webapp.solutions.auth import login
 from webapp.packages.logic import get_store_categories
 from webapp.store.logic import format_slug
@@ -15,6 +16,67 @@ session = requests.Session()
 SOLUTIONS_API_BASE = os.getenv(
     "FLASK_SOLUTIONS_API_BASE", "https://solutions.staging.charmhub.io/api"
 )
+
+
+class SolutionsServiceError(Exception):
+    pass
+
+
+def _solution_listing_item(solution):
+    media = solution.get("media") or {}
+    publisher = solution.get("publisher") or {}
+    charms = solution.get("charms") or []
+    deployable_on = solution.get("deployable-on") or []
+    deployment = deployable_on[0] if deployable_on else {}
+
+    return {
+        "title": solution.get("title", ""),
+        "name": solution.get("name", ""),
+        "summary": solution.get("summary", ""),
+        "icon": media.get("icon"),
+        "categories": solution.get("categories") or [],
+        "platform": deployment.get("platform", ""),
+        "platform_version": deployment.get("version") or [],
+        "last_updated": solution.get("last_updated"),
+        "charms": [
+            charm.get("charm_name")
+            for charm in charms
+            if isinstance(charm, dict) and charm.get("charm_name")
+        ],
+        "publisher": publisher.get("display_name")
+        or publisher.get("username", ""),
+    }
+
+
+def get_published_solutions():
+    cache_key = "published-solutions"
+    cached_solutions = redis_cache.get(cache_key, expected_type=list)
+    if cached_solutions is not None:
+        return cached_solutions
+
+    try:
+        response = session.get(f"{SOLUTIONS_API_BASE}/solutions", timeout=5)
+        if response.status_code != 200:
+            raise SolutionsServiceError(
+                f"Solutions service returned {response.status_code}"
+            )
+
+        solutions = response.json()
+        if not isinstance(solutions, list):
+            raise SolutionsServiceError("Solutions service returned invalid data")
+
+        listing = [
+            _solution_listing_item(solution)
+            for solution in solutions
+            if isinstance(solution, dict) and solution.get("name")
+        ]
+        redis_cache.set(cache_key, listing, ttl=60)
+        return listing
+    except SolutionsServiceError:
+        raise
+    except (requests.RequestException, ValueError) as error:
+        logger.exception("Failed to fetch published solutions")
+        raise SolutionsServiceError("Failed to fetch published solutions") from error
 
 
 def get_solution_categories():

--- a/webapp/solutions/views.py
+++ b/webapp/solutions/views.py
@@ -1,11 +1,14 @@
-from flask import Blueprint, abort, render_template, request
+from flask import Blueprint, abort, jsonify, render_template, request
 from webapp.decorators import redirect_uppercase_to_lowercase
 from webapp.store_api import publisher_gateway
 from webapp.helpers import markdown_to_html
 from webapp.solutions.logic import get_solution_from_backend
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from webapp.solutions.logic import get_published_solution_by_name
+from webapp.solutions.logic import get_published_solutions
 from webapp.solutions.logic import map_category_slugs_to_display
+from webapp.solutions.logic import SolutionsServiceError
+from webapp.observability.utils import trace_function
 from webapp.publisher.views import preview_cache
 
 
@@ -200,6 +203,20 @@ def solution_preview_draft(preview_key):
         solution=preview_solution,
         is_preview=True,
     )
+
+
+@trace_function
+@solutions.route("/solutions.json")
+def solutions_json():
+    try:
+        published_solutions = get_published_solutions()
+    except SolutionsServiceError:
+        return jsonify({"error": "Failed to fetch solutions"}), 502
+
+    return {
+        "solutions": published_solutions,
+        "size": len(published_solutions),
+    }
 
 
 @solutions.route("/solutions/<name>")


### PR DESCRIPTION
## Done
- Part of a solutions stack for adding solutions to charmhub - DON'T MERGE
- Adds public /solutions.json listing endpoint - will be how we fetch data for solution cards on the homepage
- Adds 60 second caching (TTL can be increased down the line but for now, we won't have many solutions)

## How to QA
- Go to https://charmhub-io-2405.demos.haus/solutions.json
- Confirm you can see currently-published solutions

## Testing

- [x] This PR has tests

## Issue / Card

Fixes [WD-38242](https://warthogs.atlassian.net/browse/WD-38242)

## UX Approval

- [x] This PR does not require UX approval

[WD-38242]: https://warthogs.atlassian.net/browse/WD-38242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ